### PR TITLE
Setup CI workflow with pnpm checks and artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+  workflow_dispatch:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validate and Smoke
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm setup
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Smoke test
+        run: pnpm smoke
+
+      - name: Verify workflow artifacts
+        if: success()
+        run: |
+          if [ ! -d episodes ] || [ -z "$(ls -A episodes)" ]; then
+            echo "episodes directory missing or empty"
+            exit 1
+          fi
+          if [ ! -d reports ] || [ -z "$(ls -A reports)" ]; then
+            echo "reports directory missing or empty"
+            exit 1
+          fi
+
+      - name: Upload episodes artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: episodes
+          path: episodes
+          if-no-files-found: warn
+
+      - name: Upload reports artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: reports
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # AOS
-agent os 
+
+agent os
+
+## Continuous Integration
+
+The repository uses the `CI` GitHub Actions workflow defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). It installs pnpm on Node.js 20 and runs `pnpm setup`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, and `pnpm smoke` sequentially. Successful runs produce the latest `episodes/` and `reports/` directories as downloadable artifacts.
+
+To enforce CI as a merge gate, protect the default branch in GitHub settings and mark the `CI` workflow check as required before merging pull requests.

--- a/plan.json
+++ b/plan.json
@@ -1,0 +1,59 @@
+{
+  "goal": "Set up CI workflow to run pnpm pipelines, upload artifacts, and enforce as merge gate.",
+  "constraints": [
+    "Follow AGENTS.md instructions",
+    "Use Node.js 20 and pnpm",
+    "Workflow must upload episodes and reports artifacts"
+  ],
+  "budget": { "currency": "CNY", "limit": 0 },
+  "acceptance": [
+    {
+      "id": "A1",
+      "given": "CI workflow runs",
+      "when": "pull requests execute workflow",
+      "then": "Steps pnpm setup/typecheck/lint/test/build/smoke succeed and artifacts uploaded"
+    },
+    {
+      "id": "A2",
+      "given": "Repository merges",
+      "when": "branch protection checks",
+      "then": "CI workflow marked required"
+    }
+  ],
+  "steps": [
+    {
+      "id": "S1",
+      "action": "tool",
+      "input": {
+        "tool": "shell",
+        "command": "Inspect repository structure for workflows"
+      },
+      "expect": "Understand existing CI setup"
+    },
+    {
+      "id": "S2",
+      "action": "tool",
+      "input": {
+        "tool": "shell",
+        "command": "Create or update .github/workflows/ci.yml with required configuration"
+      },
+      "expect": "Workflow file reflecting requested behavior"
+    },
+    {
+      "id": "S3",
+      "action": "tool",
+      "input": {
+        "tool": "shell",
+        "command": "Ensure branch protection documentation updated if necessary"
+      },
+      "expect": "CI documented as merge gate"
+    }
+  ],
+  "risks": [
+    "Missing pnpm cache or install step causing workflow failure",
+    "Artifacts directories absent leading to upload errors"
+  ],
+  "rollback": [
+    "Revert workflow file if pipeline misconfigured"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that uses Node.js 20 with pnpm to run setup, typecheck, lint, test, build, and smoke commands
- upload the generated `episodes/` and `reports/` directories as workflow artifacts
- document the CI merge gate expectations in the README and capture the implementation plan

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c90e68cc5c832b95737876125b8fb9