### PR TITLE
Initialize Node.js tooling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "root": true
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "aos",
+  "version": "0.1.0",
+  "description": "Agent Operating System workspace",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "setup": "pnpm install",
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:ui": "playwright test",
+    "smoke": "node scripts/smoke.mjs",
+    "replay": "node scripts/replay.mjs",
+    "score": "node scripts/score.mjs"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.2",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "playwright": "^1.44.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "packageManager": "pnpm@10.5.2"
+}

--- a/scripts/replay.mjs
+++ b/scripts/replay.mjs
@@ -1,0 +1,1 @@
+console.log('Replay placeholder - implement episode replay.');

--- a/scripts/score.mjs
+++ b/scripts/score.mjs
@@ -1,0 +1,1 @@
+console.log('Score placeholder - implement metrics aggregation.');

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,1 @@
+console.log('Smoke test placeholder - implement workflow simulation.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["dom", "dom.iterable", "es2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "incremental": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the initial package manifest with Node 20 engine constraint, Next.js/TypeScript dependencies, and unified scripts
- configure the shared TypeScript compiler options and provide placeholder workflow scripts referenced by package commands

## Testing
- ⚠️ `pnpm install` *(fails with 403 Forbidden when fetching packages from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c90e593864832b8f897d74de0aacf9