### PR TITLE
docs: document contributing guidelines and conduct expectations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[aos-maintainers@example.com](mailto:aos-maintainers@example.com). All complaints
+will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the
+[FAQ](https://www.contributor-covenant.org/faq). Translations are available at
+[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to AOS
+
+Thank you for your interest in improving **AOS**. This document summarizes how we work together so that pull requests can be reviewed and merged quickly.
+
+## Getting started
+
+1. Fork the repository and clone your fork locally.
+2. Install dependencies with [`pnpm setup`](./package.json). We target Node.js 20 or newer.
+3. Use [`pnpm dev`](./package.json) to start the local development server at http://localhost:3000.
+4. Keep dependencies updated via `pnpm install` and avoid committing generated assets or secrets.
+
+## Development workflow
+
+1. **Plan the change.** Discuss significant features by filing an issue so we can confirm scope and acceptance criteria before implementation.
+2. **Create a feature branch** from the default branch (`main`). Keep branches focused on a single problem to simplify review.
+3. **Implement the change** following the project structure documented in [`AGENTS.md`](./AGENTS.md). Update or add automated tests whenever behaviour changes.
+4. **Validate locally** before opening a pull request:
+   - `pnpm typecheck`
+   - `pnpm lint`
+   - `pnpm test`
+   - `pnpm smoke`
+   - Run `pnpm build` when the change impacts production builds.
+5. **Submit a pull request** that explains _why_ the change is needed and _how_ it was implemented. Link the relevant issue when available.
+6. **Respond to review** feedback promptly and keep the commit history tidy by rebasing onto `main` when necessary.
+
+## Branch strategy
+
+We follow a lightweight GitFlow-inspired approach:
+
+- `main` always reflects the latest stable state. Commits to `main` must pass CI.
+- Feature work happens on short-lived topic branches named with the pattern `type/short-description` (for example `feat/runtime-registry` or `fix/auth-timeout`).
+- Release branches are created only when preparing a production release; they are merged back into `main` once finalized.
+- Hotfixes branch from the latest release tag, receive focused fixes, and are merged into both the release branch (if still active) and `main`.
+
+## Commit conventions
+
+We use the [Conventional Commits](https://www.conventionalcommits.org/) standard:
+
+- Format: `<type>[optional scope]: <imperative summary>`
+- Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- Use the imperative mood (e.g. "add agent runner") and limit the summary line to 72 characters or fewer.
+- Include additional context in the body and reference issues with `Fixes #123` where appropriate.
+
+## Pull request checklist
+
+Before requesting review, make sure to:
+
+- [ ] Update documentation and schema definitions when behaviour changes.
+- [ ] Add or update automated tests that cover the change.
+- [ ] Ensure linting, type-checking, unit tests, and smoke tests pass locally.
+- [ ] Attach any relevant `episodes/` or `reports/` artefacts if they are necessary for reviewers to reproduce results.
+- [ ] Describe rollout or rollback considerations for risky changes.
+
+## Code review expectations
+
+- Reviews focus on correctness, clarity, maintainability, and alignment with project goals.
+- Small, focused pull requests are merged faster than large mixed changes.
+- Resolving conversations is the author's responsibility; re-request review once comments are addressed.
+- Reviewers may request additional tests or documentation before approval.
+
+## Communication
+
+- Use GitHub issues and pull requests for asynchronous discussion.
+- For urgent production topics, escalate via the team chat channels documented internally.
+- Respect the [Code of Conduct](./CODE_OF_CONDUCT.md) in all project spaces.
+
+We appreciate your contributions—thank you for helping make AOS better!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # AOS
-agent os 
+
+agent os
+
+## Contributing
+
+We welcome community contributions. Please read the following resources before opening an issue or pull request:
+
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — development workflow, branching strategy, and commit conventions.
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) — expectations for participation in the community.
+
+Thank you for helping us improve AOS!


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md outlining workflow, branching, and commit conventions
- add CODE_OF_CONDUCT.md based on the Contributor Covenant v2.1
- link the new documents from README to guide external contributors

## Testing
- not run (repository does not contain a Node.js project or test scripts)


------
https://chatgpt.com/codex/tasks/task_e_68c90e765f4c832b8e38bd3f39f42603