### PR TITLE
Add root .gitignore for Node artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Dependencies
+node_modules/
+.pnpm-store/
+
+# Build outputs
+dist/
+build/
+.next/
+out/
+coverage/
+.turbo/
+.vercel/
+storybook-static/
+tmp/
+temp/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+logs/
+
+# TypeScript
+*.tsbuildinfo
+
+# Runtime data
+.pnp.*
+.cache/
+.esbuild/
+.nyc_output/
+.eslintcache
+
+# Environment files
+.env
+.env.*
+!.env.example
+.envrc
+
+# Project artifacts
+episodes/
+reports/
+
+# IDE and OS files
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~
+Thumbs.db


### PR DESCRIPTION
## Summary
- add a repository-level `.gitignore` so common Node/Next build outputs, dependencies, and logs stay untracked

## Testing
- not run (not needed for .gitignore update)


------
https://chatgpt.com/codex/tasks/task_e_68c90e46715c832b90020d0c025f78d4