### PR TITLE
chore: add tsconfig and lint tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+dist
+coverage
+reports
+episodes

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/eslintrc",
+  "root": true,
+  "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["prettier"],
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "rules": {
+    "prettier/prettier": "warn"
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+dist
+coverage
+reports
+episodes

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "aos",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agent OS workspace",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "setup": "pnpm install",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.cjs,.mjs",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "packageManager": "pnpm@10.5.2",
+  "devDependencies": {
+    "@tsconfig/next": "^2.0.1",
+    "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/parser": "^7.16.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/plan.json
+++ b/plan.json
@@ -1,0 +1,75 @@
+{
+  "goal": "Set up TypeScript configuration and lint/format tooling for the Next.js/Node project.",
+  "constraints": [
+    "Follow repository guidelines in AGENTS.md and prefer pnpm for package management.",
+    "Use recommended settings for Next.js/Node when configuring TypeScript, ESLint, and Prettier.",
+    "Keep the worktree clean with committed changes only after verification."
+  ],
+  "budget": { "currency": "CNY", "limit": 0.0 },
+  "acceptance": [
+    {
+      "id": "A1",
+      "given": "the repository",
+      "when": "tsconfig.json is added",
+      "then": "it should extend Next.js recommended settings and support Node tooling."
+    },
+    {
+      "id": "A2",
+      "given": "package.json",
+      "when": "scripts are inspected",
+      "then": "lint and format scripts should be defined using ESLint and Prettier."
+    },
+    {
+      "id": "A3",
+      "given": "development setup",
+      "when": "pnpm install is run",
+      "then": "ESLint and Prettier should be installed as devDependencies without errors."
+    }
+  ],
+  "steps": [
+    {
+      "id": "S1",
+      "action": "tool",
+      "input": { "cmd": "Review existing repository structure and documentation" },
+      "expect": "Understand current setup and confirm missing configuration files."
+    },
+    {
+      "id": "S2",
+      "action": "tool",
+      "input": { "cmd": "Initialize package.json with pnpm if missing" },
+      "expect": "A baseline package.json ready for dependency installation."
+    },
+    {
+      "id": "S3",
+      "action": "tool",
+      "input": { "cmd": "Add ESLint, Prettier, and supporting configs" },
+      "expect": "Configuration files for linting and formatting exist with recommended settings."
+    },
+    {
+      "id": "S4",
+      "action": "tool",
+      "input": { "cmd": "Install required devDependencies via pnpm" },
+      "expect": "pnpm-lock.yaml reflects the installed tooling."
+    },
+    {
+      "id": "S5",
+      "action": "tool",
+      "input": { "cmd": "Update package scripts and verify configurations" },
+      "expect": "lint/format scripts defined and configs referencing correct paths."
+    },
+    {
+      "id": "S6",
+      "action": "tool",
+      "input": { "cmd": "Run lint command to validate setup" },
+      "expect": "Lint command executes successfully (even if no files to lint)."
+    }
+  ],
+  "risks": [
+    "No existing Next.js source may cause ESLint presets to expect files that do not exist yet.",
+    "pnpm may warn about missing package metadata which needs sensible defaults."
+  ],
+  "rollback": [
+    "Remove generated package.json, lockfile, and configuration files if setup fails irrecoverably.",
+    "Re-run pnpm install after adjusting configuration to resolve tooling conflicts."
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/next/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cts",
+    "**/*.mts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a root package.json with Node 20 engine requirement and lint/format/typecheck scripts
- configure TypeScript via tsconfig.json extending the Next.js preset for Node usage
- add ESLint and Prettier configuration plus ignore files for common build artifacts

## Testing
- pnpm lint *(fails: registry responded 403 so devDependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c90e99e0dc832b892bbe0729ed4aa0