### PR TITLE
Add local Vitest runner and CI for core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+episodes/
+reports/
+.DS_Store

--- a/core/agent.js
+++ b/core/agent.js
@@ -1,0 +1,159 @@
+/**
+ * Minimal Agent kernel runtime utilities.
+ * @module core/agent
+ */
+
+const DEFAULT_MAX_ITERATIONS = 5;
+
+/**
+ * @typedef {Object} PlannedStep
+ * @property {string} id
+ * @property {string} op
+ * @property {any} [args]
+ */
+
+/**
+ * @typedef {Object} AgentKernel
+ * @property {(context:any)=>Promise<void>|void} [perceive]
+ * @property {()=>Promise<{steps:PlannedStep[]}|null|undefined>} plan
+ * @property {(step:PlannedStep, context?:any)=>Promise<any>} act
+ * @property {(outputs:any[], context?:any)=>Promise<{score:number;passed:boolean;notes?:string[]}>|{score:number;passed:boolean;notes?:string[]}} [review]
+ * @property {(outputs:any[], review?:any)=>Promise<any>|any} [renderFinal]
+ * @property {(outputs:any[], review?:any)=>boolean} [thinksDone]
+ */
+
+function toISO(clock) {
+  try {
+    return (clock ? clock() : new Date()).toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+function serializeError(error) {
+  if (!error || typeof error !== 'object') {
+    return { message: String(error) };
+  }
+  const plain = {
+    name: error.name || 'Error',
+    message: error.message || String(error),
+  };
+  if (error.stack) plain.stack = String(error.stack);
+  return plain;
+}
+
+async function callStep(fn, emit, source) {
+  try {
+    return await fn();
+  } catch (error) {
+    emit({ type: 'error', error: serializeError(error), source });
+    throw error;
+  }
+}
+
+/**
+ * Execute a kernel run-loop and emit events for each stage.
+ * @param {AgentKernel} kernel
+ * @param {(event: Record<string, any>) => void} emit
+ * @param {{ maxIterations?: number, context?: any, clock?: () => Date }} [options]
+ * @returns {Promise<{ status: 'final'|'ask', outputs: any, reason?: string }>}
+ */
+export async function runLoop(kernel, emit, options = {}) {
+  if (!kernel || typeof kernel !== 'object') {
+    throw new TypeError('kernel must be an object implementing AgentKernel');
+  }
+  if (typeof emit !== 'function') {
+    throw new TypeError('emit must be a function');
+  }
+
+  const { maxIterations = DEFAULT_MAX_ITERATIONS, context, clock } = options;
+  const outputs = [];
+
+  if (typeof kernel.perceive === 'function') {
+    emit({ type: 'progress', step: 'perceive', pct: 0 });
+    await callStep(() => kernel.perceive(context), emit, 'perceive');
+    emit({ type: 'progress', step: 'perceive', pct: 1 });
+  }
+
+  let iterations = 0;
+  while (iterations < maxIterations) {
+    iterations += 1;
+    emit({ type: 'progress', step: 'plan', pct: 0, iteration: iterations });
+    const plan = await callStep(() => kernel.plan(context), emit, 'plan');
+    emit({ type: 'plan.ready', at: toISO(clock), plan: plan ?? null, iteration: iterations });
+
+    const steps = Array.isArray(plan?.steps) ? plan.steps : [];
+    if (steps.length === 0) {
+      const fallbackStep = { id: 'final', op: 'respond', args: { reason: 'no-plan' } };
+      let fallback;
+      if (typeof kernel.act === 'function') {
+        fallback = await callStep(() => kernel.act(fallbackStep, context), emit, 'act');
+        outputs.push(fallback);
+        emit({ type: 'tool', name: fallbackStep.op, args: fallbackStep.args, result: fallback, ts: toISO(clock) });
+      }
+      const finalOut = typeof kernel.renderFinal === 'function'
+        ? await callStep(() => kernel.renderFinal(outputs), emit, 'final')
+        : fallback;
+      emit({ type: 'final', reason: 'no-plan', outputs: finalOut, ts: toISO(clock) });
+      return { status: 'final', reason: 'no-plan', outputs: finalOut };
+    }
+
+    emit({ type: 'progress', step: 'plan', pct: 1, iteration: iterations, steps: steps.length });
+
+    let awaitingUser = false;
+    for (const step of steps) {
+      emit({ type: 'act.begin', step, ts: toISO(clock) });
+      const result = await callStep(() => kernel.act(step, context), emit, 'act');
+      emit({ type: 'tool', name: step.op, args: step.args, result, ts: toISO(clock) });
+      emit({ type: 'act.end', step, ok: !(result && result.error), ts: toISO(clock) });
+      outputs.push(result);
+
+      if (result && typeof result.ask === 'string') {
+        awaitingUser = true;
+        emit({ type: 'ask', question: result.ask, origin_step: step.id, ts: toISO(clock) });
+        break;
+      }
+      if (result && result.halt) {
+        emit({ type: 'halt', reason: result.halt, ts: toISO(clock) });
+        awaitingUser = true;
+        break;
+      }
+    }
+
+    if (awaitingUser) {
+      return { status: 'ask', outputs };
+    }
+
+    const review = typeof kernel.review === 'function'
+      ? await callStep(() => kernel.review(outputs, context), emit, 'review')
+      : { score: 1, passed: true };
+    emit({
+      type: 'score',
+      value: review?.score ?? 0,
+      passed: Boolean(review?.passed),
+      notes: review?.notes,
+      ts: toISO(clock),
+    });
+
+    const done = Boolean(review?.passed) || (typeof kernel.thinksDone === 'function' && kernel.thinksDone(outputs, review));
+    if (done) {
+      const finalOutputs = typeof kernel.renderFinal === 'function'
+        ? await callStep(() => kernel.renderFinal(outputs, review), emit, 'final')
+        : outputs;
+      emit({ type: 'final', outputs: finalOutputs, ts: toISO(clock) });
+      return { status: 'final', outputs: finalOutputs };
+    }
+
+    emit({ type: 'progress', step: 'loop', iteration: iterations, pct: iterations / maxIterations });
+  }
+
+  const finalOutputs = typeof kernel.renderFinal === 'function'
+    ? await callStep(() => kernel.renderFinal(outputs), emit, 'final')
+    : outputs;
+  emit({ type: 'final', outputs: finalOutputs, reason: 'max-iterations', ts: toISO(clock) });
+  return { status: 'final', reason: 'max-iterations', outputs: finalOutputs };
+}
+
+export default {
+  runLoop,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aos",
+  "version": "0.1.0",
+  "description": "AgentOS minimal kernel",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node scripts/vitest-runner.mjs"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.5.2",
+  "devDependencies": {
+    "vitest": "file:packages/vitest"
+  }
+}

--- a/packages/vitest/index.js
+++ b/packages/vitest/index.js
@@ -1,0 +1,279 @@
+const STATE = {
+  root: null,
+  stack: [],
+};
+
+function createSuite(name, parent = null) {
+  return {
+    name,
+    parent,
+    suites: [],
+    tests: [],
+    beforeEach: [],
+    afterEach: [],
+  };
+}
+
+function ensureRoot() {
+  if (!STATE.root) {
+    STATE.root = createSuite('root');
+    STATE.stack = [STATE.root];
+  }
+  return STATE.root;
+}
+
+export function resetSuites() {
+  STATE.root = createSuite('root');
+  STATE.stack = [STATE.root];
+}
+
+function currentSuite() {
+  ensureRoot();
+  return STATE.stack[STATE.stack.length - 1];
+}
+
+export function describe(name, handler) {
+  if (typeof name !== 'string') {
+    throw new TypeError('describe name must be a string');
+  }
+  const parent = currentSuite();
+  const suite = createSuite(name, parent);
+  parent.suites.push(suite);
+  STATE.stack.push(suite);
+  try {
+    const result = handler?.();
+    if (result && typeof result.then === 'function') {
+      throw new Error('Asynchronous describe blocks are not supported in this lightweight runner');
+    }
+  } finally {
+    STATE.stack.pop();
+  }
+}
+
+function registerTest(name, fn) {
+  if (typeof name !== 'string') {
+    throw new TypeError('test name must be a string');
+  }
+  if (typeof fn !== 'function') {
+    throw new TypeError('test fn must be a function');
+  }
+  const suite = currentSuite();
+  suite.tests.push({ name, fn });
+}
+
+export function it(name, fn) {
+  registerTest(name, fn);
+}
+
+export const test = it;
+
+export function beforeEach(fn) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('beforeEach hook must be a function');
+  }
+  currentSuite().beforeEach.push(fn);
+}
+
+export function afterEach(fn) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('afterEach hook must be a function');
+  }
+  currentSuite().afterEach.push(fn);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function deepEqual(a, b) {
+  if (Object.is(a, b)) return true;
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  if (isObject(a) && isObject(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) {
+        return false;
+      }
+      if (!deepEqual(a[key], b[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function format(value) {
+  if (typeof value === 'string') return `"${value}"`;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function makeMatchers(received, negate = false) {
+  const ensure = (condition, message) => {
+    const pass = Boolean(condition);
+    if (negate ? pass : !pass) {
+      throw new Error(message);
+    }
+  };
+
+  return {
+    toBe(expected) {
+      ensure(Object.is(received, expected), `Expected ${format(received)} ${negate ? 'not ' : ''}to be ${format(expected)}`);
+    },
+    toEqual(expected) {
+      ensure(deepEqual(received, expected), `Expected ${format(received)} ${negate ? 'not ' : ''}to equal ${format(expected)}`);
+    },
+    toStrictEqual(expected) {
+      this.toEqual(expected);
+    },
+    toBeTruthy() {
+      ensure(Boolean(received), `Expected ${format(received)} ${negate ? 'to be falsy' : 'to be truthy'}`);
+    },
+    toBeFalsy() {
+      ensure(!received, `Expected ${format(received)} ${negate ? 'to be truthy' : 'to be falsy'}`);
+    },
+    toHaveLength(expected) {
+      if (received == null || typeof received.length !== 'number') {
+        throw new Error(`Received value does not have a length: ${format(received)}`);
+      }
+      ensure(received.length === expected, `Expected length ${expected}, received ${received.length}`);
+    },
+    toContainEqual(expected) {
+      if (!Array.isArray(received)) {
+        throw new Error(`Expected an array but received ${format(received)}`);
+      }
+      const found = received.some((item) => deepEqual(item, expected));
+      ensure(found, `Expected array ${negate ? 'not ' : ''}to contain ${format(expected)}`);
+    },
+    toMatchObject(expected) {
+      if (!isObject(received) || !isObject(expected)) {
+        throw new Error('toMatchObject expects plain objects');
+      }
+      const keys = Object.keys(expected);
+      const matches = keys.every((key) => deepEqual(received[key], expected[key]));
+      ensure(matches, `Expected ${format(received)} ${negate ? 'not ' : ''}to match object ${format(expected)}`);
+    },
+    toBeInstanceOf(expected) {
+      if (typeof expected !== 'function') {
+        throw new Error('toBeInstanceOf expects a constructor');
+      }
+      ensure(received instanceof expected, `Expected value to ${negate ? 'not ' : ''}be instance of ${expected.name || 'provided constructor'}`);
+    },
+    get not() {
+      return makeMatchers(received, !negate);
+    },
+  };
+}
+
+export function expect(received) {
+  const matchers = makeMatchers(received);
+  Object.defineProperty(matchers, 'not', {
+    get() {
+      return makeMatchers(received, true);
+    },
+  });
+  return matchers;
+}
+
+function gatherBeforeEach(chain) {
+  return chain.flatMap((suite) => suite.beforeEach);
+}
+
+function gatherAfterEach(chain) {
+  const hooks = [];
+  for (let i = chain.length - 1; i >= 0; i -= 1) {
+    hooks.push(...chain[i].afterEach);
+  }
+  return hooks;
+}
+
+async function runSuite(suite, reporter, summary, chain = []) {
+  const nextChain = chain.concat(suite);
+
+  if (suite !== ensureRoot()) {
+    summary.suites += 1;
+    reporter?.onSuiteStart?.(suite, nextChain);
+  }
+
+  for (const child of suite.suites) {
+    await runSuite(child, reporter, summary, nextChain);
+  }
+
+  for (const test of suite.tests) {
+    summary.tests += 1;
+    reporter?.onTestStart?.(test, nextChain);
+    const beforeHooks = gatherBeforeEach(nextChain);
+    const afterHooks = gatherAfterEach(nextChain);
+    const started = Date.now();
+    let error = null;
+    try {
+      for (const hook of beforeHooks) {
+        await hook();
+      }
+      await test.fn();
+      summary.passed += 1;
+      reporter?.onTestSuccess?.(test, nextChain, Date.now() - started);
+    } catch (err) {
+      error = err;
+      summary.failed += 1;
+      reporter?.onTestFail?.(test, nextChain, err);
+    } finally {
+      for (const hook of afterHooks) {
+        try {
+          await hook();
+        } catch (hookError) {
+          error = error || hookError;
+          reporter?.onHookError?.(hookError, nextChain);
+        }
+      }
+    }
+    if (error) {
+      reporter?.onTestError?.(test, nextChain, error);
+    }
+  }
+
+  if (suite !== ensureRoot()) {
+    reporter?.onSuiteFinish?.(suite, nextChain);
+  }
+}
+
+export async function runSuites(reporter) {
+  ensureRoot();
+  const summary = { suites: 0, tests: 0, passed: 0, failed: 0, duration: 0 };
+  const started = Date.now();
+  await runSuite(STATE.root, reporter, summary, []);
+  summary.duration = Date.now() - started;
+  return summary;
+}
+
+resetSuites();
+
+export default {
+  describe,
+  it,
+  test,
+  beforeEach,
+  afterEach,
+  expect,
+  runSuites,
+  resetSuites,
+};

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vitest",
+  "version": "0.0.0-local",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/plan.json
+++ b/plan.json
@@ -1,0 +1,22 @@
+{
+  "goal": "Add Vitest-based tests for runLoop, EpisodeLogger, and Replay, with CI integration.",
+  "constraints": [
+    "Use pnpm as the package manager",
+    "Follow repository instructions from AGENTS.md",
+    "Keep implementation minimal while ensuring testability"
+  ],
+  "budget": { "currency": "CNY", "limit": 0.0 },
+  "acceptance": [
+    {"id":"A1","given":"the repo","when":"pnpm test runs","then":"tests covering runLoop, EpisodeLogger, Replay pass"},
+    {"id":"A2","given":"CI workflow","when":"push or PR occurs","then":"pnpm test executes"}
+  ],
+  "steps": [
+    {"id":"S1","action":"tool","input":{"cmd":"Inspect existing repository structure"},"expect":"Understand current files and missing modules"},
+    {"id":"S2","action":"tool","input":{"cmd":"Initialize pnpm project with ESM JavaScript and local Vitest runner"},"expect":"package.json and dependencies ready"},
+    {"id":"S3","action":"tool","input":{"cmd":"Implement minimal core modules (runLoop, EpisodeLogger, Replay)"},"expect":"Core functionality available for testing"},
+    {"id":"S4","action":"tool","input":{"cmd":"Create tests/ directory with vitest specs covering required modules"},"expect":"Vitest tests in place"},
+    {"id":"S5","action":"tool","input":{"cmd":"Add CI workflow to run pnpm test"},"expect":"CI executes pnpm test"}
+  ],
+  "risks": ["Implementations might deviate from future design expectations", "CI configuration may need adjustment without existing infrastructure"],
+  "rollback": ["Remove new files and dependencies if approach invalid", "Revert CI workflow if conflicts arise"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      vitest:
+        specifier: file:packages/vitest
+        version: file:packages/vitest
+
+packages:
+
+  vitest@file:packages/vitest:
+    resolution: {directory: packages/vitest, type: directory}
+
+snapshots:
+
+  vitest@file:packages/vitest: {}

--- a/runtime/episode.js
+++ b/runtime/episode.js
@@ -1,0 +1,155 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+const { mkdir, stat, readFile, appendFile, writeFile } = fs;
+const DEFAULT_VERSION = 'v001';
+
+function toISOString(clock) {
+  try {
+    return (clock ? clock() : new Date()).toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+async function ensureFileExists(filePath) {
+  try {
+    await stat(filePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      await writeFile(filePath, '', 'utf8');
+    } else {
+      throw error;
+    }
+  }
+}
+
+async function loadExistingState(filePath) {
+  try {
+    const text = await readFile(filePath, 'utf8');
+    if (!text) {
+      return { line: 0, offset: 0 };
+    }
+    const lines = text.split('\n').filter(Boolean);
+    return { line: lines.length, offset: Buffer.byteLength(text) };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { line: 0, offset: 0 };
+    }
+    throw error;
+  }
+}
+
+async function readManifest(manifestPath) {
+  try {
+    const text = await readFile(manifestPath, 'utf8');
+    return JSON.parse(text);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeManifest(manifestPath, manifest) {
+  const data = JSON.stringify(manifest, null, 2);
+  await writeFile(manifestPath, `${data}\n`, 'utf8');
+}
+
+export class EpisodeLogger {
+  constructor(options = {}) {
+    const { traceId, version = DEFAULT_VERSION, baseDir = join(process.cwd(), 'episodes'), clock } = options;
+    if (!traceId) {
+      throw new Error('EpisodeLogger requires a traceId');
+    }
+    this.traceId = traceId;
+    this.version = version;
+    this.baseDir = baseDir;
+    this.clock = clock;
+    this.dir = join(this.baseDir, this.traceId, this.version);
+    this.filePath = join(this.dir, 'events.jsonl');
+    this.manifestPath = join(this.baseDir, this.traceId, 'manifest.json');
+    this.line = 0;
+    this.offset = 0;
+    this.ready = false;
+  }
+
+  async init() {
+    if (this.ready) return;
+    await mkdir(this.dir, { recursive: true });
+    await ensureFileExists(this.filePath);
+    const existing = await loadExistingState(this.filePath);
+    this.line = existing.line;
+    this.offset = existing.offset;
+    await this.#ensureManifest();
+    this.ready = true;
+  }
+
+  async #ensureManifest() {
+    const manifest = await readManifest(this.manifestPath);
+    if (!manifest) {
+      const created = {
+        trace_id: this.traceId,
+        latest_version: this.version,
+        versions: {
+          [this.version]: {
+            file: `./${this.version}/events.jsonl`,
+            latest_ln: this.line,
+            latest_ts: null,
+          },
+        },
+        created_at: toISOString(this.clock),
+      };
+      await writeManifest(this.manifestPath, created);
+      return;
+    }
+
+    if (!manifest.versions) manifest.versions = {};
+    manifest.trace_id = this.traceId;
+    manifest.latest_version = this.version;
+    manifest.versions[this.version] = {
+      file: `./${this.version}/events.jsonl`,
+      latest_ln: this.line,
+      latest_ts: manifest.versions[this.version]?.latest_ts ?? null,
+    };
+    await writeManifest(this.manifestPath, manifest);
+  }
+
+  async log(event) {
+    await this.init();
+    const record = {
+      ...event,
+      ts: event?.ts ?? toISOString(this.clock),
+      ln: this.line + 1,
+      byte_offset: this.offset,
+    };
+    const line = `${JSON.stringify(record)}\n`;
+    await appendFile(this.filePath, line, 'utf8');
+    this.line += 1;
+    this.offset += Buffer.byteLength(line);
+    await this.#updateManifest(record);
+    return record;
+  }
+
+  async #updateManifest(record) {
+    const manifest = (await readManifest(this.manifestPath)) ?? {
+      trace_id: this.traceId,
+      latest_version: this.version,
+      versions: {},
+    };
+    if (!manifest.versions) manifest.versions = {};
+    manifest.trace_id = this.traceId;
+    manifest.latest_version = this.version;
+    manifest.versions[this.version] = {
+      file: `./${this.version}/events.jsonl`,
+      latest_ln: record.ln,
+      latest_ts: record.ts,
+    };
+    await writeManifest(this.manifestPath, manifest);
+  }
+}
+
+export default {
+  EpisodeLogger,
+};

--- a/runtime/replay.js
+++ b/runtime/replay.js
@@ -1,0 +1,81 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+const { readFile, stat } = fs;
+const DEFAULT_VERSION = 'v001';
+
+function sortEvents(events) {
+  return events.slice().sort((a, b) => {
+    if (typeof a.ln === 'number' && typeof b.ln === 'number') {
+      return a.ln - b.ln;
+    }
+    if (a.ts && b.ts) {
+      return a.ts.localeCompare(b.ts);
+    }
+    return 0;
+  });
+}
+
+async function readEvents(filePath) {
+  try {
+    await stat(filePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`Episode file not found: ${filePath}`);
+    }
+    throw error;
+  }
+  const content = await readFile(filePath, 'utf8');
+  if (!content.trim()) {
+    return [];
+  }
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Invalid JSONL line: ${line}`);
+      }
+    });
+}
+
+export class Replay {
+  constructor(options = {}) {
+    const { traceId, version = DEFAULT_VERSION, baseDir = join(process.cwd(), 'episodes') } = options;
+    if (!traceId) {
+      throw new Error('Replay requires a traceId');
+    }
+    this.traceId = traceId;
+    this.version = version;
+    this.baseDir = baseDir;
+    this.filePath = join(this.baseDir, this.traceId, this.version, 'events.jsonl');
+  }
+
+  async load() {
+    const events = await readEvents(this.filePath);
+    return sortEvents(events);
+  }
+
+  async run(onEvent) {
+    const events = await this.load();
+    if (typeof onEvent === 'function') {
+      for (let index = 0; index < events.length; index += 1) {
+        await onEvent(events[index], index);
+      }
+    }
+    return events;
+  }
+}
+
+export async function replay(options = {}) {
+  const { onEvent, ...rest } = options;
+  const runner = new Replay(rest);
+  return runner.run(onEvent);
+}
+
+export default {
+  Replay,
+  replay,
+};

--- a/scripts/vitest-runner.mjs
+++ b/scripts/vitest-runner.mjs
@@ -1,0 +1,88 @@
+import { readdir, stat } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runSuites, resetSuites } from 'vitest';
+
+const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?js$/i;
+
+async function collectFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return results;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await collectFiles(fullPath);
+      results.push(...nested);
+    } else if (entry.isFile() && TEST_FILE_PATTERN.test(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results.sort();
+}
+
+function formatChain(chain, testName) {
+  const labels = chain
+    .filter((suite) => suite.name && suite.name !== 'root')
+    .map((suite) => suite.name);
+  if (testName) labels.push(testName);
+  return labels.join(' > ');
+}
+
+async function run() {
+  const testsDir = resolve(process.cwd(), 'tests');
+  try {
+    await stat(testsDir);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      console.warn('No tests directory found.');
+      return;
+    }
+    throw error;
+  }
+
+  const files = await collectFiles(testsDir);
+  if (files.length === 0) {
+    console.warn('No test files discovered.');
+    return;
+  }
+
+  resetSuites();
+  for (const file of files) {
+    const url = pathToFileURL(file).href;
+    await import(url);
+  }
+
+  const reporter = {
+    onTestSuccess(test, chain, duration) {
+      console.log(`✔ ${formatChain(chain, test.name)} (${duration} ms)`);
+    },
+    onTestFail(test, chain, error) {
+      console.error(`✖ ${formatChain(chain, test.name)}`);
+      if (error?.stack) {
+        console.error(error.stack);
+      } else {
+        console.error(String(error));
+      }
+    },
+  };
+
+  const summary = await runSuites(reporter);
+  console.log(`\nTotal: ${summary.tests}, Passed: ${summary.passed}, Failed: ${summary.failed}, Duration: ${summary.duration} ms`);
+  if (summary.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+run().catch((error) => {
+  console.error('Vitest runner failed:', error);
+  process.exitCode = 1;
+});

--- a/tests/episodeLogger.test.js
+++ b/tests/episodeLogger.test.js
@@ -1,0 +1,40 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { EpisodeLogger } from '../runtime/episode.js';
+
+describe('EpisodeLogger', () => {
+  it('writes JSONL entries with monotonic line numbers and offsets', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'episode-'));
+    let tick = 0;
+    const logger = new EpisodeLogger({
+      traceId: 'trace-123',
+      baseDir,
+      clock: () => new Date(Date.UTC(2024, 0, 1, 0, 0, tick++)),
+    });
+
+    const first = await logger.log({ type: 'progress', step: 'plan', note: 'start' });
+    const second = await logger.log({ type: 'final', outputs: { text: 'done' } });
+
+    expect(first.ln).toBe(1);
+    expect(first.byte_offset).toBe(0);
+    expect(second.ln).toBe(2);
+    const firstBytes = Buffer.byteLength(`${JSON.stringify(first)}\n`);
+    expect(second.byte_offset).toBe(firstBytes);
+
+    const filePath = join(baseDir, 'trace-123', 'v001', 'events.jsonl');
+    const fileContents = await readFile(filePath, 'utf8');
+    const lines = fileContents.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const parsedSecond = JSON.parse(lines[1]);
+    expect(parsedSecond.byte_offset).toBe(firstBytes);
+    expect(parsedSecond.ln).toBe(2);
+
+    const manifestPath = join(baseDir, 'trace-123', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+    expect(manifest.latest_version).toBe('v001');
+    expect(manifest.versions['v001'].latest_ln).toBe(2);
+    expect(manifest.versions['v001'].latest_ts).toBe(second.ts);
+  });
+});

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,40 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { EpisodeLogger } from '../runtime/episode.js';
+import { replay, Replay } from '../runtime/replay.js';
+
+describe('Replay', () => {
+  it('streams events in the order they were recorded', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'replay-'));
+    let tick = 0;
+    const logger = new EpisodeLogger({
+      traceId: 'trace-replay',
+      baseDir,
+      clock: () => new Date(Date.UTC(2024, 0, 1, 0, 0, tick++)),
+    });
+
+    const first = await logger.log({ type: 'progress', step: 'act' });
+    const second = await logger.log({ type: 'final', outputs: { answer: 42 } });
+
+    const seenTypes = [];
+    const events = await replay({ traceId: 'trace-replay', baseDir, onEvent: (event) => seenTypes.push(event.type) });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].ln).toBe(first.ln);
+    expect(events[1].ln).toBe(second.ln);
+    expect(seenTypes).toEqual(['progress', 'final']);
+  });
+
+  it('supports the Replay class helper', async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), 'replay-class-'));
+    const logger = new EpisodeLogger({ traceId: 'trace-class', baseDir });
+    await logger.log({ type: 'progress', step: 'plan' });
+    await logger.log({ type: 'final', outputs: { ok: true } });
+
+    const runner = new Replay({ traceId: 'trace-class', baseDir });
+    const events = await runner.run();
+    expect(events.map((event) => event.type)).toEqual(['progress', 'final']);
+  });
+});

--- a/tests/runLoop.test.js
+++ b/tests/runLoop.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { runLoop } from '../core/agent.js';
+
+describe('runLoop', () => {
+  it('executes plan steps and resolves when review passes', async () => {
+    const emitted = [];
+    const kernel = {
+      async perceive() {
+        emitted.push({ type: 'perceived' });
+      },
+      async plan() {
+        return {
+          steps: [
+            { id: 's1', op: 'tool.echo', args: { value: 'hi' } },
+            { id: 's2', op: 'tool.echo', args: { value: 'there' } },
+          ],
+        };
+      },
+      async act(step) {
+        return { id: step.id, result: step.args.value.toUpperCase() };
+      },
+      async review(outputs) {
+        return { score: outputs.length, passed: true, notes: ['ok'] };
+      },
+      async renderFinal(outputs) {
+        return outputs.map((item) => item.result).join(' ');
+      },
+    };
+
+    const result = await runLoop(kernel, (event) => emitted.push(event), { maxIterations: 3 });
+
+    expect(result.status).toBe('final');
+    expect(result.outputs).toBe('HI THERE');
+    expect(emitted.some((event) => event.type === 'plan.ready')).toBeTruthy();
+    expect(emitted.filter((event) => event.type === 'tool')).toHaveLength(2);
+    const finalEvent = emitted.find((event) => event.type === 'final');
+    expect(finalEvent.outputs).toBe('HI THERE');
+  });
+
+  it('falls back to final output when no plan is produced', async () => {
+    const emitted = [];
+    const kernel = {
+      async plan() {
+        return { steps: [] };
+      },
+      async act(step) {
+        return { fallback: true, reason: step.args.reason };
+      },
+      async renderFinal(outputs) {
+        return outputs;
+      },
+    };
+
+    const result = await runLoop(kernel, (event) => emitted.push(event));
+
+    expect(result.status).toBe('final');
+    expect(result.reason).toBe('no-plan');
+    expect(result.outputs).toEqual([{ fallback: true, reason: 'no-plan' }]);
+    const finalEvent = emitted.find((event) => event.type === 'final');
+    expect(finalEvent.reason).toBe('no-plan');
+    expect(emitted.some((event) => event.type === 'tool' && event.name === 'respond')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- define core agent run loop plus EpisodeLogger and Replay utilities to drive the minimal agent kernel
- add a lightweight Vitest-compatible runner with specs covering runLoop, EpisodeLogger, and Replay
- wire pnpm test into GitHub Actions so CI exercises the new unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c90e66dae8832bb3ed361c2d36d9e9