### PR TITLE
feat: scaffold minimal agent kernel

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -1,0 +1,188 @@
+import { readFile } from 'node:fs/promises';
+import { ToolInvoker, ToolCall, ToolResult, ToolOk, ToolError, AgentKernel, Plan, PlanStep, ActionOutcome, ReviewResult } from '../core/agent';
+
+async function handleHttpGet(args: any): Promise<ToolResult> {
+  const url = args?.url;
+  if (!url) {
+    return { ok: false, code: 'http.invalid_url', message: 'url is required' };
+  }
+  try {
+    const response = await fetch(url);
+    const body = await response.text();
+    return {
+      ok: true,
+      data: {
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        body,
+      },
+      latency_ms: 0,
+    } satisfies ToolOk;
+  } catch (err: any) {
+    return {
+      ok: false,
+      code: 'http.error',
+      message: err?.message ?? 'request failed',
+      retryable: true,
+    } satisfies ToolError;
+  }
+}
+
+async function handleFileRead(args: any): Promise<ToolResult> {
+  const path = args?.path;
+  if (!path) {
+    return { ok: false, code: 'file.invalid_path', message: 'path is required' };
+  }
+  try {
+    const content = await readFile(path, 'utf8');
+    return { ok: true, data: { path, content } } satisfies ToolOk;
+  } catch (err: any) {
+    return {
+      ok: false,
+      code: 'file.read_error',
+      message: err?.message ?? 'failed to read file',
+    } satisfies ToolError;
+  }
+}
+
+function handleEcho(args: any): ToolResult {
+  return { ok: true, data: args } satisfies ToolOk;
+}
+
+function handleChat(args: any): ToolResult {
+  const prompt = args?.prompt;
+  const messages = Array.isArray(args?.messages) ? args.messages : [];
+  const content =
+    typeof prompt === 'string' && prompt.trim().length
+      ? prompt
+      : messages.map((m: any) => m?.content).filter(Boolean).join('\n');
+
+  const reply =
+    content?.length > 0
+      ? `Echoing (${content.length} chars): ${content}`
+      : 'Hello! I am a local chat kernel. Provide a prompt to continue.';
+
+  return { ok: true, data: { content: reply } } satisfies ToolOk;
+}
+
+export function createDefaultToolInvoker(): ToolInvoker {
+  return async (call: ToolCall, _ctx) => {
+    switch (call.name) {
+      case 'echo':
+        return handleEcho(call.args);
+      case 'http.get':
+        return handleHttpGet(call.args);
+      case 'file.read':
+        return handleFileRead(call.args);
+      case 'llm.chat':
+        return handleChat(call.args);
+      default:
+        return {
+          ok: false,
+          code: 'tool.not_found',
+          message: `tool ${call.name} is not available`,
+        } satisfies ToolError;
+    }
+  };
+}
+
+export function summarizeToolResult(result: ToolResult): any {
+  if (result.ok) {
+    const data = result.data;
+    if (typeof data === 'string') {
+      return data.length > 160 ? `${data.slice(0, 157)}...` : data;
+    }
+    if (data && typeof data === 'object' && 'content' in data) {
+      const text = (data as any).content;
+      if (typeof text === 'string') {
+        return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+      }
+    }
+    return data;
+  }
+  return { code: result.code, message: result.message };
+}
+
+interface ChatKernelOptions {
+  message: string;
+  traceId: string;
+  toolInvoker: ToolInvoker;
+}
+
+class ChatKernel implements AgentKernel {
+  private perceived = false;
+  private planCount = 0;
+  private actions: ActionOutcome[] = [];
+
+  constructor(
+    private readonly options: ChatKernelOptions
+  ) {}
+
+  async perceive(): Promise<void> {
+    this.perceived = true;
+  }
+
+  async plan(): Promise<Plan> {
+    this.planCount += 1;
+    if (!this.perceived) {
+      throw new Error('perceive must be called before plan');
+    }
+    return {
+      revision: this.planCount,
+      reason: this.planCount === 1 ? 'initial' : 'retry',
+      steps: [
+        {
+          id: `${this.options.traceId}-step-${this.planCount}`,
+          op: 'llm.chat',
+          args: { prompt: this.options.message },
+        },
+      ],
+    } satisfies Plan;
+  }
+
+  async act(step: PlanStep): Promise<ActionOutcome> {
+    const result = await this.options.toolInvoker(
+      { name: step.op, args: step.args },
+      {
+        trace_id: this.options.traceId,
+        span_id: step.id,
+      }
+    );
+    const outcome: ActionOutcome = { step, result };
+    this.actions.push(outcome);
+    return outcome;
+  }
+
+  async review(actions: ActionOutcome[]): Promise<ReviewResult> {
+    const latest = actions.at(-1);
+    const passed = Boolean(latest?.result.ok);
+    return {
+      score: passed ? 1 : 0,
+      passed,
+      notes: passed
+        ? ['auto-pass: chat response generated']
+        : ['tool invocation failed'],
+    } satisfies ReviewResult;
+  }
+
+  async renderFinal(actions: ActionOutcome[]): Promise<any> {
+    const latest = actions.at(-1);
+    if (!latest) return { text: '' };
+    if (latest.result.ok) {
+      const data = latest.result.data;
+      if (typeof data === 'string') {
+        return { text: data };
+      }
+      if (data && typeof data === 'object' && 'content' in data) {
+        const text = (data as any).content;
+        return { text, raw: data };
+      }
+      return { text: JSON.stringify(data), raw: data };
+    }
+    return { error: latest.result };
+  }
+}
+
+export function createChatKernel(options: ChatKernelOptions): AgentKernel {
+  return new ChatKernel(options);
+}

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { randomUUID } from 'node:crypto';
+import { runLoop, type CoreEvent } from './core/agent';
+import { EventBus, wrapCoreEvent } from './runtime/events';
+import { EpisodeLogger } from './runtime/episode';
+import { replayEpisode } from './runtime/replay';
+import { createChatKernel, createDefaultToolInvoker } from './adapters/core';
+
+async function runOnce(message: string) {
+  const traceId = randomUUID();
+  const bus = new EventBus();
+  const logger = new EpisodeLogger({ traceId });
+  const toolInvoker = createDefaultToolInvoker();
+  const kernel = createChatKernel({ message, traceId, toolInvoker });
+
+  bus.subscribe((event) => {
+    logEvent(event.data);
+    return logger.append(event);
+  });
+
+  const emit = (event: CoreEvent) => bus.publish(wrapCoreEvent(traceId, event));
+  const result = await runLoop(kernel, emit, {
+    context: { traceId, input: message },
+  });
+
+  console.log('\nFinal output:', JSON.stringify(result.final, null, 2));
+  console.log(`Episode saved to episodes/${traceId}.jsonl`);
+}
+
+function logEvent(event: CoreEvent) {
+  const time = new Date().toISOString();
+  switch (event.type) {
+    case 'progress':
+      console.log(`[${time}] progress/${event.step} ${(event.pct * 100).toFixed(0)}%`);
+      break;
+    case 'plan':
+      console.log(`[${time}] plan revision=${event.revision} steps=${event.steps.length}`);
+      break;
+    case 'tool':
+      console.log(`[${time}] tool ${event.name}`, event.result);
+      break;
+    case 'ask':
+      console.log(`[${time}] ask ${event.question}`);
+      break;
+    case 'score':
+      console.log(`[${time}] score ${event.value} passed=${event.passed}`);
+      break;
+    case 'final':
+      console.log(`[${time}] final`, event.outputs);
+      break;
+    case 'log':
+      console.log(`[${time}] ${event.level}`, event.message);
+      break;
+  }
+}
+
+async function replay(traceId: string) {
+  const events = await replayEpisode(traceId, {
+    onEvent: (event) => {
+      console.log(`${event.ts} ${event.type}`, event.data);
+    },
+  });
+  console.log(`Replayed ${events.length} events.`);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (!command || command === 'help') {
+    console.log('Usage (after compiling to JavaScript):');
+    console.log('  node dist/cli.js run "message"');
+    console.log('  node dist/cli.js replay <trace_id>');
+    process.exit(0);
+  }
+
+  if (command === 'run') {
+    const message = args.join(' ') || 'Hello from CLI';
+    await runOnce(message);
+    return;
+  }
+
+  if (command === 'replay') {
+    const traceId = args[0];
+    if (!traceId) {
+      console.error('Trace id is required for replay.');
+      process.exit(1);
+    }
+    await replay(traceId);
+    return;
+  }
+
+  console.error(`Unknown command: ${command}`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from 'node:crypto';
+
+export type Step = 'perceive' | 'plan' | 'act' | 'review' | 'final';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface PlanStep<TArgs = any> {
+  id: string;
+  op: string;
+  args: TArgs;
+  description?: string;
+}
+
+export interface Plan {
+  steps: PlanStep[];
+  revision?: number;
+  reason?: string;
+  notes?: string[];
+}
+
+export interface AskRequest {
+  question: string;
+  origin_step?: string;
+  detail?: any;
+}
+
+export type ToolError = {
+  ok: false;
+  code: string;
+  message: string;
+  retryable?: boolean;
+};
+
+export type ToolOk<T = any> = {
+  ok: true;
+  data: T;
+  latency_ms?: number;
+  cost?: number;
+};
+
+export type ToolResult<T = any> = ToolOk<T> | ToolError;
+
+export interface ToolCall<TArgs = any> {
+  name: string;
+  args: TArgs;
+}
+
+export interface ToolContext {
+  trace_id: string;
+  span_id?: string;
+  metadata?: Record<string, any>;
+}
+
+export type ToolInvoker = (
+  call: ToolCall,
+  ctx: ToolContext
+) => Promise<ToolResult>;
+
+export interface ActionOutcome<T = any> {
+  step: PlanStep;
+  result: ToolResult<T>;
+  ask?: AskRequest;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface ReviewResult {
+  score: number;
+  passed: boolean;
+  notes?: string[];
+}
+
+export type CoreEvent =
+  | { type: 'progress'; step: Step; pct: number; note?: string }
+  | { type: 'plan'; steps: PlanStep[]; revision: number; reason?: string }
+  | {
+      type: 'tool';
+      name: string;
+      args: any;
+      result?: any;
+      cost?: number;
+      latency_ms?: number;
+    }
+  | { type: 'ask'; question: string; origin_step?: string }
+  | { type: 'score'; value: number; passed: boolean; notes?: string[] }
+  | { type: 'final'; outputs: any; reason?: string }
+  | { type: 'log'; level: LogLevel; message: string; detail?: any };
+
+export interface AgentContext {
+  traceId: string;
+  input?: any;
+  metadata?: Record<string, any>;
+}
+
+export interface AgentKernel {
+  perceive(ctx: AgentContext): Promise<void>;
+  plan(): Promise<Plan | null>;
+  act(step: PlanStep): Promise<ActionOutcome>;
+  review(actions: ActionOutcome[]): Promise<ReviewResult>;
+  renderFinal(actions: ActionOutcome[]): Promise<any>;
+}
+
+export interface RunLoopOptions {
+  maxIterations?: number;
+  context?: AgentContext;
+}
+
+export interface RunLoopResult {
+  actions: ActionOutcome[];
+  final?: any;
+  reason: 'completed' | 'no-plan' | 'ask' | 'max-iterations';
+  review?: ReviewResult;
+}
+
+const ensurePromise = async <T>(value: T | Promise<T>): Promise<T> => value;
+
+export async function runLoop(
+  kernel: AgentKernel,
+  emit: (event: CoreEvent) => void | Promise<void>,
+  options: RunLoopOptions = {}
+): Promise<RunLoopResult> {
+  const maxIterations = options.maxIterations ?? 3;
+  const actions: ActionOutcome[] = [];
+  const context = options.context ?? { traceId: randomUUID() };
+
+  await ensurePromise(kernel.perceive(context));
+  await ensurePromise(emit({ type: 'progress', step: 'perceive', pct: 0.2 }));
+
+  let iteration = 0;
+  let lastReview: ReviewResult | undefined;
+
+  while (iteration < maxIterations) {
+    iteration += 1;
+    const plan = await kernel.plan();
+    const steps = plan?.steps ?? [];
+    const revision = plan?.revision ?? iteration;
+    await ensurePromise(
+      emit({
+        type: 'plan',
+        steps,
+        revision,
+        reason: plan?.reason ?? (iteration === 1 ? 'initial' : 'retry'),
+      })
+    );
+
+    if (!steps.length) {
+      await ensurePromise(
+        emit({
+          type: 'log',
+          level: 'warn',
+          message: 'plan returned no executable steps, using fallback response',
+        })
+      );
+
+      const fallbackStep: PlanStep = {
+        id: `fallback-${iteration}`,
+        op: 'llm.chat',
+        args: { prompt: context.input ?? '' },
+      };
+      const outcome = await kernel.act(fallbackStep);
+      actions.push(outcome);
+      await ensurePromise(
+        emit({
+          type: 'tool',
+          name: fallbackStep.op,
+          args: fallbackStep.args,
+          result: outcome.result,
+          cost: outcome.result.ok ? outcome.result.cost : undefined,
+          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+        })
+      );
+      const finalOutputs = await kernel.renderFinal(actions);
+      await ensurePromise(
+        emit({ type: 'final', outputs: finalOutputs, reason: 'no-plan' })
+      );
+      return { actions, final: finalOutputs, reason: 'no-plan' };
+    }
+
+    for (const step of steps) {
+      await ensurePromise(
+        emit({ type: 'progress', step: 'act', pct: 0.4 })
+      );
+      const outcome = await kernel.act(step);
+      actions.push(outcome);
+      await ensurePromise(
+        emit({
+          type: 'tool',
+          name: step.op,
+          args: step.args,
+          result: outcome.result,
+          cost: outcome.result.ok ? outcome.result.cost : undefined,
+          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+        })
+      );
+
+      if (outcome.ask) {
+        await ensurePromise(
+          emit({
+            type: 'ask',
+            question: outcome.ask.question,
+            origin_step: outcome.ask.origin_step ?? step.id,
+          })
+        );
+        return { actions, reason: 'ask' };
+      }
+    }
+
+    lastReview = await kernel.review(actions);
+    await ensurePromise(
+      emit({
+        type: 'score',
+        value: lastReview.score,
+        passed: lastReview.passed,
+        notes: lastReview.notes,
+      })
+    );
+
+    if (lastReview.passed) {
+      const finalOutputs = await kernel.renderFinal(actions);
+      await ensurePromise(
+        emit({ type: 'final', outputs: finalOutputs, reason: 'completed' })
+      );
+      return {
+        actions,
+        final: finalOutputs,
+        reason: 'completed',
+        review: lastReview,
+      };
+    }
+  }
+
+  await ensurePromise(
+    emit({
+      type: 'log',
+      level: 'warn',
+      message: 'max iterations reached without passing review',
+    })
+  );
+  return { actions, reason: 'max-iterations', review: lastReview };
+}

--- a/plan.json
+++ b/plan.json
@@ -1,0 +1,30 @@
+{
+  "goal": "Implement minimal AgentOS kernel with chat, logging, and replay capabilities using <=10 source files.",
+  "constraints": [
+    "Follow AGENTS.md instructions and dependency whitelist",
+    "Limit implementation to specified directories and files (<=10)",
+    "Episodes must persist to disk and support replay"
+  ],
+  "budget": { "currency": "CNY", "limit": 0 },
+  "acceptance": [
+    {"id": "A1", "given": "User runs pnpm dev", "when": "Server receives POST /api/run", "then": "Chat response is generated and episode file is written"},
+    {"id": "A2", "given": "Episode exists", "when": "User runs replay command", "then": "Logged events are re-emitted in order"}
+  ],
+  "steps": [
+    {"id": "S1", "action": "llm", "input": {"task": "Design data structures and module interfaces for core/agent and runtime components"}, "expect": "Agreed minimal TypeScript interfaces"},
+    {"id": "S2", "action": "tool", "input": {"tool": "fs"}, "expect": "Create directories and baseline files"},
+    {"id": "S3", "action": "tool", "input": {"tool": "ts"}, "expect": "Implement run loop, event bus, episode logger, and replay"},
+    {"id": "S4", "action": "tool", "input": {"tool": "ts"}, "expect": "Implement adapters and HTTP server"},
+    {"id": "S5", "action": "tool", "input": {"tool": "html"}, "expect": "Build simple UI for chat and log display"},
+    {"id": "S6", "action": "tool", "input": {"tool": "ts"}, "expect": "Provide CLI entry supporting run and replay"},
+    {"id": "S7", "action": "tool", "input": {"tool": "ts"}, "expect": "Add lightweight tests or manual validation hooks if feasible"}
+  ],
+  "risks": [
+    "Time constraints limit comprehensive test coverage",
+    "File count restriction complicates separation of concerns"
+  ],
+  "rollback": [
+    "Revert to initial empty repository commit if architecture fails",
+    "Simplify run loop to sequential execution without planner updates"
+  ]
+}

--- a/runtime/episode.ts
+++ b/runtime/episode.ts
@@ -1,0 +1,71 @@
+import { dirname, join } from 'node:path';
+import { mkdir, readFile, stat, appendFile } from 'node:fs/promises';
+import type { EventEnvelope } from './events';
+
+export interface EpisodeLoggerOptions {
+  traceId: string;
+  dir?: string;
+}
+
+export class EpisodeLogger {
+  private readonly filePath: string;
+  private ready = false;
+  private line = 0;
+  private byteOffset = 0;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: EpisodeLoggerOptions) {
+    const baseDir = options.dir ?? join(process.cwd(), 'episodes');
+    this.filePath = join(baseDir, `${options.traceId}.jsonl`);
+  }
+
+  private async ensureReady() {
+    if (this.ready) return;
+    await mkdir(dirname(this.filePath), { recursive: true });
+    try {
+      const fileStat = await stat(this.filePath);
+      this.byteOffset = fileStat.size;
+      const content = await readFile(this.filePath, 'utf8');
+      const lines = content.split('\n').filter(Boolean);
+      this.line = lines.length;
+    } catch (err: any) {
+      if (err && err.code !== 'ENOENT') {
+        throw err;
+      }
+      this.byteOffset = 0;
+      this.line = 0;
+    }
+    this.ready = true;
+  }
+
+  append(event: EventEnvelope): Promise<EventEnvelope> {
+    this.queue = this.queue.then(async () => {
+      await this.ensureReady();
+      const enriched = event;
+      enriched.ln = enriched.ln ?? ++this.line;
+      enriched.byte_offset = enriched.byte_offset ?? this.byteOffset;
+      const payload = JSON.stringify(enriched) + '\n';
+      const bufferLength = Buffer.byteLength(payload);
+      await appendFile(this.filePath, payload, 'utf8');
+      this.byteOffset += bufferLength;
+    });
+
+    return this.queue.then(() => event);
+  }
+
+  async readAll(): Promise<EventEnvelope[]> {
+    await this.ensureReady();
+    try {
+      const content = await readFile(this.filePath, 'utf8');
+      return content
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as EventEnvelope);
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        return [];
+      }
+      throw err;
+    }
+  }
+}

--- a/runtime/events.ts
+++ b/runtime/events.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'node:crypto';
+import type { CoreEvent } from '../core/agent';
+
+export interface EventEnvelope<T = any> {
+  id: string;
+  ts: string;
+  type: string;
+  version: number;
+  trace_id: string;
+  span_id?: string;
+  parent_span_id?: string;
+  topic?: string;
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  data: T;
+  ln?: number;
+  byte_offset?: number;
+}
+
+export type EventSubscriber = (
+  event: EventEnvelope
+) => void | Promise<void>;
+
+export interface EventBusOptions {
+  version?: number;
+}
+
+export class EventBus {
+  private subscribers = new Set<EventSubscriber>();
+  private sequence = 0;
+
+  constructor(private readonly options: EventBusOptions = {}) {}
+
+  subscribe(sub: EventSubscriber): () => void {
+    this.subscribers.add(sub);
+    return () => {
+      this.subscribers.delete(sub);
+    };
+  }
+
+  async publish<T>(envelope: EventEnvelope<T>): Promise<EventEnvelope<T>> {
+    const enriched = envelope;
+    enriched.id = enriched.id || randomUUID();
+    enriched.ts = enriched.ts || new Date().toISOString();
+    enriched.version = enriched.version ?? this.options.version ?? 1;
+    enriched.ln = enriched.ln ?? ++this.sequence;
+
+    for (const sub of this.subscribers) {
+      await sub(enriched);
+    }
+
+    return enriched;
+  }
+}
+
+export interface WrapEventOptions {
+  spanId?: string;
+  parentSpanId?: string;
+  topic?: string;
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  version?: number;
+}
+
+export function wrapCoreEvent(
+  traceId: string,
+  event: CoreEvent,
+  options: WrapEventOptions = {}
+): EventEnvelope<CoreEvent> {
+  return {
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    type: `agent.${event.type}`,
+    version: options.version ?? 1,
+    trace_id: traceId,
+    span_id: options.spanId,
+    parent_span_id: options.parentSpanId,
+    topic: options.topic,
+    level: options.level,
+    data: event,
+  };
+}

--- a/runtime/replay.ts
+++ b/runtime/replay.ts
@@ -1,0 +1,36 @@
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import type { EventEnvelope } from './events';
+
+export interface ReplayOptions {
+  dir?: string;
+  onEvent?: (event: EventEnvelope) => void | Promise<void>;
+}
+
+export async function replayEpisode(
+  traceId: string,
+  options: ReplayOptions = {}
+): Promise<EventEnvelope[]> {
+  const baseDir = options.dir ?? join(process.cwd(), 'episodes');
+  const filePath = join(baseDir, `${traceId}.jsonl`);
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') {
+      throw new Error(`episode not found for trace ${traceId}`);
+    }
+    throw err;
+  }
+
+  const lines = content.split('\n').filter(Boolean);
+  const events: EventEnvelope[] = [];
+  for (const line of lines) {
+    const parsed = JSON.parse(line) as EventEnvelope;
+    events.push(parsed);
+    if (options.onEvent) {
+      await options.onEvent(parsed);
+    }
+  }
+  return events;
+}

--- a/server/http.ts
+++ b/server/http.ts
@@ -1,0 +1,138 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { runLoop, type CoreEvent } from '../core/agent';
+import { EventBus, wrapCoreEvent, type EventEnvelope } from '../runtime/events';
+import { EpisodeLogger } from '../runtime/episode';
+import { createChatKernel, createDefaultToolInvoker } from '../adapters/core';
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+const episodesDir = join(process.cwd(), 'episodes');
+const uiFile = join(process.cwd(), 'ui', 'index.html');
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown) {
+  const payload = JSON.stringify(data);
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Length', Buffer.byteLength(payload));
+  res.end(payload);
+}
+
+function sendText(res: ServerResponse, status: number, text: string, type = 'text/plain') {
+  res.statusCode = status;
+  res.setHeader('Content-Type', `${type}; charset=utf-8`);
+  res.setHeader('Content-Length', Buffer.byteLength(text));
+  res.end(text);
+}
+
+async function handleRun(req: IncomingMessage, res: ServerResponse) {
+  const bodyText = await readBody(req);
+  let payload: any = {};
+  if (bodyText) {
+    try {
+      payload = JSON.parse(bodyText);
+    } catch {
+      sendJson(res, 400, { error: 'invalid_json', message: 'request body must be valid json' });
+      return;
+    }
+  }
+  const message: string = payload.message ?? payload.input ?? '';
+  const traceId = randomUUID();
+
+  const bus = new EventBus();
+  const logger = new EpisodeLogger({ traceId, dir: episodesDir });
+  const toolInvoker = createDefaultToolInvoker();
+  const kernel = createChatKernel({ message, traceId, toolInvoker });
+
+  const events: EventEnvelope<CoreEvent>[] = [];
+  bus.subscribe((event) => {
+    events.push(event);
+    return logger.append(event).catch((err) => {
+      console.error('failed to append episode event', err);
+    });
+  });
+
+  const emit = (event: CoreEvent) => bus.publish(wrapCoreEvent(traceId, event));
+  const result = await runLoop(kernel, emit, {
+    context: { traceId, input: message },
+  });
+
+  sendJson(res, 200, {
+    trace_id: traceId,
+    result: result.final,
+    events: events.map((evt) => ({
+      ts: evt.ts,
+      type: evt.type,
+      data: evt.data,
+    })),
+  });
+}
+
+async function handleGetEpisode(res: ServerResponse, traceId: string) {
+  try {
+    const file = await readFile(join(episodesDir, `${traceId}.jsonl`), 'utf8');
+    sendText(res, 200, file);
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') {
+      sendJson(res, 404, { error: 'not_found', message: `episode ${traceId} not found` });
+      return;
+    }
+    sendJson(res, 500, { error: 'read_failed', message: err?.message ?? 'unknown error' });
+  }
+}
+
+async function handleUi(res: ServerResponse) {
+  try {
+    const html = await readFile(uiFile, 'utf8');
+    sendText(res, 200, html, 'text/html');
+  } catch (err: any) {
+    sendJson(res, 500, { error: 'ui_missing', message: err?.message ?? 'unable to read ui' });
+  }
+}
+
+export const server = createServer(async (req, res) => {
+  if (!req.url) {
+    sendJson(res, 400, { error: 'invalid_request', message: 'empty url' });
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+
+  try {
+    if (req.method === 'POST' && url.pathname === '/api/run') {
+      await handleRun(req, res);
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname.startsWith('/api/episodes/')) {
+      const traceId = url.pathname.split('/').pop() ?? '';
+      await handleGetEpisode(res, traceId);
+      return;
+    }
+
+    if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/ui')) {
+      await handleUi(res);
+      return;
+    }
+
+    sendJson(res, 404, { error: 'not_found', message: 'route not found' });
+  } catch (err: any) {
+    console.error('request failed', err);
+    sendJson(res, 500, { error: 'internal_error', message: err?.message ?? 'unknown error' });
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(PORT, () => {
+    console.log(`AgentOS dev server listening on http://localhost:${PORT}`);
+  });
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AgentOS · Chat + LogFlow</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0;
+        padding: 0;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      header {
+        padding: 1.5rem 2rem;
+        background: #1e293b;
+        box-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
+      }
+      main {
+        padding: 2rem;
+        display: grid;
+        gap: 1.5rem;
+        max-width: 960px;
+        margin: 0 auto;
+      }
+      textarea {
+        width: 100%;
+        min-height: 140px;
+        padding: 1rem;
+        font-size: 1rem;
+        border-radius: 8px;
+        border: 1px solid #334155;
+        background: #0f172a;
+        color: inherit;
+      }
+      button {
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        border: none;
+        background: #38bdf8;
+        color: #0f172a;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button:disabled {
+        background: #475569;
+        cursor: not-allowed;
+      }
+      .panel {
+        background: #1e293b;
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+      }
+      .logs {
+        white-space: pre-wrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        background: #0f172a;
+        border-radius: 8px;
+        padding: 1rem;
+        max-height: 320px;
+        overflow-y: auto;
+      }
+      .trace-info {
+        font-size: 0.875rem;
+        color: #94a3b8;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>AgentOS · Chat + LogFlow</h1>
+      <p class="trace-info">
+        Submit a prompt to generate a response, inspect events, and replay episodes.
+      </p>
+    </header>
+    <main>
+      <section class="panel">
+        <h2>Chat</h2>
+        <textarea id="message" placeholder="Ask the agent for a summary or instruction..."></textarea>
+        <div style="margin-top: 1rem; display: flex; gap: 1rem; align-items: center;">
+          <button id="run" type="button">Run</button>
+          <span id="status" class="trace-info"></span>
+        </div>
+        <div style="margin-top: 1rem;">
+          <strong>Final Output</strong>
+          <div id="final" class="logs"></div>
+        </div>
+      </section>
+      <section class="panel">
+        <h2>LogFlow</h2>
+        <div class="trace-info" id="trace"></div>
+        <div id="log" class="logs"></div>
+      </section>
+    </main>
+    <script>
+      const runButton = document.getElementById('run');
+      const messageInput = document.getElementById('message');
+      const finalOutput = document.getElementById('final');
+      const logOutput = document.getElementById('log');
+      const traceInfo = document.getElementById('trace');
+      const status = document.getElementById('status');
+
+      async function runChat() {
+        const prompt = messageInput.value.trim();
+        runButton.disabled = true;
+        status.textContent = 'Running...';
+        finalOutput.textContent = '';
+        logOutput.textContent = '';
+        traceInfo.textContent = '';
+
+        try {
+          const response = await fetch('/api/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: prompt }),
+          });
+
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.message || 'Request failed');
+          }
+
+          const data = await response.json();
+          const traceId = data.trace_id;
+          status.textContent = 'Completed';
+          traceInfo.textContent = `trace_id: ${traceId}`;
+          finalOutput.textContent = JSON.stringify(data.result, null, 2);
+
+          const episodeResponse = await fetch(`/api/episodes/${traceId}`);
+          if (episodeResponse.ok) {
+            const episodeText = await episodeResponse.text();
+            logOutput.textContent = episodeText.trim();
+          } else {
+            logOutput.textContent = 'Episode not available yet.';
+          }
+        } catch (error) {
+          status.textContent = 'Failed';
+          finalOutput.textContent = String(error.message || error);
+        } finally {
+          runButton.disabled = false;
+        }
+      }
+
+      runButton.addEventListener('click', runChat);
+      messageInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+          event.preventDefault();
+          runChat();
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- define the agent kernel interfaces and run loop used to emit plan/act/review events
- add runtime facilities for in-memory events, episode logging, and offline replay
- expose a default chat kernel with HTTP endpoints, HTML UI, and CLI helpers for run/replay

## Testing
- not run (project scaffolding only)


------
https://chatgpt.com/codex/tasks/task_e_68c90e5b524c832ba9e05a74dda3fe30