### PR TITLE
Add event streaming and accessibility updates

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -3,13 +3,92 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { runLoop, type CoreEvent } from "../core/agent";
-import { EventBus, wrapCoreEvent, type EventEnvelope } from "../runtime/events";
+import { EventBus, wrapCoreEvent } from "../runtime/events";
 import { EpisodeLogger } from "../runtime/episode";
 import { createChatKernel, createDefaultToolInvoker } from "../adapters/core";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 const episodesDir = join(process.cwd(), "episodes");
 const uiFile = join(process.cwd(), "ui", "index.html");
+
+type StreamEvent = "event" | "complete" | "run-error";
+
+interface StreamEventPayload {
+  ts: string;
+  type: string;
+  data: CoreEvent;
+}
+
+interface StreamMessage {
+  event: StreamEvent;
+  data: StreamEventPayload | { final: any; reason: string } | { message: string };
+}
+
+class EventStreamBroker {
+  private readonly clients = new Map<string, Set<ServerResponse>>();
+
+  register(traceId: string, res: ServerResponse): () => void {
+    let listeners = this.clients.get(traceId);
+    if (!listeners) {
+      listeners = new Set();
+      this.clients.set(traceId, listeners);
+    }
+    listeners.add(res);
+    return () => this.unregister(traceId, res);
+  }
+
+  send(traceId: string, event: StreamEvent, data: any) {
+    const listeners = this.clients.get(traceId);
+    if (!listeners || listeners.size === 0) return;
+    for (const client of listeners) {
+      this.write(client, event, data);
+    }
+  }
+
+  replay(res: ServerResponse, messages: StreamMessage[]) {
+    for (const message of messages) {
+      this.write(res, message.event, message.data);
+    }
+  }
+
+  close(traceId: string) {
+    const listeners = this.clients.get(traceId);
+    if (!listeners) return;
+    for (const client of listeners) {
+      if (!client.writableEnded) {
+        client.end();
+      }
+    }
+    this.clients.delete(traceId);
+  }
+
+  private unregister(traceId: string, res: ServerResponse) {
+    const listeners = this.clients.get(traceId);
+    if (!listeners) return;
+    listeners.delete(res);
+    if (listeners.size === 0) {
+      this.clients.delete(traceId);
+    }
+  }
+
+  private write(res: ServerResponse, event: StreamEvent, data: any) {
+    if (res.writableEnded) return;
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  }
+}
+
+const streamBroker = new EventStreamBroker();
+const streamBuffers = new Map<string, StreamMessage[]>();
+
+function scheduleBufferCleanup(traceId: string, delayMs: number) {
+  const timer = setTimeout(() => {
+    streamBuffers.delete(traceId);
+  }, delayMs);
+  if (typeof timer.unref === "function") {
+    timer.unref();
+  }
+}
 
 async function readBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -53,27 +132,44 @@ async function handleRun(req: IncomingMessage, res: ServerResponse) {
   const toolInvoker = createDefaultToolInvoker();
   const kernel = createChatKernel({ message, traceId, toolInvoker });
 
-  const events: EventEnvelope<CoreEvent>[] = [];
+  const eventBuffer: StreamMessage[] = [];
+  streamBuffers.set(traceId, eventBuffer);
+
   bus.subscribe((event) => {
-    events.push(event);
+    const summary: StreamEventPayload = {
+      ts: event.ts,
+      type: event.type,
+      data: event.data,
+    };
+    eventBuffer.push({ event: "event", data: summary });
+    streamBroker.send(traceId, "event", summary);
     return logger.append(event).catch((err) => {
       console.error("failed to append episode event", err);
     });
   });
 
   const emit = (event: CoreEvent) => bus.publish(wrapCoreEvent(traceId, event));
-  const result = await runLoop(kernel, emit, {
+  void runLoop(kernel, emit, {
     context: { traceId, input: message },
-  });
+  })
+    .then((result) => {
+      const completePayload = { final: result.final, reason: result.reason };
+      eventBuffer.push({ event: "complete", data: completePayload });
+      streamBroker.send(traceId, "complete", completePayload);
+      scheduleBufferCleanup(traceId, 60_000);
+      streamBroker.close(traceId);
+    })
+    .catch((err) => {
+      console.error("runLoop failed", err);
+      const errorPayload = { message: err?.message ?? "run loop failed" };
+      eventBuffer.push({ event: "run-error", data: errorPayload });
+      streamBroker.send(traceId, "run-error", errorPayload);
+      scheduleBufferCleanup(traceId, 60_000);
+      streamBroker.close(traceId);
+    });
 
-  sendJson(res, 200, {
+  sendJson(res, 202, {
     trace_id: traceId,
-    result: result.final,
-    events: events.map((evt) => ({
-      ts: evt.ts,
-      type: evt.type,
-      data: evt.data,
-    })),
   });
 }
 
@@ -99,6 +195,29 @@ async function handleUi(res: ServerResponse) {
   }
 }
 
+function handleEventStream(req: IncomingMessage, res: ServerResponse, traceId: string) {
+  if (!traceId) {
+    sendJson(res, 400, { error: "invalid_trace", message: "trace id is required" });
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.write(": connected\n\n");
+
+  const cleanup = streamBroker.register(traceId, res);
+  const backlog = streamBuffers.get(traceId);
+  if (backlog && backlog.length > 0) {
+    streamBroker.replay(res, backlog);
+  }
+
+  req.on("close", () => {
+    cleanup();
+  });
+}
+
 export const server = createServer(async (req, res) => {
   if (!req.url) {
     sendJson(res, 400, { error: "invalid_request", message: "empty url" });
@@ -116,6 +235,17 @@ export const server = createServer(async (req, res) => {
     if (req.method === "GET" && url.pathname.startsWith("/api/episodes/")) {
       const traceId = url.pathname.split("/").pop() ?? "";
       await handleGetEpisode(res, traceId);
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      url.pathname.startsWith("/api/run/") &&
+      url.pathname.endsWith("/events")
+    ) {
+      const segments = url.pathname.split("/");
+      const traceId = segments.length >= 4 ? segments[3] : "";
+      handleEventStream(req, res, traceId);
       return;
     }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -80,20 +80,34 @@
         <textarea
           id="message"
           placeholder="Ask the agent for a summary or instruction..."
+          aria-label="Agent prompt input"
+          role="textbox"
         ></textarea>
         <div style="margin-top: 1rem; display: flex; gap: 1rem; align-items: center">
-          <button id="run" type="button">Run</button>
-          <span id="status" class="trace-info"></span>
+          <button id="run" type="button" aria-label="Run agent" role="button">Run</button>
+          <span id="status" class="trace-info" role="status" aria-live="polite"></span>
         </div>
         <div style="margin-top: 1rem">
           <strong>Final Output</strong>
-          <div id="final" class="logs"></div>
+          <div
+            id="final"
+            class="logs"
+            role="status"
+            aria-live="polite"
+            aria-label="Final agent output"
+          ></div>
         </div>
       </section>
       <section class="panel">
         <h2>LogFlow</h2>
-        <div class="trace-info" id="trace"></div>
-        <div id="log" class="logs"></div>
+        <div class="trace-info" id="trace" role="status" aria-live="polite"></div>
+        <div
+          id="log"
+          class="logs"
+          role="log"
+          aria-live="polite"
+          aria-label="Streaming agent events"
+        ></div>
       </section>
     </main>
     <script>
@@ -103,14 +117,106 @@
       const logOutput = document.getElementById("log");
       const traceInfo = document.getElementById("trace");
       const status = document.getElementById("status");
+      let eventSource = null;
+      let logLines = [];
+
+      function closeStream() {
+        if (eventSource) {
+          eventSource.close();
+          eventSource = null;
+        }
+      }
+
+      function appendLogLine(line) {
+        logLines.push(line);
+        logOutput.textContent = logLines.join("\n");
+        logOutput.scrollTop = logOutput.scrollHeight;
+      }
+
+      async function hydrateEpisode(traceId) {
+        try {
+          const response = await fetch(`/api/episodes/${traceId}`);
+          if (response.ok) {
+            const text = (await response.text()).trim();
+            if (text.length > 0) {
+              logLines = text.split(/\n/);
+              logOutput.textContent = logLines.join("\n");
+              logOutput.scrollTop = logOutput.scrollHeight;
+            }
+          }
+        } catch (error) {
+          console.error("Failed to hydrate episode", error);
+        }
+      }
+
+      function subscribeToEvents(traceId) {
+        closeStream();
+        const source = new EventSource(`/api/run/${traceId}/events`);
+        eventSource = source;
+
+        source.addEventListener("open", () => {
+          status.textContent = "Running...";
+        });
+
+        source.addEventListener("event", (evt) => {
+          try {
+            const payload = JSON.parse(evt.data);
+            appendLogLine(JSON.stringify(payload));
+            status.textContent = "Streaming events...";
+          } catch (error) {
+            console.error("Failed to parse event", error);
+          }
+        });
+
+        source.addEventListener("complete", async (evt) => {
+          try {
+            const payload = JSON.parse(evt.data);
+            const reason = payload.reason ? ` (${payload.reason})` : "";
+            status.textContent = `Completed${reason}`;
+            finalOutput.textContent = JSON.stringify(payload.final ?? null, null, 2);
+          } catch (error) {
+            status.textContent = "Completed";
+            console.error("Failed to parse completion payload", error);
+          }
+          runButton.disabled = false;
+          await hydrateEpisode(traceId);
+          closeStream();
+        });
+
+        source.addEventListener("run-error", (evt) => {
+          try {
+            const payload = JSON.parse(evt.data);
+            status.textContent = `Failed: ${payload.message || "Unknown error"}`;
+            finalOutput.textContent = payload.message || "Run failed.";
+          } catch (error) {
+            status.textContent = "Failed";
+            finalOutput.textContent = "Run failed.";
+            console.error("Failed to parse error payload", error);
+          }
+          runButton.disabled = false;
+          closeStream();
+        });
+
+        source.onerror = () => {
+          if (source.readyState === EventSource.CLOSED) {
+            if (runButton.disabled) {
+              status.textContent = "Stream closed";
+              runButton.disabled = false;
+            }
+            closeStream();
+          }
+        };
+      }
 
       async function runChat() {
         const prompt = messageInput.value.trim();
+        closeStream();
         runButton.disabled = true;
-        status.textContent = "Running...";
+        status.textContent = "Starting...";
         finalOutput.textContent = "";
         logOutput.textContent = "";
         traceInfo.textContent = "";
+        logLines = [];
 
         try {
           const response = await fetch("/api/run", {
@@ -126,21 +232,15 @@
 
           const data = await response.json();
           const traceId = data.trace_id;
-          status.textContent = "Completed";
-          traceInfo.textContent = `trace_id: ${traceId}`;
-          finalOutput.textContent = JSON.stringify(data.result, null, 2);
-
-          const episodeResponse = await fetch(`/api/episodes/${traceId}`);
-          if (episodeResponse.ok) {
-            const episodeText = await episodeResponse.text();
-            logOutput.textContent = episodeText.trim();
-          } else {
-            logOutput.textContent = "Episode not available yet.";
+          if (!traceId) {
+            throw new Error("Trace id missing from response");
           }
+          traceInfo.textContent = `trace_id: ${traceId}`;
+          status.textContent = "Waiting for events...";
+          subscribeToEvents(traceId);
         } catch (error) {
           status.textContent = "Failed";
-          finalOutput.textContent = String(error.message || error);
-        } finally {
+          finalOutput.textContent = String(error?.message || error);
           runButton.disabled = false;
         }
       }


### PR DESCRIPTION
## Summary
- stream core events over a server-sent events endpoint and broadcast them to connected clients
- update the UI to subscribe to the live stream, hydrate the final episode transcript, and improve accessibility attributes
- add an in-memory broker and buffer to share events with late subscribers and close streams cleanly

## Testing
- pnpm typecheck *(fails: @types/node missing because registry access is forbidden, pnpm install returns 403)*
- pnpm lint *(fails: ESLint 9 fallback is picked up because dependencies cannot be installed; registry 403 prevents installing pinned eslint 8)*
- pnpm test *(fails: vitest package cannot be resolved without registry access; pnpm install returns 403)*
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68c91db88250832b9f08083399077539