### PR TITLE
Add LogFlow APIs and panel interactions

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  BranchNode,
+  BranchResponse,
+  LogFlowMessage,
+  MainlineResponse,
+} from "../types/logflow";
+
+interface LogFlowPanelProps {
+  traceId?: string;
+}
+
+interface RequestState {
+  loading: boolean;
+  error: string | null;
+}
+
+const initialRequestState: RequestState = { loading: false, error: null };
+
+export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
+  const [messages, setMessages] = useState<LogFlowMessage[]>([]);
+  const [mainlineState, setMainlineState] = useState<RequestState>(initialRequestState);
+  const [selectedMessage, setSelectedMessage] = useState<LogFlowMessage | null>(null);
+  const [branchState, setBranchState] = useState<RequestState>(initialRequestState);
+  const [branch, setBranch] = useState<BranchResponse | null>(null);
+  const latestSelectionRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!traceId) {
+      setMessages([]);
+      setSelectedMessage(null);
+      setBranch(null);
+      setMainlineState(initialRequestState);
+      setBranchState(initialRequestState);
+      latestSelectionRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    setMainlineState({ loading: true, error: null });
+    setSelectedMessage(null);
+    setBranch(null);
+    setBranchState(initialRequestState);
+    latestSelectionRef.current = null;
+
+    const controller = new AbortController();
+
+    fetch(`/api/logflow/mainline?trace_id=${encodeURIComponent(traceId)}`, {
+      signal: controller.signal,
+    })
+      .then(async (resp) => {
+        if (!resp.ok) {
+          const detail = await resp.json().catch(() => ({}));
+          throw new Error(detail?.message ?? `Failed to load mainline (${resp.status})`);
+        }
+        return (await resp.json()) as MainlineResponse;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setMessages(data.messages);
+      })
+      .catch((err: any) => {
+        if (cancelled) return;
+        setMessages([]);
+        setMainlineState({ loading: false, error: err?.message ?? "Failed to load mainline" });
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setMainlineState((prev) => ({ ...prev, loading: false }));
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [traceId]);
+
+  const handleSelect = useCallback(
+    (message: LogFlowMessage) => {
+      if (!traceId) return;
+      setSelectedMessage(message);
+      latestSelectionRef.current = message.id;
+      setBranch(null);
+      setBranchState({ loading: true, error: null });
+
+      const params = new URLSearchParams({ trace_id: traceId });
+      if (message.span_id) {
+        params.set("span_id", message.span_id);
+      } else {
+        params.set("ln", String(message.ln));
+      }
+
+      fetch(`/api/logflow/branch?${params.toString()}`)
+        .then(async (resp) => {
+          if (!resp.ok) {
+            const detail = await resp.json().catch(() => ({}));
+            throw new Error(detail?.message ?? `Failed to load branch (${resp.status})`);
+          }
+          return (await resp.json()) as BranchResponse;
+        })
+        .then((data) => {
+          if (latestSelectionRef.current !== message.id) {
+            return;
+          }
+          setBranch(data);
+          setBranchState({ loading: false, error: null });
+        })
+        .catch((err: any) => {
+          if (latestSelectionRef.current !== message.id) {
+            return;
+          }
+          setBranch(null);
+          setBranchState({ loading: false, error: err?.message ?? "Failed to load branch" });
+        });
+    },
+    [traceId],
+  );
+
+  const selectedBranchNode = useMemo<BranchNode | null>(() => {
+    if (!branch?.tree) return null;
+    return branch.tree;
+  }, [branch]);
+
+  return (
+    <section style={{ border: "1px solid #1f2937", borderRadius: 12, padding: "1rem" }}>
+      <header style={{ marginBottom: "0.75rem" }}>
+        <h2 style={{ margin: 0, fontSize: "1.1rem" }}>LogFlow</h2>
+        {traceId ? (
+          <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
+            trace_id: <code>{traceId}</code>
+          </p>
+        ) : (
+          <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
+            Submit a run to see timeline and branch details.
+          </p>
+        )}
+      </header>
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "flex-start" }}>
+        <div style={{ flex: 1 }}>
+          <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Mainline Messages</h3>
+          {mainlineState.loading ? (
+            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>Loading mainline…</p>
+          ) : mainlineState.error ? (
+            <p style={{ fontSize: "0.9rem", color: "#f87171" }}>{mainlineState.error}</p>
+          ) : messages.length === 0 ? (
+            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>No events recorded yet.</p>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: 320, overflowY: "auto" }}>
+              {messages.map((message) => {
+                const isSelected = selectedMessage?.id === message.id;
+                return (
+                  <li key={message.id} style={{ marginBottom: "0.5rem" }}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(message)}
+                      style={{
+                        width: "100%",
+                        textAlign: "left",
+                        borderRadius: 8,
+                        border: "1px solid",
+                        borderColor: isSelected ? "#38bdf8" : "#1f2937",
+                        background: isSelected ? "rgba(56, 189, 248, 0.12)" : "#0f172a",
+                        padding: "0.5rem 0.75rem",
+                        color: "inherit",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <div style={{ fontWeight: 600, fontSize: "0.95rem" }}>{message.message}</div>
+                      <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                        ln {message.ln}
+                        {message.span_id ? ` · span ${message.span_id}` : ""}
+                        {message.type ? ` · ${message.type}` : ""}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div style={{ flex: 1 }}>
+          <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Branch Detail</h3>
+          {selectedMessage ? (
+            <div style={{ marginBottom: "0.75rem", fontSize: "0.85rem", color: "#94a3b8" }}>
+              <div>
+                Selected message ln {selectedMessage.ln}
+                {selectedMessage.span_id ? ` (span ${selectedMessage.span_id})` : ""}
+              </div>
+              <div>Type: {selectedMessage.type}</div>
+            </div>
+          ) : (
+            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+              Select a message to inspect its branch timeline.
+            </p>
+          )}
+
+          {branchState.loading ? (
+            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>Loading branch…</p>
+          ) : branchState.error ? (
+            <p style={{ fontSize: "0.9rem", color: "#f87171" }}>{branchState.error}</p>
+          ) : branch ? (
+            <div style={{ display: "grid", gap: "0.75rem" }}>
+              <div style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
+                Origin: {branch.origin.span_id ? `span ${branch.origin.span_id}` : "message"}
+                {branch.origin.ln !== undefined ? ` · ln ${branch.origin.ln}` : ""}
+              </div>
+              {branch.messages.length > 0 && (
+                <div>
+                  <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Events</h4>
+                  <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: 200, overflowY: "auto" }}>
+                    {branch.messages.map((msg) => (
+                      <li key={msg.id} style={{ marginBottom: "0.4rem" }}>
+                        <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>{msg.message}</div>
+                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                          ln {msg.ln}
+                          {msg.span_id ? ` · span ${msg.span_id}` : ""}
+                          {msg.type ? ` · ${msg.type}` : ""}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {selectedBranchNode ? (
+                <div>
+                  <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Task Tree</h4>
+                  <div style={{ maxHeight: 220, overflowY: "auto" }}>
+                    {renderBranchNode(selectedBranchNode)}
+                  </div>
+                </div>
+              ) : (
+                <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+                  No task tree available for this selection.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function renderBranchNode(node: BranchNode, depth = 0): JSX.Element {
+  return (
+    <div key={node.span_id} style={{ marginLeft: depth ? depth * 12 : 0 }}>
+      <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>
+        span {node.span_id} · ln {node.first_ln} – {node.last_ln}
+      </div>
+      <ul style={{ listStyle: "none", padding: 0, margin: "0.25rem 0 0.5rem" }}>
+        {node.events.map((evt) => (
+          <li key={evt.id} style={{ marginBottom: "0.25rem" }}>
+            <div style={{ fontSize: "0.85rem" }}>{evt.message}</div>
+            <div style={{ fontSize: "0.7rem", color: "#94a3b8" }}>
+              ln {evt.ln}
+              {evt.type ? ` · ${evt.type}` : ""}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {node.children.map((child) => renderBranchNode(child, depth + 1))}
+    </div>
+  );
+}
+
+export default LogFlowPanel;

--- a/lib/logflow.ts
+++ b/lib/logflow.ts
@@ -1,0 +1,163 @@
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import type { EventEnvelope } from "../runtime/events";
+import { readEpisodeIndex } from "../runtime/episode";
+import type {
+  BranchNode,
+  EpisodeIndexEntry,
+  LogFlowMessage,
+} from "../types/logflow";
+
+const DEFAULT_EPISODE_DIR = join(process.cwd(), "episodes");
+
+async function readJsonlFile<T>(filePath: string): Promise<T[]> {
+  const content = await readFile(filePath, "utf8");
+  if (!content) {
+    return [];
+  }
+  return content
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
+}
+
+export async function readEpisodeEvents(
+  traceId: string,
+  dir: string = DEFAULT_EPISODE_DIR,
+): Promise<EventEnvelope[]> {
+  const filePath = join(dir, `${traceId}.jsonl`);
+  const events = await readJsonlFile<EventEnvelope>(filePath);
+  return events.sort((a, b) => (a.ln ?? 0) - (b.ln ?? 0));
+}
+
+export async function readEpisodeIndexEntries(
+  traceId: string,
+  dir: string = DEFAULT_EPISODE_DIR,
+): Promise<EpisodeIndexEntry[]> {
+  return readEpisodeIndex(traceId, dir);
+}
+
+function summarizeEvent(event: EventEnvelope): string {
+  const data = event.data as any;
+  switch (event.type) {
+    case "agent.plan": {
+      const steps = Array.isArray(data?.steps) ? data.steps.length : 0;
+      const revision = data?.revision ?? "?";
+      return `Plan revision ${revision} with ${steps} step${steps === 1 ? "" : "s"}`;
+    }
+    case "agent.tool":
+      return `Tool ${data?.name ?? "(unknown)"}`;
+    case "agent.final":
+      return "Final output ready";
+    case "agent.ask":
+      return data?.question ? `Ask: ${data.question}` : "Ask";
+    case "agent.score":
+      return `Score ${data?.value ?? "?"} (${data?.passed ? "pass" : "fail"})`;
+    case "agent.progress":
+      return `Progress ${Math.round((data?.pct ?? 0) * 100)}% (${data?.step ?? "step"})`;
+    case "agent.log":
+      return typeof data?.message === "string" ? data.message : "Log";
+    default:
+      return event.type;
+  }
+}
+
+export function toLogFlowMessage(event: EventEnvelope): LogFlowMessage {
+  return {
+    id: event.id,
+    ln: event.ln ?? 0,
+    span_id: event.span_id,
+    parent_span_id: event.parent_span_id,
+    type: event.type,
+    ts: event.ts,
+    level: event.level,
+    message: summarizeEvent(event),
+    data: event.data,
+    byte_offset: event.byte_offset,
+  } satisfies LogFlowMessage;
+}
+
+interface MutableBranchNode {
+  span_id: string;
+  parent_span_id?: string;
+  first_ln: number;
+  last_ln: number;
+  events: LogFlowMessage[];
+  children: MutableBranchNode[];
+}
+
+export function buildBranchTree(
+  messages: LogFlowMessage[],
+  originSpanId: string,
+): BranchNode | null {
+  const nodes = new Map<string, MutableBranchNode>();
+
+  for (const message of messages) {
+    if (!message.span_id) continue;
+    let node = nodes.get(message.span_id);
+    if (!node) {
+      node = {
+        span_id: message.span_id,
+        parent_span_id: message.parent_span_id,
+        first_ln: message.ln,
+        last_ln: message.ln,
+        events: [],
+        children: [],
+      } satisfies MutableBranchNode;
+      nodes.set(message.span_id, node);
+    }
+    node.parent_span_id = message.parent_span_id ?? node.parent_span_id;
+    node.events.push(message);
+    node.first_ln = Math.min(node.first_ln, message.ln);
+    node.last_ln = Math.max(node.last_ln, message.ln);
+  }
+
+  if (!nodes.size || !nodes.has(originSpanId)) {
+    return null;
+  }
+
+  for (const node of nodes.values()) {
+    node.events.sort((a, b) => a.ln - b.ln);
+  }
+
+  for (const node of nodes.values()) {
+    if (!node.parent_span_id) continue;
+    const parent = nodes.get(node.parent_span_id);
+    if (parent && !parent.children.includes(node)) {
+      parent.children.push(node);
+    }
+  }
+
+  for (const node of nodes.values()) {
+    node.children.sort((a, b) => a.first_ln - b.first_ln);
+  }
+
+  const visited = new Set<string>();
+  const toBranch = (node: MutableBranchNode): BranchNode => {
+    if (visited.has(node.span_id)) {
+      return {
+        span_id: node.span_id,
+        parent_span_id: node.parent_span_id,
+        first_ln: node.first_ln,
+        last_ln: node.last_ln,
+        events: node.events,
+        children: [],
+      } satisfies BranchNode;
+    }
+    visited.add(node.span_id);
+    return {
+      span_id: node.span_id,
+      parent_span_id: node.parent_span_id,
+      first_ln: node.first_ln,
+      last_ln: node.last_ln,
+      events: node.events,
+      children: node.children.map(toBranch),
+    } satisfies BranchNode;
+  };
+
+  const root = nodes.get(originSpanId);
+  if (!root) {
+    return null;
+  }
+  return toBranch(root);
+}

--- a/pages/api/logflow/branch.ts
+++ b/pages/api/logflow/branch.ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  buildBranchTree,
+  readEpisodeEvents,
+  readEpisodeIndexEntries,
+  toLogFlowMessage,
+} from "../../../lib/logflow";
+import type { BranchOrigin, BranchResponse, LogFlowMessage } from "../../../types/logflow";
+
+const METHOD = "GET";
+
+function getQueryParam(value: string | string[] | undefined): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && value.length > 0) return value[0];
+  return undefined;
+}
+
+function getRequestParam(req: NextApiRequest, key: string): string | undefined {
+  const value = req.query[key];
+  return getQueryParam(value as string | string[] | undefined);
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  if (req.method !== METHOD) {
+    res.setHeader("Allow", METHOD);
+    res.status(405).json({ error: "method_not_allowed", message: "Only GET is supported" });
+    return;
+  }
+
+  const traceId = getRequestParam(req, "trace_id");
+  if (!traceId) {
+    res
+      .status(400)
+      .json({ error: "invalid_trace_id", message: "trace_id query parameter is required" });
+    return;
+  }
+
+  const spanParam = getRequestParam(req, "span_id");
+  const lnParam = getRequestParam(req, "ln") ?? getRequestParam(req, "origin_ln");
+
+  let originLn: number | undefined;
+  if (lnParam !== undefined) {
+    const parsed = Number.parseInt(lnParam, 10);
+    if (Number.isNaN(parsed)) {
+      res.status(400).json({ error: "invalid_ln", message: "ln must be an integer" });
+      return;
+    }
+    originLn = parsed;
+  }
+
+  try {
+    const [events, indexEntries] = await Promise.all([
+      readEpisodeEvents(traceId),
+      readEpisodeIndexEntries(traceId),
+    ]);
+    const messages = events.map(toLogFlowMessage);
+
+    let originSpanId = spanParam ?? undefined;
+    if (!originSpanId && originLn !== undefined) {
+      const entry = indexEntries.find((item) => item.ln === originLn);
+      if (entry?.span_id) {
+        originSpanId = entry.span_id;
+      }
+    }
+
+    if (originSpanId && originLn === undefined) {
+      const entry = indexEntries.find((item) => item.span_id === originSpanId);
+      if (entry) {
+        originLn = entry.ln;
+      }
+    }
+
+    const origin: BranchOrigin = {};
+    if (originSpanId) origin.span_id = originSpanId;
+    if (originLn !== undefined) origin.ln = originLn;
+
+    let branchMessages: LogFlowMessage[] = [];
+    if (originSpanId) {
+      branchMessages = messages.filter((msg) => msg.span_id === originSpanId);
+    } else if (originLn !== undefined) {
+      const match = messages.find((msg) => msg.ln === originLn);
+      if (match) branchMessages = [match];
+    }
+
+    const tree = originSpanId ? buildBranchTree(messages, originSpanId) : null;
+
+    if (!branchMessages.length && !tree) {
+      res.status(404).json({ error: "branch_not_found", message: "No branch data for selection" });
+      return;
+    }
+
+    const payload: BranchResponse = {
+      trace_id: traceId,
+      origin,
+      messages: branchMessages,
+      tree,
+    };
+    res.status(200).json(payload);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      res
+        .status(404)
+        .json({ error: "episode_not_found", message: `episode ${traceId} not found` });
+      return;
+    }
+    console.error("Failed to read logflow branch", err);
+    res
+      .status(500)
+      .json({ error: "internal_error", message: err?.message ?? "unexpected error" });
+  }
+}

--- a/pages/api/logflow/mainline.ts
+++ b/pages/api/logflow/mainline.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  readEpisodeEvents,
+  readEpisodeIndexEntries,
+  toLogFlowMessage,
+} from "../../../lib/logflow";
+import type { MainlineResponse } from "../../../types/logflow";
+
+const METHOD = "GET";
+
+function getQueryParam(value: string | string[] | undefined): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && value.length > 0) return value[0];
+  return undefined;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  if (req.method !== METHOD) {
+    res.setHeader("Allow", METHOD);
+    res.status(405).json({ error: "method_not_allowed", message: "Only GET is supported" });
+    return;
+  }
+
+  const traceId = getQueryParam(req.query.trace_id);
+  if (!traceId) {
+    res
+      .status(400)
+      .json({ error: "invalid_trace_id", message: "trace_id query parameter is required" });
+    return;
+  }
+
+  try {
+    const [events, indexEntries] = await Promise.all([
+      readEpisodeEvents(traceId),
+      readEpisodeIndexEntries(traceId),
+    ]);
+    const messages = events.map(toLogFlowMessage);
+    const payload: MainlineResponse = {
+      trace_id: traceId,
+      messages,
+      index: indexEntries,
+    };
+    res.status(200).json(payload);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      res
+        .status(404)
+        .json({ error: "episode_not_found", message: `episode ${traceId} not found` });
+      return;
+    }
+    console.error("Failed to read mainline logflow", err);
+    res
+      .status(500)
+      .json({ error: "internal_error", message: err?.message ?? "unexpected error" });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,43 +1,127 @@
-import { NextPage } from "next";
+import { FormEventHandler, useCallback, useState } from "react";
+import type { NextPage } from "next";
+import LogFlowPanel from "../components/LogFlowPanel";
 
 const HomePage: NextPage = () => {
+  const [input, setInput] = useState("");
+  const [isRunning, setIsRunning] = useState(false);
+  const [traceId, setTraceId] = useState<string | undefined>(undefined);
+  const [finalOutput, setFinalOutput] = useState<any>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+
+  const handleRun = useCallback(async () => {
+    if (isRunning) return;
+    const prompt = input.trim();
+    setIsRunning(true);
+    setRunError(null);
+    setTraceId(undefined);
+    setFinalOutput(null);
+    try {
+      const response = await fetch("/api/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: prompt }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        throw new Error(data?.message ?? `Request failed (${response.status})`);
+      }
+      setTraceId(data.trace_id);
+      setFinalOutput(data.result);
+    } catch (err: any) {
+      setRunError(err?.message ?? "Failed to run agent");
+    } finally {
+      setIsRunning(false);
+    }
+  }, [input, isRunning]);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+    (event) => {
+      event.preventDefault();
+      void handleRun();
+    },
+    [handleRun],
+  );
+
   return (
-    <div style={{ padding: "2rem" }}>
-      <h1>Agent OS (AOS)</h1>
-      <p>Welcome to Agent Operating System</p>
-      <div>
-        <h2>Project Features</h2>
-        <ul>
-          <li>最小可信闭环：围绕感知、计划、执行、评审与产出的 RunLoop</li>
-          <li>Episode 事件日志：以追加写 JSONL 记录所有事件</li>
-          <li>可回放与审计工具链：支持离线回放、审计与故障排查</li>
-          <li>工具/MCP 兼容层：统一封装 LLM 与工具调用</li>
-          <li>TypeScript 一体化：前后端、CLI 与脚本共享类型定义</li>
-        </ul>
-      </div>
-      <div>
-        <h2>Available Scripts</h2>
-        <ul>
-          <li>
-            <code>pnpm dev</code> - 启动开发服务器
-          </li>
-          <li>
-            <code>pnpm test</code> - 运行单元测试
-          </li>
-          <li>
-            <code>pnpm lint</code> - 运行代码检查
-          </li>
-          <li>
-            <code>pnpm typecheck</code> - 执行类型检查
-          </li>
-          <li>
-            <code>pnpm smoke</code> - 执行端到端冒烟测试
-          </li>
-          <li>
-            <code>pnpm replay</code> - 重放最近任务轨迹
-          </li>
-        </ul>
-      </div>
+    <div style={{ minHeight: "100vh", background: "#0f172a", color: "#e2e8f0" }}>
+      <header style={{ padding: "1.5rem 2rem", background: "#1e293b", boxShadow: "0 1px 12px rgba(0,0,0,0.4)" }}>
+        <h1 style={{ margin: 0 }}>AgentOS · Chat + LogFlow</h1>
+        <p style={{ margin: "0.25rem 0 0", fontSize: "0.95rem", color: "#94a3b8" }}>
+          Submit a prompt to run the local agent, inspect timeline events, and explore task branches.
+        </p>
+      </header>
+
+      <main style={{ maxWidth: 1100, margin: "0 auto", padding: "2rem", display: "grid", gap: "1.5rem" }}>
+        <section style={{ background: "#1e293b", borderRadius: 12, padding: "1.5rem", boxShadow: "inset 0 0 0 1px rgba(148,163,184,0.15)" }}>
+          <form onSubmit={handleSubmit} style={{ display: "grid", gap: "1rem" }}>
+            <label htmlFor="prompt" style={{ fontWeight: 600 }}>
+              Chat Input
+            </label>
+            <textarea
+              id="prompt"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  void handleRun();
+                }
+              }}
+              placeholder="Ask the agent for a summary or instruction..."
+              style={{
+                width: "100%",
+                minHeight: 140,
+                padding: "1rem",
+                borderRadius: 8,
+                border: "1px solid #334155",
+                background: "#0f172a",
+                color: "inherit",
+                fontSize: "1rem",
+              }}
+            />
+            <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+              <button
+                type="submit"
+                disabled={isRunning}
+                style={{
+                  padding: "0.75rem 1.5rem",
+                  borderRadius: 999,
+                  border: "none",
+                  background: isRunning ? "#475569" : "#38bdf8",
+                  color: "#0f172a",
+                  fontWeight: 600,
+                  cursor: isRunning ? "not-allowed" : "pointer",
+                }}
+              >
+                {isRunning ? "Running…" : "Run"}
+              </button>
+              <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+                {traceId ? `trace_id: ${traceId}` : runError ? runError : isRunning ? "Running agent" : "Idle"}
+              </span>
+            </div>
+          </form>
+
+          <div style={{ marginTop: "1.5rem" }}>
+            <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
+            <pre
+              style={{
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                background: "#0f172a",
+                borderRadius: 8,
+                padding: "1rem",
+                border: "1px solid #1f2937",
+                minHeight: 120,
+              }}
+            >
+              {finalOutput ? JSON.stringify(finalOutput, null, 2) : "No output yet."}
+            </pre>
+          </div>
+        </section>
+
+        <LogFlowPanel traceId={traceId} />
+      </main>
     </div>
   );
 };

--- a/runtime/episode.ts
+++ b/runtime/episode.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from "node:path";
-import { mkdir, readFile, stat, appendFile } from "node:fs/promises";
+import { mkdir, readFile, stat, appendFile, writeFile } from "node:fs/promises";
 import type { EventEnvelope } from "./events";
+import type { EpisodeIndexEntry } from "../types/logflow";
 
 export interface EpisodeLoggerOptions {
   traceId: string;
@@ -9,14 +10,17 @@ export interface EpisodeLoggerOptions {
 
 export class EpisodeLogger {
   private readonly filePath: string;
+  private readonly indexPath: string;
   private ready = false;
   private line = 0;
   private byteOffset = 0;
   private queue: Promise<void> = Promise.resolve();
+  private index: EpisodeIndexEntry[] = [];
 
   constructor(private readonly options: EpisodeLoggerOptions) {
     const baseDir = options.dir ?? join(process.cwd(), "episodes");
     this.filePath = join(baseDir, `${options.traceId}.jsonl`);
+    this.indexPath = join(baseDir, `${options.traceId}.index.jsonl`);
   }
 
   private async ensureReady() {
@@ -25,9 +29,6 @@ export class EpisodeLogger {
     try {
       const fileStat = await stat(this.filePath);
       this.byteOffset = fileStat.size;
-      const content = await readFile(this.filePath, "utf8");
-      const lines = content.split("\n").filter(Boolean);
-      this.line = lines.length;
     } catch (err: any) {
       if (err && err.code !== "ENOENT") {
         throw err;
@@ -35,6 +36,21 @@ export class EpisodeLogger {
       this.byteOffset = 0;
       this.line = 0;
     }
+
+    const existingIndex = await readEpisodeIndex(this.options.traceId, this.options.dir);
+    if (existingIndex.length) {
+      this.index = existingIndex;
+      this.line = existingIndex[existingIndex.length - 1]?.ln ?? this.line;
+    } else if (this.byteOffset > 0) {
+      const rebuilt = await this.rebuildIndexFromLog();
+      this.index = rebuilt;
+      this.line = rebuilt.at(-1)?.ln ?? this.line;
+      if (rebuilt.length) {
+        const serialized = rebuilt.map((entry) => JSON.stringify(entry)).join("\n") + "\n";
+        await writeFile(this.indexPath, serialized, "utf8");
+      }
+    }
+
     this.ready = true;
   }
 
@@ -42,12 +58,24 @@ export class EpisodeLogger {
     this.queue = this.queue.then(async () => {
       await this.ensureReady();
       const enriched = event;
-      enriched.ln = enriched.ln ?? ++this.line;
-      enriched.byte_offset = enriched.byte_offset ?? this.byteOffset;
+      if (typeof enriched.ln === "number") {
+        this.line = Math.max(this.line, enriched.ln);
+      } else {
+        enriched.ln = ++this.line;
+      }
+      const startOffset = enriched.byte_offset ?? this.byteOffset;
+      enriched.byte_offset = startOffset;
       const payload = JSON.stringify(enriched) + "\n";
       const bufferLength = Buffer.byteLength(payload);
       await appendFile(this.filePath, payload, "utf8");
       this.byteOffset += bufferLength;
+      const indexEntry: EpisodeIndexEntry = {
+        ln: enriched.ln,
+        span_id: enriched.span_id,
+        byte_offset: startOffset,
+      };
+      this.index.push(indexEntry);
+      await appendFile(this.indexPath, JSON.stringify(indexEntry) + "\n", "utf8");
     });
 
     return this.queue.then(() => event);
@@ -67,5 +95,63 @@ export class EpisodeLogger {
       }
       throw err;
     }
+  }
+
+  async readIndex(): Promise<EpisodeIndexEntry[]> {
+    await this.ensureReady();
+    return [...this.index];
+  }
+
+  private async rebuildIndexFromLog(): Promise<EpisodeIndexEntry[]> {
+    try {
+      const content = await readFile(this.filePath, "utf8");
+      if (!content) {
+        return [];
+      }
+      const lines = content.split("\n").filter(Boolean);
+      const entries: EpisodeIndexEntry[] = [];
+      let offset = 0;
+      for (const line of lines) {
+        const parsed = JSON.parse(line) as EventEnvelope;
+        const ln = parsed.ln ?? entries.length + 1;
+        const entry: EpisodeIndexEntry = {
+          ln,
+          span_id: parsed.span_id,
+          byte_offset: offset,
+        };
+        entries.push(entry);
+        offset += Buffer.byteLength(`${line}\n`);
+      }
+      this.byteOffset = offset;
+      return entries;
+    } catch (err: any) {
+      if (err && err.code === "ENOENT") {
+        return [];
+      }
+      throw err;
+    }
+  }
+}
+
+export async function readEpisodeIndex(
+  traceId: string,
+  dir?: string,
+): Promise<EpisodeIndexEntry[]> {
+  const baseDir = dir ?? join(process.cwd(), "episodes");
+  const indexPath = join(baseDir, `${traceId}.index.jsonl`);
+  try {
+    const content = await readFile(indexPath, "utf8");
+    if (!content) {
+      return [];
+    }
+    return content
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as EpisodeIndexEntry);
+  } catch (err: any) {
+    if (err && err.code === "ENOENT") {
+      return [];
+    }
+    throw err;
   }
 }

--- a/types/logflow.ts
+++ b/types/logflow.ts
@@ -1,0 +1,45 @@
+export interface EpisodeIndexEntry {
+  ln: number;
+  span_id?: string;
+  byte_offset: number;
+}
+
+export interface LogFlowMessage {
+  id: string;
+  ln: number;
+  span_id?: string;
+  parent_span_id?: string;
+  type: string;
+  ts: string;
+  level?: "debug" | "info" | "warn" | "error";
+  message: string;
+  data: unknown;
+  byte_offset?: number;
+}
+
+export interface BranchNode {
+  span_id: string;
+  parent_span_id?: string;
+  first_ln: number;
+  last_ln: number;
+  events: LogFlowMessage[];
+  children: BranchNode[];
+}
+
+export interface BranchOrigin {
+  span_id?: string;
+  ln?: number;
+}
+
+export interface MainlineResponse {
+  trace_id: string;
+  messages: LogFlowMessage[];
+  index: EpisodeIndexEntry[];
+}
+
+export interface BranchResponse {
+  trace_id: string;
+  origin: BranchOrigin;
+  messages: LogFlowMessage[];
+  tree: BranchNode | null;
+}


### PR DESCRIPTION
## Summary
- extend the episode logger with an append-only index to capture ln/span offsets for quick lookups
- expose `/api/logflow/mainline` and `/api/logflow/branch` routes that hydrate messages and task trees from the episode logs
- build a LogFlow panel on the home page that loads the mainline timeline and fetches branch details when a message is selected

## Testing
- pnpm typecheck *(fails: missing @types/node because dependencies cannot be installed in the sandbox)*
- pnpm lint *(fails: repository lacks ESLint flat-config migration and cannot resolve eslint.config.js yet)*
- pnpm test *(fails: vitest package unavailable without dependency install)*
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68c91db94904832bb50154629d2746f0