### PR TITLE
Add explicit parameter types for log flow utilities

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -210,7 +210,7 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
                 <div>
                   <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Events</h4>
                   <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: 200, overflowY: "auto" }}>
-                    {branch.messages.map((msg) => (
+                    {branch.messages.map((msg: LogFlowMessage) => (
                       <li key={msg.id} style={{ marginBottom: "0.4rem" }}>
                         <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>{msg.message}</div>
                         <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
@@ -250,7 +250,7 @@ function renderBranchNode(node: BranchNode, depth = 0): JSX.Element {
         span {node.span_id} · ln {node.first_ln} – {node.last_ln}
       </div>
       <ul style={{ listStyle: "none", padding: 0, margin: "0.25rem 0 0.5rem" }}>
-        {node.events.map((evt) => (
+        {node.events.map((evt: LogFlowMessage) => (
           <li key={evt.id} style={{ marginBottom: "0.25rem" }}>
             <div style={{ fontSize: "0.85rem" }}>{evt.message}</div>
             <div style={{ fontSize: "0.7rem", color: "#94a3b8" }}>
@@ -260,7 +260,7 @@ function renderBranchNode(node: BranchNode, depth = 0): JSX.Element {
           </li>
         ))}
       </ul>
-      {node.children.map((child) => renderBranchNode(child, depth + 1))}
+      {node.children.map((child: BranchNode) => renderBranchNode(child, depth + 1))}
     </div>
   );
 }

--- a/pages/api/logflow/branch.ts
+++ b/pages/api/logflow/branch.ts
@@ -5,7 +5,12 @@ import {
   readEpisodeIndexEntries,
   toLogFlowMessage,
 } from "../../../lib/logflow";
-import type { BranchOrigin, BranchResponse, LogFlowMessage } from "../../../types/logflow";
+import type {
+  BranchOrigin,
+  BranchResponse,
+  EpisodeIndexEntry,
+  LogFlowMessage,
+} from "../../../types/logflow";
 
 const METHOD = "GET";
 
@@ -60,14 +65,14 @@ export default async function handler(
 
     let originSpanId = spanParam ?? undefined;
     if (!originSpanId && originLn !== undefined) {
-      const entry = indexEntries.find((item) => item.ln === originLn);
+      const entry = indexEntries.find((item: EpisodeIndexEntry) => item.ln === originLn);
       if (entry?.span_id) {
         originSpanId = entry.span_id;
       }
     }
 
     if (originSpanId && originLn === undefined) {
-      const entry = indexEntries.find((item) => item.span_id === originSpanId);
+      const entry = indexEntries.find((item: EpisodeIndexEntry) => item.span_id === originSpanId);
       if (entry) {
         originLn = entry.ln;
       }
@@ -79,9 +84,9 @@ export default async function handler(
 
     let branchMessages: LogFlowMessage[] = [];
     if (originSpanId) {
-      branchMessages = messages.filter((msg) => msg.span_id === originSpanId);
+      branchMessages = messages.filter((msg: LogFlowMessage) => msg.span_id === originSpanId);
     } else if (originLn !== undefined) {
-      const match = messages.find((msg) => msg.ln === originLn);
+      const match = messages.find((msg: LogFlowMessage) => msg.ln === originLn);
       if (match) branchMessages = [match];
     }
 

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -64,11 +64,13 @@ export default async function handler(
   const kernel = createChatKernel({ message, traceId, toolInvoker });
 
   const events: EventEnvelope<CoreEvent>[] = [];
-  bus.subscribe((event) => {
+  bus.subscribe((event: EventEnvelope<CoreEvent>) => {
     events.push(event);
-    return logger.append(event).catch((error) => {
-      console.error("failed to append episode event", error);
-    });
+    return logger
+      .append(event)
+      .catch((error: unknown) => {
+        console.error("failed to append episode event", error);
+      });
   });
 
   try {
@@ -80,7 +82,7 @@ export default async function handler(
     res.status(200).json({
       trace_id: traceId,
       result: result.final,
-      events: events.map((evt) => ({
+      events: events.map((evt: EventEnvelope<CoreEvent>) => ({
         ts: evt.ts,
         type: evt.type,
         data: evt.data,


### PR DESCRIPTION
## Summary
- add explicit type annotations to LogFlowPanel callbacks that iterate branch data
- type logflow branch API filters/finders against episode index and message structures
- annotate run API event handlers to provide explicit event and error types

## Testing
- pnpm typecheck *(fails: NodeNext module resolution requires explicit .js extensions in existing imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c92a40a960832b8e97c64ab863cb03