### PR TITLE
Add event data viewer to LogFlow panel

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -23,7 +23,10 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   const [selectedMessage, setSelectedMessage] = useState<LogFlowMessage | null>(null);
   const [branchState, setBranchState] = useState<RequestState>(initialRequestState);
   const [branch, setBranch] = useState<BranchResponse | null>(null);
+  const [isDataExpanded, setIsDataExpanded] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "error">("idle");
   const latestSelectionRef = useRef<string | null>(null);
+  const copyResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!traceId) {
@@ -121,6 +124,107 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
     return branch.tree;
   }, [branch]);
 
+  const formattedSelectedData = useMemo(() => {
+    if (!selectedMessage) return null;
+    const { data } = selectedMessage;
+    if (data === undefined) {
+      return null;
+    }
+
+    const safeStringify = (value: unknown): string => {
+      const seen = new WeakSet<object>();
+      return JSON.stringify(
+        value,
+        (_key, val) => {
+          if (typeof val === "bigint") {
+            return val.toString();
+          }
+          if (typeof val === "object" && val !== null) {
+            if (seen.has(val)) {
+              return "[Circular]";
+            }
+            seen.add(val);
+          }
+          return val;
+        },
+        2,
+      );
+    };
+
+    try {
+      if (typeof data === "string") {
+        const trimmed = data.trim();
+        if (!trimmed) {
+          return '""';
+        }
+        try {
+          return safeStringify(JSON.parse(trimmed));
+        } catch {
+          return safeStringify(data);
+        }
+      }
+      return safeStringify(data);
+    } catch {
+      if (typeof data === "string") {
+        return data;
+      }
+      return String(data);
+    }
+  }, [selectedMessage]);
+
+  useEffect(() => {
+    if (copyResetTimeoutRef.current) {
+      clearTimeout(copyResetTimeoutRef.current);
+      copyResetTimeoutRef.current = null;
+    }
+    setCopyStatus("idle");
+    setIsDataExpanded(Boolean(formattedSelectedData));
+  }, [formattedSelectedData]);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeoutRef.current) {
+        clearTimeout(copyResetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const toggleDataExpanded = useCallback(() => {
+    setIsDataExpanded((prev) => !prev);
+  }, []);
+
+  const handleCopyData = useCallback(() => {
+    if (!formattedSelectedData) {
+      return;
+    }
+    const scheduleReset = () => {
+      if (copyResetTimeoutRef.current) {
+        clearTimeout(copyResetTimeoutRef.current);
+      }
+      copyResetTimeoutRef.current = setTimeout(() => {
+        setCopyStatus("idle");
+        copyResetTimeoutRef.current = null;
+      }, 1500);
+    };
+
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      setCopyStatus("error");
+      scheduleReset();
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(formattedSelectedData)
+      .then(() => {
+        setCopyStatus("copied");
+        scheduleReset();
+      })
+      .catch(() => {
+        setCopyStatus("error");
+        scheduleReset();
+      });
+  }, [formattedSelectedData]);
+
   return (
     <section style={{ border: "1px solid #1f2937", borderRadius: 12, padding: "1rem" }}>
       <header style={{ marginBottom: "0.75rem" }}>
@@ -183,12 +287,113 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
         <div style={{ flex: 1 }}>
           <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Branch Detail</h3>
           {selectedMessage ? (
-            <div style={{ marginBottom: "0.75rem", fontSize: "0.85rem", color: "#94a3b8" }}>
-              <div>
-                Selected message ln {selectedMessage.ln}
-                {selectedMessage.span_id ? ` (span ${selectedMessage.span_id})` : ""}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem",
+                marginBottom: "0.75rem",
+              }}
+            >
+              <div style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
+                <div>
+                  Selected message ln {selectedMessage.ln}
+                  {selectedMessage.span_id ? ` (span ${selectedMessage.span_id})` : ""}
+                </div>
+                <div>Type: {selectedMessage.type}</div>
               </div>
-              <div>Type: {selectedMessage.type}</div>
+              {formattedSelectedData ? (
+                <div
+                  style={{
+                    border: "1px solid #1f2937",
+                    borderRadius: 8,
+                    background: "#0f172a",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: "0.5rem",
+                      padding: "0.5rem 0.75rem",
+                      borderBottom: isDataExpanded ? "1px solid #1f2937" : undefined,
+                    }}
+                  >
+                    <span style={{ fontSize: "0.85rem", fontWeight: 600 }}>Event Data</span>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.5rem",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      {copyStatus === "copied" ? (
+                        <span style={{ fontSize: "0.75rem", color: "#34d399" }}>Copied!</span>
+                      ) : copyStatus === "error" ? (
+                        <span style={{ fontSize: "0.75rem", color: "#f87171" }}>Copy failed</span>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={toggleDataExpanded}
+                        style={{
+                          borderRadius: 6,
+                          border: "1px solid",
+                          borderColor: isDataExpanded ? "#38bdf8" : "#1f2937",
+                          background: isDataExpanded ? "rgba(56, 189, 248, 0.12)" : "#1f2937",
+                          color: "#e2e8f0",
+                          padding: "0.35rem 0.6rem",
+                          fontSize: "0.75rem",
+                          cursor: "pointer",
+                        }}
+                      >
+                        {isDataExpanded ? "Collapse" : "Expand"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleCopyData}
+                        disabled={!formattedSelectedData}
+                        style={{
+                          borderRadius: 6,
+                          border: "1px solid #1f2937",
+                          background: "#1f2937",
+                          color: "#e2e8f0",
+                          padding: "0.35rem 0.6rem",
+                          fontSize: "0.75rem",
+                          cursor: formattedSelectedData ? "pointer" : "not-allowed",
+                          opacity: formattedSelectedData ? 1 : 0.6,
+                        }}
+                      >
+                        Copy JSON
+                      </button>
+                    </div>
+                  </div>
+                  {isDataExpanded ? (
+                    <pre
+                      style={{
+                        margin: 0,
+                        padding: "0.75rem",
+                        fontSize: "0.75rem",
+                        lineHeight: 1.5,
+                        maxHeight: 240,
+                        overflow: "auto",
+                        color: "#e2e8f0",
+                        fontFamily:
+                          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                        whiteSpace: "pre",
+                      }}
+                    >
+                      {formattedSelectedData}
+                    </pre>
+                  ) : null}
+                </div>
+              ) : (
+                <p style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
+                  Selected event has no data payload.
+                </p>
+              )}
             </div>
           ) : (
             <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>

--- a/types/logflow.ts
+++ b/types/logflow.ts
@@ -4,6 +4,15 @@ export interface EpisodeIndexEntry {
   byte_offset: number;
 }
 
+export type LogFlowMessageData =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
 export interface LogFlowMessage {
   id: string;
   ln: number;
@@ -13,7 +22,7 @@ export interface LogFlowMessage {
   ts: string;
   level?: "debug" | "info" | "warn" | "error";
   message: string;
-  data: unknown;
+  data: LogFlowMessageData;
   byte_offset?: number;
 }
 


### PR DESCRIPTION
## Summary
- render the selected LogFlow event's payload as formatted JSON in the branch detail panel
- add expand/collapse and copy-to-clipboard controls for inspecting event data
- widen LogFlow message typings to cover the displayed payload values

## Testing
- pnpm typecheck *(fails: existing repository imports lack .js extensions under node16 module resolution)*
- pnpm lint *(fails: existing @next/next/no-sync-scripts error in pages/_document.tsx)*
- pnpm test
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68c9293fac64832bbedf0d7c531208fe