### PR TITLE
Add tabbed layout for chat and log panels

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -122,8 +122,8 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   }, [branch]);
 
   return (
-    <section style={{ border: "1px solid #1f2937", borderRadius: 12, padding: "1rem" }}>
-      <header style={{ marginBottom: "0.75rem" }}>
+    <section style={{ display: "grid", gap: "1rem" }}>
+      <header>
         <h2 style={{ margin: 0, fontSize: "1.1rem" }}>LogFlow</h2>
         {traceId ? (
           <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
@@ -136,7 +136,17 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
         )}
       </header>
 
-      <div style={{ display: "flex", gap: "1rem", alignItems: "flex-start" }}>
+      <div
+        style={{
+          display: "flex",
+          gap: "1rem",
+          alignItems: "flex-start",
+          background: "#0f172a",
+          border: "1px solid #1f2937",
+          borderRadius: 12,
+          padding: "1rem",
+        }}
+      >
         <div style={{ flex: 1 }}>
           <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Mainline Messages</h3>
           {mainlineState.loading ? (
@@ -146,7 +156,15 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
           ) : messages.length === 0 ? (
             <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>No events recorded yet.</p>
           ) : (
-            <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: 320, overflowY: "auto" }}>
+            <ul
+              style={{
+                listStyle: "none",
+                padding: 0,
+                margin: 0,
+                maxHeight: 320,
+                overflowY: "auto",
+              }}
+            >
               {messages.map((message) => {
                 const isSelected = selectedMessage?.id === message.id;
                 return (
@@ -209,7 +227,15 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
               {branch.messages.length > 0 && (
                 <div>
                   <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Events</h4>
-                  <ul style={{ listStyle: "none", padding: 0, margin: 0, maxHeight: 200, overflowY: "auto" }}>
+                  <ul
+                    style={{
+                      listStyle: "none",
+                      padding: 0,
+                      margin: 0,
+                      maxHeight: 200,
+                      overflowY: "auto",
+                    }}
+                  >
                     {branch.messages.map((msg) => (
                       <li key={msg.id} style={{ marginBottom: "0.4rem" }}>
                         <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>{msg.message}</div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,6 +8,7 @@ const HomePage: NextPage = () => {
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
   const [finalOutput, setFinalOutput] = useState<any>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"chat" | "log">("chat");
 
   const handleRun = useCallback(async () => {
     if (isRunning) return;
@@ -43,84 +44,168 @@ const HomePage: NextPage = () => {
     [handleRun],
   );
 
+  const tabs: { id: "chat" | "log"; label: string }[] = [
+    { id: "chat", label: "Chat" },
+    { id: "log", label: "Log Flow" },
+  ];
+
+  const panelStyle = {
+    background: "#1e293b",
+    borderRadius: 12,
+    padding: "1.5rem",
+    boxShadow: "inset 0 0 0 1px rgba(148,163,184,0.15)",
+  } as const;
+
   return (
-    <div style={{ minHeight: "100vh", background: "#0f172a", color: "#e2e8f0" }}>
-      <header style={{ padding: "1.5rem 2rem", background: "#1e293b", boxShadow: "0 1px 12px rgba(0,0,0,0.4)" }}>
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#0f172a",
+        color: "#e2e8f0",
+      }}
+    >
+      <header
+        style={{
+          padding: "1.5rem 2rem",
+          background: "#1e293b",
+          boxShadow: "0 1px 12px rgba(0,0,0,0.4)",
+        }}
+      >
         <h1 style={{ margin: 0 }}>AgentOS · Chat + LogFlow</h1>
         <p style={{ margin: "0.25rem 0 0", fontSize: "0.95rem", color: "#94a3b8" }}>
           Submit a prompt to run the local agent, inspect timeline events, and explore task branches.
         </p>
       </header>
 
-      <main style={{ maxWidth: 1100, margin: "0 auto", padding: "2rem", display: "grid", gap: "1.5rem" }}>
-        <section style={{ background: "#1e293b", borderRadius: 12, padding: "1.5rem", boxShadow: "inset 0 0 0 1px rgba(148,163,184,0.15)" }}>
-          <form onSubmit={handleSubmit} style={{ display: "grid", gap: "1rem" }}>
-            <label htmlFor="prompt" style={{ fontWeight: 600 }}>
-              Chat Input
-            </label>
-            <textarea
-              id="prompt"
-              value={input}
-              onChange={(event) => setInput(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                  event.preventDefault();
-                  void handleRun();
-                }
-              }}
-              placeholder="Ask the agent for a summary or instruction..."
-              style={{
-                width: "100%",
-                minHeight: 140,
-                padding: "1rem",
-                borderRadius: 8,
-                border: "1px solid #334155",
-                background: "#0f172a",
-                color: "inherit",
-                fontSize: "1rem",
-              }}
-            />
-            <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <main
+        style={{
+          maxWidth: 1100,
+          margin: "0 auto",
+          padding: "2rem",
+          display: "grid",
+          gap: "1.5rem",
+        }}
+      >
+        <nav
+          aria-label="Agent panels"
+          role="tablist"
+          style={{
+            display: "flex",
+            gap: "0.75rem",
+            background: "rgba(15, 23, 42, 0.6)",
+            borderRadius: 999,
+            padding: "0.4rem",
+            border: "1px solid #334155",
+          }}
+        >
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
               <button
-                type="submit"
-                disabled={isRunning}
+                key={tab.id}
+                id={`${tab.id}-tab`}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`${tab.id}-panel`}
+                onClick={() => setActiveTab(tab.id)}
                 style={{
-                  padding: "0.75rem 1.5rem",
+                  flex: 1,
+                  padding: "0.6rem 1.25rem",
                   borderRadius: 999,
                   border: "none",
-                  background: isRunning ? "#475569" : "#38bdf8",
-                  color: "#0f172a",
+                  background: isActive ? "#38bdf8" : "transparent",
+                  color: isActive ? "#0f172a" : "#cbd5f5",
                   fontWeight: 600,
-                  cursor: isRunning ? "not-allowed" : "pointer",
+                  cursor: "pointer",
+                  transition: "background 0.2s ease, color 0.2s ease",
+                  boxShadow: isActive ? "0 1px 6px rgba(56,189,248,0.35)" : "none",
                 }}
               >
-                {isRunning ? "Running…" : "Run"}
+                {tab.label}
               </button>
-              <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
-                {traceId ? `trace_id: ${traceId}` : runError ? runError : isRunning ? "Running agent" : "Idle"}
-              </span>
+            );
+          })}
+        </nav>
+
+        {activeTab === "chat" ? (
+          <section id="chat-panel" role="tabpanel" aria-labelledby="chat-tab" style={panelStyle}>
+            <form onSubmit={handleSubmit} style={{ display: "grid", gap: "1rem" }}>
+              <label htmlFor="prompt" style={{ fontWeight: 600 }}>
+                Chat Input
+              </label>
+              <textarea
+                id="prompt"
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                    event.preventDefault();
+                    void handleRun();
+                  }
+                }}
+                placeholder="Ask the agent for a summary or instruction..."
+                style={{
+                  width: "100%",
+                  minHeight: 140,
+                  padding: "1rem",
+                  borderRadius: 8,
+                  border: "1px solid #334155",
+                  background: "#0f172a",
+                  color: "inherit",
+                  fontSize: "1rem",
+                }}
+              />
+              <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+                <button
+                  type="submit"
+                  disabled={isRunning}
+                  style={{
+                    padding: "0.75rem 1.5rem",
+                    borderRadius: 999,
+                    border: "none",
+                    background: isRunning ? "#475569" : "#38bdf8",
+                    color: "#0f172a",
+                    fontWeight: 600,
+                    cursor: isRunning ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {isRunning ? "Running…" : "Run"}
+                </button>
+                <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+                  {traceId
+                    ? `trace_id: ${traceId}`
+                    : runError
+                      ? runError
+                      : isRunning
+                        ? "Running agent"
+                        : "Idle"}
+                </span>
+              </div>
+            </form>
+
+            <div style={{ marginTop: "1.5rem" }}>
+              <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
+              <pre
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  background: "#0f172a",
+                  borderRadius: 8,
+                  padding: "1rem",
+                  border: "1px solid #1f2937",
+                  minHeight: 120,
+                }}
+              >
+                {finalOutput ? JSON.stringify(finalOutput, null, 2) : "No output yet."}
+              </pre>
             </div>
-          </form>
-
-          <div style={{ marginTop: "1.5rem" }}>
-            <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
-            <pre
-              style={{
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                background: "#0f172a",
-                borderRadius: 8,
-                padding: "1rem",
-                border: "1px solid #1f2937",
-                minHeight: 120,
-              }}
-            >
-              {finalOutput ? JSON.stringify(finalOutput, null, 2) : "No output yet."}
-            </pre>
-          </div>
-        </section>
-
-        <LogFlowPanel traceId={traceId} />
+          </section>
+        ) : (
+          <section id="log-panel" role="tabpanel" aria-labelledby="log-tab" style={panelStyle}>
+            <LogFlowPanel traceId={traceId} />
+          </section>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add tab navigation on the home page to switch between chat and log flow panels with matching styling
- wrap LogFlowPanel content with updated styling so it fits inside the new tabbed card layout

## Testing
- pnpm typecheck *(fails: repository requires explicit .js extensions under node16 resolution across many existing files)*
- pnpm lint *(fails: repository contains numerous pre-existing prettier and Next.js lint issues outside the modified files)*
- pnpm test
- pnpm build *(fails: same module resolution errors as pnpm typecheck)*
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68c9293f2484832b91abba873740d0c2