### PR TITLE
Enable conversational history in chat UI

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -220,14 +220,18 @@ interface ChatKernelOptions {
   message: string;
   traceId: string;
   toolInvoker: ToolInvoker;
+  history?: ChatMessage[];
 }
 
 class ChatKernel implements AgentKernel {
   private perceived = false;
   private planCount = 0;
   private actions: ActionOutcome[] = [];
+  private readonly history: ChatMessage[];
 
-  constructor(private readonly options: ChatKernelOptions) {}
+  constructor(private readonly options: ChatKernelOptions) {
+    this.history = Array.isArray(options.history) ? [...options.history] : [];
+  }
 
   async perceive(): Promise<void> {
     this.perceived = true;
@@ -238,6 +242,13 @@ class ChatKernel implements AgentKernel {
     if (!this.perceived) {
       throw new Error("perceive must be called before plan");
     }
+    const combinedHistory = [
+      ...this.history,
+      ...(this.options.message
+        ? [{ role: "user", content: this.options.message } satisfies ChatMessage]
+        : []),
+    ];
+
     return {
       revision: this.planCount,
       reason: this.planCount === 1 ? "initial" : "retry",
@@ -245,7 +256,7 @@ class ChatKernel implements AgentKernel {
         {
           id: `${this.options.traceId}-step-${this.planCount}`,
           op: "llm.chat",
-          args: { prompt: this.options.message },
+          args: { messages: combinedHistory },
         },
       ],
     } satisfies Plan;

--- a/cli.ts
+++ b/cli.ts
@@ -11,7 +11,7 @@ async function runOnce(message: string) {
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId });
   const toolInvoker = createDefaultToolInvoker();
-  const kernel = createChatKernel({ message, traceId, toolInvoker });
+  const kernel = createChatKernel({ message, traceId, toolInvoker, history: [] });
 
   bus.subscribe((event: any) => {
     logEvent(event.data);

--- a/components/ChatMessageList.tsx
+++ b/components/ChatMessageList.tsx
@@ -1,0 +1,74 @@
+import type { FC } from "react";
+
+interface ChatMessageListProps {
+  messages: Array<{ role: string; content: string }>;
+  isRunning?: boolean;
+}
+
+const bubbleStyles: Record<
+  string,
+  { alignSelf: "flex-start" | "flex-end" | "center"; background: string }
+> = {
+  user: { alignSelf: "flex-end", background: "#38bdf8" },
+  assistant: { alignSelf: "flex-start", background: "#334155" },
+  system: { alignSelf: "center", background: "#475569" },
+};
+
+const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false }) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.75rem",
+        maxHeight: 360,
+        overflowY: "auto",
+        padding: "1rem",
+        borderRadius: 8,
+        border: "1px solid #1f2937",
+        background: "#0f172a",
+      }}
+    >
+      {messages.length === 0 ? (
+        <p style={{ margin: 0, color: "#94a3b8" }}>No messages yet.</p>
+      ) : (
+        messages.map((message, index) => {
+          const style = bubbleStyles[message.role] ?? bubbleStyles.assistant;
+          return (
+            <div
+              key={`chat-message-${index}`}
+              data-role={message.role}
+              style={{
+                alignSelf: style.alignSelf,
+                background: style.background,
+                color: message.role === "user" ? "#0f172a" : "#e2e8f0",
+                borderRadius: 12,
+                padding: "0.75rem 1rem",
+                maxWidth: "80%",
+                boxShadow: "0 4px 12px rgba(15,23,42,0.45)",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {message.content}
+            </div>
+          );
+        })
+      )}
+      {isRunning ? (
+        <div
+          data-role="status"
+          style={{
+            alignSelf: "flex-start",
+            color: "#94a3b8",
+            fontStyle: "italic",
+          }}
+        >
+          Generating response…
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ChatMessageList;

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -15,6 +15,8 @@ interface RunResponse {
 
 const episodesDir = join(process.cwd(), "episodes");
 
+type RequestMessage = { role: string; content: string };
+
 function parseRequestBody(req: NextApiRequest): Record<string, unknown> {
   const { body } = req;
   if (body == null || body === "") {
@@ -34,6 +36,20 @@ function parseRequestBody(req: NextApiRequest): Record<string, unknown> {
   }
 
   return {};
+}
+
+function normaliseHistory(raw: unknown): RequestMessage[] {
+  if (!Array.isArray(raw)) return [];
+  const history: RequestMessage[] = [];
+  for (const entry of raw) {
+    if (entry && typeof entry === "object" && typeof (entry as any).role === "string") {
+      const content = (entry as any).content;
+      if (typeof content === "string") {
+        history.push({ role: (entry as any).role, content });
+      }
+    }
+  }
+  return history;
 }
 
 export default async function handler(
@@ -56,12 +72,13 @@ export default async function handler(
 
   const messageRaw = payload.message ?? payload.input ?? "";
   const message = typeof messageRaw === "string" ? messageRaw : "";
+  const history = normaliseHistory(payload.messages);
   const traceId = randomUUID();
 
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId, dir: episodesDir });
   const toolInvoker = createDefaultToolInvoker();
-  const kernel = createChatKernel({ message, traceId, toolInvoker });
+  const kernel = createChatKernel({ message, traceId, toolInvoker, history });
 
   const events: EventEnvelope<CoreEvent>[] = [];
   bus.subscribe((event: EventEnvelope<CoreEvent>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,40 +1,64 @@
 import { FormEventHandler, useCallback, useMemo, useState } from "react";
 import type { NextPage } from "next";
+import ChatMessageList from "../components/ChatMessageList";
 import LogFlowPanel from "../components/LogFlowPanel";
+
+export type ChatMessage = {
+  role: "user" | "assistant" | "system";
+  content: string;
+};
 
 const HomePage: NextPage = () => {
   const [input, setInput] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
-  const [finalOutput, setFinalOutput] = useState<any>(null);
+  const [latestResponse, setLatestResponse] = useState<any>(null);
+  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
   const [runError, setRunError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
 
   const handleRun = useCallback(async () => {
     if (isRunning) return;
     const prompt = input.trim();
+    if (!prompt) return;
+
+    const previousHistory = chatHistory;
+    const userMessage: ChatMessage = { role: "user", content: prompt };
+    const nextHistory = [...previousHistory, userMessage];
+
+    setChatHistory(nextHistory);
     setIsRunning(true);
     setRunError(null);
     setTraceId(undefined);
-    setFinalOutput(null);
+    setLatestResponse(null);
     try {
       const response = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: prompt }),
+        body: JSON.stringify({ message: prompt, messages: previousHistory }),
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data) {
         throw new Error(data?.message ?? `Request failed (${response.status})`);
       }
       setTraceId(data.trace_id);
-      setFinalOutput(data.result);
+      setLatestResponse(data.result);
+      const assistantMessage: ChatMessage = {
+        role: "assistant",
+        content: data.result?.text ?? JSON.stringify(data.result),
+      };
+      setChatHistory((history) => [...history, assistantMessage]);
     } catch (err: any) {
       setRunError(err?.message ?? "Failed to run agent");
+      const errorMessage: ChatMessage = {
+        role: "system",
+        content: `Error: ${err?.message ?? "Failed to run agent"}`,
+      };
+      setChatHistory((history) => [...history, errorMessage]);
     } finally {
       setIsRunning(false);
     }
-  }, [input, isRunning]);
+  }, [input, isRunning, chatHistory]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -124,6 +148,10 @@ const HomePage: NextPage = () => {
               gap: "1.5rem",
             }}
           >
+            <div>
+              <h3 style={{ margin: "0 0 0.75rem" }}>Conversation</h3>
+              <ChatMessageList messages={chatHistory} isRunning={isRunning} />
+            </div>
             <form onSubmit={handleSubmit} style={{ display: "grid", gap: "1rem" }}>
               <label htmlFor="prompt" style={{ fontWeight: 600 }}>
                 Chat Input
@@ -177,23 +205,25 @@ const HomePage: NextPage = () => {
                 </span>
               </div>
             </form>
-
-            <div>
-              <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
+            <details
+              style={{
+                background: "#0f172a",
+                borderRadius: 8,
+                border: "1px solid #1f2937",
+                padding: "1rem",
+              }}
+            >
+              <summary style={{ cursor: "pointer", fontWeight: 600 }}>Latest raw response</summary>
               <pre
                 style={{
                   whiteSpace: "pre-wrap",
                   wordBreak: "break-word",
-                  background: "#0f172a",
-                  borderRadius: 8,
-                  padding: "1rem",
-                  border: "1px solid #1f2937",
-                  minHeight: 120,
+                  marginTop: "0.75rem",
                 }}
               >
-                {finalOutput ? JSON.stringify(finalOutput, null, 2) : "No output yet."}
+                {latestResponse ? JSON.stringify(latestResponse, null, 2) : "No response yet."}
               </pre>
-            </div>
+            </details>
           </section>
         ) : (
           <section

--- a/scripts/ts-loader.mjs
+++ b/scripts/ts-loader.mjs
@@ -11,6 +11,7 @@ const COMPILER_OPTIONS = {
   esModuleInterop: true,
   skipLibCheck: true,
   sourceMap: false,
+  jsx: ts.JsxEmit.ReactJSX,
 };
 
 async function fileExists(url) {

--- a/tests/chatKernel.test.ts
+++ b/tests/chatKernel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createChatKernel } from "../adapters/core";
+import type { ToolInvoker } from "../core/agent";
+
+describe("createChatKernel", () => {
+  it("includes history messages when planning and acting", async () => {
+    const invocations: any[] = [];
+    const toolInvoker: ToolInvoker = async (call) => {
+      invocations.push(call);
+      return { ok: true, data: { content: "ack" } };
+    };
+
+    const history = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ];
+
+    const kernel = createChatKernel({
+      message: "what's next?",
+      traceId: "trace-test",
+      toolInvoker,
+      history,
+    });
+
+    await kernel.perceive({ traceId: "trace-test" });
+    const plan = await kernel.plan();
+    expect(Boolean(plan)).toBe(true);
+
+    const nonNullPlan = plan!;
+    expect(nonNullPlan.steps).toHaveLength(1);
+
+    const step = nonNullPlan.steps[0];
+    expect(step.args).toEqual({
+      messages: [...history, { role: "user", content: "what's next?" }],
+    });
+
+    const outcome = await kernel.act(step);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({
+      name: "llm.chat",
+      args: step.args,
+    });
+    expect(outcome.result.ok).toBe(true);
+  });
+});

--- a/tests/chatMessageList.test.tsx
+++ b/tests/chatMessageList.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import ChatMessageList from "../components/ChatMessageList";
+
+describe("ChatMessageList", () => {
+  it("renders multi-turn conversation bubbles with status", () => {
+    const html = renderToStaticMarkup(
+      <ChatMessageList
+        messages={[
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi, how can I help?" },
+          { role: "user", content: "Tell me a joke." },
+        ]}
+        isRunning
+      />,
+    );
+
+    expect(html.includes('data-role="user"')).toBe(true);
+    expect(html.includes('data-role="assistant"')).toBe(true);
+    expect(html.includes("Hello")).toBe(true);
+    expect(html.includes("Hi, how can I help?")).toBe(true);
+    expect(html.includes("Tell me a joke.")).toBe(true);
+    expect(html.includes('data-role="status"')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- manage chat history in the chat tab, show styled bubbles, and keep a raw response drawer
- forward message history through the /api/run handler into the chat kernel so llm.chat receives context
- add regression tests for chat history planning/rendering and support JSX in the test loader

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68ca40603124832bb58705fc4768a685