### PR TITLE
feat: support chat history across frontend and kernel

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -11,6 +11,7 @@ import {
   ActionOutcome,
   ReviewResult,
 } from "../core/agent";
+import type { ChatMessage } from "../types/chat";
 import { buildChatCompletionsUrl, loadLLMConfig } from "../config/llm";
 
 async function handleHttpGet(args: any): Promise<ToolResult> {
@@ -60,8 +61,6 @@ async function handleFileRead(args: any): Promise<ToolResult> {
 function handleEcho(args: any): ToolResult {
   return { ok: true, data: args } satisfies ToolOk;
 }
-
-type ChatMessage = { role: string; content: string };
 
 function normaliseMessages(args: any): ChatMessage[] {
   const messages: ChatMessage[] = [];
@@ -220,6 +219,7 @@ interface ChatKernelOptions {
   message: string;
   traceId: string;
   toolInvoker: ToolInvoker;
+  history?: ChatMessage[];
 }
 
 class ChatKernel implements AgentKernel {
@@ -227,7 +227,13 @@ class ChatKernel implements AgentKernel {
   private planCount = 0;
   private actions: ActionOutcome[] = [];
 
-  constructor(private readonly options: ChatKernelOptions) {}
+  private readonly history: ChatMessage[];
+
+  constructor(private readonly options: ChatKernelOptions) {
+    this.history = Array.isArray(options.history)
+      ? options.history.map((msg) => ({ role: msg.role, content: msg.content }))
+      : [];
+  }
 
   async perceive(): Promise<void> {
     this.perceived = true;
@@ -245,7 +251,9 @@ class ChatKernel implements AgentKernel {
         {
           id: `${this.options.traceId}-step-${this.planCount}`,
           op: "llm.chat",
-          args: { prompt: this.options.message },
+          args: {
+            messages: [...this.history, { role: "user", content: this.options.message }],
+          },
         },
       ],
     } satisfies Plan;

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import { createChatKernel, createDefaultToolInvoker } from "../../adapters/core";
+import type { ChatMessage } from "../../types/chat";
 import { runLoop, type CoreEvent } from "../../core/agent";
 import { EpisodeLogger } from "../../runtime/episode";
 import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../runtime/events";
@@ -56,12 +57,20 @@ export default async function handler(
 
   const messageRaw = payload.message ?? payload.input ?? "";
   const message = typeof messageRaw === "string" ? messageRaw : "";
+  const history: ChatMessage[] = Array.isArray(payload.messages)
+    ? (payload.messages as Array<any>).reduce<ChatMessage[]>((acc, item) => {
+        if (item && typeof item.role === "string" && typeof item.content === "string") {
+          acc.push({ role: item.role, content: item.content });
+        }
+        return acc;
+      }, [])
+    : [];
   const traceId = randomUUID();
 
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId, dir: episodesDir });
   const toolInvoker = createDefaultToolInvoker();
-  const kernel = createChatKernel({ message, traceId, toolInvoker });
+  const kernel = createChatKernel({ message, traceId, toolInvoker, history });
 
   const events: EventEnvelope<CoreEvent>[] = [];
   bus.subscribe((event: EventEnvelope<CoreEvent>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import { FormEventHandler, useCallback, useMemo, useState } from "react";
 import type { NextPage } from "next";
 import LogFlowPanel from "../components/LogFlowPanel";
+import type { ChatMessage } from "../types/chat";
 
 const HomePage: NextPage = () => {
   const [input, setInput] = useState("");
@@ -9,19 +10,27 @@ const HomePage: NextPage = () => {
   const [finalOutput, setFinalOutput] = useState<any>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
+  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
 
   const handleRun = useCallback(async () => {
     if (isRunning) return;
     const prompt = input.trim();
+    if (!prompt) {
+      setRunError("Please enter a message before running.");
+      return;
+    }
     setIsRunning(true);
     setRunError(null);
     setTraceId(undefined);
     setFinalOutput(null);
+    const previousHistory = chatHistory;
+    const nextHistory = [...previousHistory, { role: "user", content: prompt }];
+    setChatHistory(nextHistory);
     try {
       const response = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: prompt }),
+        body: JSON.stringify({ message: prompt, messages: previousHistory }),
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data) {
@@ -29,12 +38,24 @@ const HomePage: NextPage = () => {
       }
       setTraceId(data.trace_id);
       setFinalOutput(data.result);
+      const assistantReplyRaw = data?.result?.text ?? data?.result?.content ?? data?.result;
+      let assistantReplyText = "";
+      if (typeof assistantReplyRaw === "string") {
+        assistantReplyText = assistantReplyRaw;
+      } else if (assistantReplyRaw) {
+        assistantReplyText = JSON.stringify(assistantReplyRaw, null, 2);
+      }
+      const replyContent = assistantReplyText.trim() || "(no response)";
+      setChatHistory([...nextHistory, { role: "assistant", content: replyContent }]);
     } catch (err: any) {
-      setRunError(err?.message ?? "Failed to run agent");
+      const message = err?.message ?? "Failed to run agent";
+      setRunError(message);
+      setChatHistory([...nextHistory, { role: "system", content: message }]);
     } finally {
       setIsRunning(false);
+      setInput("");
     }
-  }, [input, isRunning]);
+  }, [chatHistory, input, isRunning]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -178,21 +199,98 @@ const HomePage: NextPage = () => {
               </div>
             </form>
 
-            <div>
-              <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
-              <pre
-                style={{
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                  background: "#0f172a",
-                  borderRadius: 8,
-                  padding: "1rem",
-                  border: "1px solid #1f2937",
-                  minHeight: 120,
-                }}
-              >
-                {finalOutput ? JSON.stringify(finalOutput, null, 2) : "No output yet."}
-              </pre>
+            <div style={{ display: "grid", gap: "1.5rem" }}>
+              <div>
+                <h3 style={{ margin: "0 0 0.5rem" }}>Conversation</h3>
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.75rem",
+                    maxHeight: 360,
+                    overflowY: "auto",
+                    background: "#0f172a",
+                    borderRadius: 8,
+                    padding: "1rem",
+                    border: "1px solid #1f2937",
+                  }}
+                >
+                  {chatHistory.length === 0 ? (
+                    <p style={{ margin: 0, color: "#94a3b8", fontSize: "0.95rem" }}>
+                      No messages yet. Start the conversation above.
+                    </p>
+                  ) : (
+                    chatHistory.map((message, index) => {
+                      const isUser = message.role === "user";
+                      const isAssistant = message.role === "assistant";
+                      const alignSelf = isUser ? "flex-end" : "flex-start";
+                      const color = isUser ? "#0f172a" : "#e2e8f0";
+                      let background = "#f97316";
+                      if (isUser) {
+                        background = "#38bdf8";
+                      } else if (isAssistant) {
+                        background = "#1f2937";
+                      }
+                      let label = "System";
+                      if (isUser) {
+                        label = "You";
+                      } else if (isAssistant) {
+                        label = "Agent";
+                      }
+                      return (
+                        <div
+                          key={`${message.role}-${index}`}
+                          style={{
+                            alignSelf,
+                            maxWidth: "80%",
+                            background,
+                            color,
+                            borderRadius: 12,
+                            padding: "0.75rem 1rem",
+                            boxShadow: "0 4px 12px rgba(15, 23, 42, 0.35)",
+                            border: isAssistant ? "1px solid #334155" : "none",
+                          }}
+                        >
+                          <div
+                            style={{ fontSize: "0.75rem", opacity: 0.8, marginBottom: "0.35rem" }}
+                          >
+                            {label}
+                          </div>
+                          <div style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                            {message.content}
+                          </div>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <h3 style={{ margin: "0 0 0.5rem" }}>Final Output</h3>
+                <pre
+                  style={{
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    background: "#0f172a",
+                    borderRadius: 8,
+                    padding: "1rem",
+                    border: "1px solid #1f2937",
+                    minHeight: 120,
+                  }}
+                >
+                  {(() => {
+                    if (!finalOutput) return "No output yet.";
+                    const payload = finalOutput.raw ?? finalOutput;
+                    if (typeof payload === "string") return payload;
+                    try {
+                      return JSON.stringify(payload, null, 2);
+                    } catch (err) {
+                      return String(payload);
+                    }
+                  })()}
+                </pre>
+              </div>
             </div>
           </section>
         ) : (

--- a/tests/chatKernel.test.ts
+++ b/tests/chatKernel.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { createChatKernel } from "../adapters/core";
+import type { ToolInvoker } from "../core/agent";
+import type { ChatMessage } from "../types/chat";
+
+describe("createChatKernel", () => {
+  it("appends the current user message to history when planning", async () => {
+    const history: ChatMessage[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+    ];
+    const toolInvoker: ToolInvoker = async () => ({ ok: true, data: {} });
+    const kernel = createChatKernel({
+      message: "How are you?",
+      history,
+      traceId: "trace-123",
+      toolInvoker,
+    });
+
+    await kernel.perceive({ traceId: "trace-123" });
+    const plan = await kernel.plan();
+    expect(plan).toBeTruthy();
+    if (!plan) {
+      throw new Error("plan should not be null");
+    }
+    expect(plan.steps).toHaveLength(1);
+    const [step] = plan.steps;
+    expect(step.op).toBe("llm.chat");
+    expect(step.args).toMatchObject({
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+        { role: "user", content: "How are you?" },
+      ],
+    });
+  });
+});

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,0 +1,4 @@
+export interface ChatMessage {
+  role: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
* Maintain a chat history on the home page, send it with each run, and render past turns alongside the latest raw output for clarity.【F:pages/index.tsx†L1-L56】【F:pages/index.tsx†L202-L294】
* Parse chat history in the run API and extend the chat kernel to prepend previous turns when calling the LLM.【F:pages/api/run.ts†L5-L74】【F:adapters/core.ts†L218-L256】
* Share a ChatMessage type and cover the new planning behaviour with a unit test.【F:types/chat.ts†L1-L4】【F:tests/chatKernel.test.ts†L1-L35】

## Testing
* `pnpm typecheck`
* `pnpm lint`
* `pnpm test`
* `pnpm build`
* `pnpm smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ca41fc9b68832b8c5d6c669f0932ce