### PR TITLE
feat(ui): persist chat history with metadata bubbles

### DIFF
--- a/components/ChatMessageList.tsx
+++ b/components/ChatMessageList.tsx
@@ -1,30 +1,79 @@
 import type { FC } from "react";
 
+export type ChatHistoryMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  ts: string;
+  status?: "pending" | "sent" | "done" | "error";
+  msgId?: string;
+  traceId?: string;
+  latencyMs?: number | null;
+  cost?: number | null;
+  error?: string | null;
+};
+
 interface ChatMessageListProps {
-  messages: Array<{ role: string; content: string }>;
+  messages: ChatHistoryMessage[];
   isRunning?: boolean;
 }
 
 const bubbleStyles: Record<
-  string,
-  { alignSelf: "flex-start" | "flex-end" | "center"; background: string }
+  ChatHistoryMessage["role"],
+  {
+    alignSelf: "flex-start" | "flex-end" | "center";
+    background: string;
+    color: string;
+  }
 > = {
-  user: { alignSelf: "flex-end", background: "#38bdf8" },
-  assistant: { alignSelf: "flex-start", background: "#334155" },
-  system: { alignSelf: "center", background: "#475569" },
+  user: { alignSelf: "flex-end", background: "#38bdf8", color: "#0f172a" },
+  assistant: { alignSelf: "flex-start", background: "#1f2937", color: "#e2e8f0" },
+  system: { alignSelf: "center", background: "#334155", color: "#e2e8f0" },
+};
+
+const groupMessagesByRole = (messages: ChatHistoryMessage[]) => {
+  const groups: Array<{ role: ChatHistoryMessage["role"]; items: ChatHistoryMessage[] }> = [];
+  for (const message of messages) {
+    const lastGroup = groups[groups.length - 1];
+    if (lastGroup && lastGroup.role === message.role) {
+      lastGroup.items.push(message);
+    } else {
+      groups.push({ role: message.role, items: [message] });
+    }
+  }
+  return groups;
+};
+
+const formatTimestamp = (ts: string): string => {
+  if (!ts) return "";
+  try {
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) {
+      return ts;
+    }
+    return date.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return ts;
+  }
 };
 
 const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false }) => {
+  const groups = groupMessagesByRole(messages);
+
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "0.75rem",
-        maxHeight: 360,
+        gap: "1rem",
+        maxHeight: 420,
         overflowY: "auto",
         padding: "1rem",
-        borderRadius: 8,
+        borderRadius: 12,
         border: "1px solid #1f2937",
         background: "#0f172a",
       }}
@@ -32,25 +81,86 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
       {messages.length === 0 ? (
         <p style={{ margin: 0, color: "#94a3b8" }}>No messages yet.</p>
       ) : (
-        messages.map((message, index) => {
-          const style = bubbleStyles[message.role] ?? bubbleStyles.assistant;
+        groups.map((group) => {
+          const style = bubbleStyles[group.role];
           return (
             <div
-              key={`chat-message-${index}`}
-              data-role={message.role}
+              key={`chat-group-${group.items[0]?.id ?? group.role}`}
+              data-group-role={group.role}
               style={{
-                alignSelf: style.alignSelf,
-                background: style.background,
-                color: message.role === "user" ? "#0f172a" : "#e2e8f0",
-                borderRadius: 12,
-                padding: "0.75rem 1rem",
-                maxWidth: "80%",
-                boxShadow: "0 4px 12px rgba(15,23,42,0.45)",
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem",
+                alignItems:
+                  style.alignSelf === "center"
+                    ? "center"
+                    : style.alignSelf === "flex-end"
+                      ? "flex-end"
+                      : "flex-start",
               }}
             >
-              {message.content}
+              <span
+                style={{
+                  fontSize: "0.75rem",
+                  letterSpacing: "0.04em",
+                  textTransform: "uppercase",
+                  color: "#64748b",
+                }}
+              >
+                {group.role}
+              </span>
+              {group.items.map((message) => (
+                <article
+                  key={message.id}
+                  data-role={message.role}
+                  data-msg-id={message.msgId ?? undefined}
+                  data-status={message.status ?? "sent"}
+                  style={{
+                    alignSelf: style.alignSelf,
+                    background: style.background,
+                    color: style.color,
+                    borderRadius: 12,
+                    padding: "0.75rem 1rem",
+                    maxWidth: "82%",
+                    boxShadow: "0 4px 12px rgba(15,23,42,0.45)",
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    border: message.status === "error" ? "1px solid #f97316" : "none",
+                  }}
+                >
+                  <div>{message.content}</div>
+                  <footer
+                    style={{
+                      marginTop: "0.5rem",
+                      fontSize: "0.75rem",
+                      color: style.color === "#e2e8f0" ? "#cbd5f5" : "#0f172a",
+                      opacity: 0.75,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "0.15rem",
+                    }}
+                  >
+                    <span>
+                      {message.msgId ? `msg_id: ${message.msgId}` : `local_id: ${message.id}`}
+                    </span>
+                    <span>{formatTimestamp(message.ts)}</span>
+                    <span>
+                      {message.status === "error"
+                        ? message.error ?? "Delivery failed"
+                        : message.status === "pending"
+                          ? "Pending"
+                          : message.status === "done"
+                            ? "Delivered"
+                            : "Sent"}
+                    </span>
+                    {message.traceId ? <span>trace_id: {message.traceId}</span> : null}
+                    {typeof message.latencyMs === "number" ? (
+                      <span>latency: {message.latencyMs.toFixed(0)} ms</span>
+                    ) : null}
+                    {typeof message.cost === "number" ? <span>cost: {message.cost.toFixed(4)}</span> : null}
+                  </footer>
+                </article>
+              ))}
             </div>
           );
         })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,64 +1,187 @@
 import { FormEventHandler, useCallback, useMemo, useState } from "react";
 import type { NextPage } from "next";
-import ChatMessageList from "../components/ChatMessageList";
+import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 import LogFlowPanel from "../components/LogFlowPanel";
 
-export type ChatMessage = {
-  role: "user" | "assistant" | "system";
-  content: string;
+interface ChatSendResponse {
+  trace_id?: string;
+  msg_id?: string;
+  message?: {
+    msg_id?: string;
+    role?: string;
+    content?: string;
+    text?: string;
+    ts?: string;
+    trace_id?: string;
+  };
+  result?: { text?: string; msg_id?: string; ts?: string };
+  output?: { text?: string; msg_id?: string; ts?: string };
+  final?: { text?: string; msg_id?: string; ts?: string };
+  metrics?: { latency_ms?: number; cost?: number };
+  error?: { message?: string } | null;
+  message_error?: string;
+}
+
+const generateLocalId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
 };
+
+const serialiseHistoryForRequest = (messages: ChatHistoryMessage[]) =>
+  messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    msg_id: message.msgId,
+    id: message.id,
+    ts: message.ts,
+  }));
 
 const HomePage: NextPage = () => {
   const [input, setInput] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
   const [latestResponse, setLatestResponse] = useState<any>(null);
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
+  const [chatHistory, setChatHistory] = useState<ChatHistoryMessage[]>([]);
   const [runError, setRunError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [cost, setCost] = useState<number | null>(null);
 
   const handleRun = useCallback(async () => {
     if (isRunning) return;
     const prompt = input.trim();
     if (!prompt) return;
 
-    const previousHistory = chatHistory;
-    const userMessage: ChatMessage = { role: "user", content: prompt };
-    const nextHistory = [...previousHistory, userMessage];
+    const createdAt = new Date().toISOString();
+    const localId = generateLocalId();
+    const userMessage: ChatHistoryMessage = {
+      id: localId,
+      role: "user",
+      content: prompt,
+      ts: createdAt,
+      status: "pending",
+      traceId,
+    };
 
-    setChatHistory(nextHistory);
+    const historyForRequest = [...chatHistory, userMessage];
+
+    setChatHistory(historyForRequest);
     setIsRunning(true);
     setRunError(null);
+    const previousTraceId = traceId;
     setTraceId(undefined);
     setLatestResponse(null);
+    setLatencyMs(null);
+    setCost(null);
+    setInput("");
+    const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
     try {
-      const response = await fetch("/api/run", {
+      const response = await fetch("/api/chat.send", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: prompt, messages: previousHistory }),
+        body: JSON.stringify({
+          text: prompt,
+          trace_id: traceId,
+          history: serialiseHistoryForRequest(historyForRequest),
+        }),
       });
-      const data = await response.json().catch(() => null);
-      if (!response.ok || !data) {
-        throw new Error(data?.message ?? `Request failed (${response.status})`);
+      const data: ChatSendResponse | null = await response.json().catch(() => null);
+      if (!response.ok || !data || data.error || data.message_error) {
+        const errorMessage =
+          (data?.error as { message?: string } | undefined)?.message ??
+          data?.message_error ??
+          data?.message?.content ??
+          `Request failed (${response.status})`;
+        throw new Error(errorMessage);
       }
-      setTraceId(data.trace_id);
-      setLatestResponse(data.result);
-      const assistantMessage: ChatMessage = {
-        role: "assistant",
-        content: data.result?.text ?? JSON.stringify(data.result),
+      setLatestResponse(data);
+      const resolvedTraceId = data.trace_id ?? data.message?.trace_id ?? previousTraceId ?? traceId;
+      setTraceId(resolvedTraceId);
+
+      const computedLatency = data.metrics?.latency_ms ??
+        (typeof performance !== "undefined" ? Math.round(performance.now() - startedAt) : Date.now() - startedAt);
+      const computedCost = data.metrics?.cost ?? null;
+      setLatencyMs(typeof computedLatency === "number" ? computedLatency : null);
+      setCost(typeof computedCost === "number" ? computedCost : null);
+
+      const assistantPayload = (data.message ?? data.result ?? data.output ?? data.final ?? {}) as {
+        content?: string;
+        text?: string;
+        msg_id?: string;
+        ts?: string;
+        trace_id?: string;
       };
-      setChatHistory((history) => [...history, assistantMessage]);
+      const assistantContentRaw =
+        typeof assistantPayload.content === "string"
+          ? assistantPayload.content
+          : typeof assistantPayload.text === "string"
+            ? assistantPayload.text
+            : assistantPayload && typeof assistantPayload === "object"
+              ? JSON.stringify(assistantPayload)
+              : "";
+      const assistantContent =
+        typeof assistantContentRaw === "string" && assistantContentRaw.length > 0
+          ? assistantContentRaw
+          : "";
+      const assistantMsgId = assistantPayload.msg_id ?? data.msg_id ?? generateLocalId();
+      const assistantTs = assistantPayload.ts ?? new Date().toISOString();
+
+      setChatHistory((history) => {
+        const updatedHistory: ChatHistoryMessage[] = history.map((message) =>
+          message.id === localId
+            ? {
+                ...message,
+                msgId: data.msg_id ?? message.msgId,
+                traceId: resolvedTraceId,
+                status: "done" as const,
+              }
+            : message,
+        );
+        const assistantMessage: ChatHistoryMessage = {
+          id: assistantMsgId ?? generateLocalId(),
+          msgId: assistantMsgId,
+          role: "assistant",
+          content: assistantContent,
+          ts: assistantTs,
+          status: "done" as const,
+          traceId: resolvedTraceId,
+          latencyMs: typeof computedLatency === "number" ? computedLatency : null,
+          cost: typeof computedCost === "number" ? computedCost : null,
+        };
+        return [...updatedHistory, assistantMessage];
+      });
     } catch (err: any) {
-      setRunError(err?.message ?? "Failed to run agent");
-      const errorMessage: ChatMessage = {
-        role: "system",
-        content: `Error: ${err?.message ?? "Failed to run agent"}`,
-      };
-      setChatHistory((history) => [...history, errorMessage]);
+      const errorMessage = err?.message ?? "Failed to run agent";
+      setRunError(errorMessage);
+      setChatHistory((history) => {
+        const updated = history.map((message) =>
+          message.id === localId
+            ? {
+                ...message,
+                status: "error" as const,
+                error: errorMessage,
+              }
+            : message,
+        );
+        return [
+          ...updated,
+          {
+            id: generateLocalId(),
+            role: "system",
+            content: `Error: ${errorMessage}`,
+            ts: new Date().toISOString(),
+            status: "error" as const,
+            error: errorMessage,
+          },
+        ];
+      });
+      setTraceId(previousTraceId);
     } finally {
       setIsRunning(false);
     }
-  }, [input, isRunning, chatHistory]);
+  }, [input, isRunning, chatHistory, traceId]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -178,31 +301,73 @@ const HomePage: NextPage = () => {
                   fontSize: "1rem",
                 }}
               />
-              <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-                <button
-                  type="submit"
-                  disabled={isRunning}
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.75rem",
+                }}
+              >
+                <div
                   style={{
-                    padding: "0.75rem 1.5rem",
-                    borderRadius: 999,
-                    border: "none",
-                    background: isRunning ? "#475569" : "#38bdf8",
-                    color: "#0f172a",
-                    fontWeight: 600,
-                    cursor: isRunning ? "not-allowed" : "pointer",
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                    gap: "0.75rem",
+                    padding: "0.75rem 1rem",
+                    borderRadius: 10,
+                    background: "#0f172a",
+                    border: "1px solid #1f2937",
                   }}
                 >
-                  {isRunning ? "Running…" : "Run"}
-                </button>
-                <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
-                  {traceId
-                    ? `trace_id: ${traceId}`
-                    : runError
+                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <span style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}>
+                      trace_id
+                    </span>
+                    <span style={{ fontSize: "0.9rem" }}>{traceId ?? "-"}</span>
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <span style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}>
+                      latency
+                    </span>
+                    <span style={{ fontSize: "0.9rem" }}>
+                      {typeof latencyMs === "number" ? `${latencyMs.toFixed(0)} ms` : "-"}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <span style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}>
+                      cost
+                    </span>
+                    <span style={{ fontSize: "0.9rem" }}>
+                      {typeof cost === "number" ? cost.toFixed(4) : "-"}
+                    </span>
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+                  <button
+                    type="submit"
+                    disabled={isRunning}
+                    style={{
+                      padding: "0.75rem 1.5rem",
+                      borderRadius: 999,
+                      border: "none",
+                      background: isRunning ? "#475569" : "#38bdf8",
+                      color: "#0f172a",
+                      fontWeight: 600,
+                      cursor: isRunning ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {isRunning ? "Running…" : "Run"}
+                  </button>
+                  <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+                    {runError
                       ? runError
                       : isRunning
                         ? "Running agent"
-                        : "Idle"}
-                </span>
+                        : chatHistory.length > 0
+                          ? "Ready"
+                          : "Idle"}
+                  </span>
+                </div>
               </div>
             </form>
             <details

--- a/tests/chatMessageList.test.tsx
+++ b/tests/chatMessageList.test.tsx
@@ -1,26 +1,52 @@
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import ChatMessageList from "../components/ChatMessageList";
+import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 
 describe("ChatMessageList", () => {
   it("renders multi-turn conversation bubbles with status", () => {
+    const messages: ChatHistoryMessage[] = [
+      {
+        id: "u-1",
+        role: "user",
+        content: "Hello",
+        ts: new Date("2023-06-01T00:00:00Z").toISOString(),
+        status: "done",
+        msgId: "msg-user-1",
+      },
+      {
+        id: "a-1",
+        role: "assistant",
+        content: "Hi, how can I help?",
+        ts: new Date("2023-06-01T00:00:01Z").toISOString(),
+        status: "done",
+        msgId: "msg-assistant-1",
+        latencyMs: 1200,
+        cost: 0.0042,
+        traceId: "trace-123",
+      },
+      {
+        id: "u-2",
+        role: "user",
+        content: "Tell me a joke.",
+        ts: new Date("2023-06-01T00:00:02Z").toISOString(),
+        status: "pending",
+      },
+    ];
+
     const html = renderToStaticMarkup(
-      <ChatMessageList
-        messages={[
-          { role: "user", content: "Hello" },
-          { role: "assistant", content: "Hi, how can I help?" },
-          { role: "user", content: "Tell me a joke." },
-        ]}
-        isRunning
-      />,
+      <ChatMessageList messages={messages} isRunning />,
     );
 
-    expect(html.includes('data-role="user"')).toBe(true);
-    expect(html.includes('data-role="assistant"')).toBe(true);
+    expect(html.includes('data-group-role="user"')).toBe(true);
+    expect(html.includes('data-group-role="assistant"')).toBe(true);
+    expect(html.includes('data-status="pending"')).toBe(true);
+    expect(html.includes('data-msg-id="msg-assistant-1"')).toBe(true);
     expect(html.includes("Hello")).toBe(true);
     expect(html.includes("Hi, how can I help?")).toBe(true);
     expect(html.includes("Tell me a joke.")).toBe(true);
+    expect(html.includes("latency: 1200 ms")).toBe(true);
+    expect(html.includes("cost: 0.0042")).toBe(true);
     expect(html.includes('data-role="status"')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- track chat history entries with ids, timestamps, and metrics while adapting the client to the new `/api/chat.send` payloads and status bar
- render grouped chat bubbles with message metadata, latency, cost, and trace identifiers for each role
- update the ChatMessageList snapshot test to validate multi-turn rendering with pending and delivered states

## Testing
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca438edad4832b9ecf9e0cfa5a4cba