### PR TITLE
Add span metadata to run loop events and logflow UI

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
-import { runLoop, type CoreEvent } from "./core/agent";
+import { runLoop, type CoreEvent, type EventMetadata } from "./core/agent";
 import { EventBus, wrapCoreEvent } from "./runtime/events";
 import { EpisodeLogger } from "./runtime/episode";
 import { replayEpisode } from "./runtime/replay";
@@ -18,8 +18,8 @@ async function runOnce(message: string) {
     logger.append(event).catch(console.error);
   });
 
-  const emit = (event: CoreEvent) => {
-    bus.publish(wrapCoreEvent(traceId, event)).catch(console.error);
+  const emit = (event: CoreEvent, meta?: EventMetadata) => {
+    bus.publish(wrapCoreEvent(traceId, event, meta)).catch(console.error);
   };
   const result = await runLoop(kernel, emit, {
     context: { traceId, input: message },

--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -25,6 +25,10 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   const [branch, setBranch] = useState<BranchResponse | null>(null);
   const latestSelectionRef = useRef<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const branchCards = useMemo(() => {
+    if (!branch?.tree) return [];
+    return flattenBranchNodes(branch.tree);
+  }, [branch]);
 
   useEffect(() => {
     if (!traceId) {
@@ -242,9 +246,55 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
             <p style={{ fontSize: "0.9rem", color: "#f87171" }}>{branchState.error}</p>
           ) : branch ? (
             <div style={{ display: "grid", gap: "0.75rem" }}>
-              <div style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
-                Origin: {branch.origin.span_id ? `span ${branch.origin.span_id}` : "message"}
-                {branch.origin.ln !== undefined ? ` · ln ${branch.origin.ln}` : ""}
+              <div>
+                <div style={{ fontSize: "0.85rem", color: "#94a3b8", marginBottom: "0.5rem" }}>
+                  Origin: {branch.origin.span_id ? `span ${branch.origin.span_id}` : "message"}
+                  {branch.origin.ln !== undefined ? ` · ln ${branch.origin.ln}` : ""}
+                </div>
+                {branchCards.length > 0 ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      gap: "0.75rem",
+                    }}
+                  >
+                    {branchCards.map(({ node, depth }) => (
+                      <div
+                        key={`${node.span_id}-${depth}`}
+                        style={{
+                          flex: "1 1 180px",
+                          minWidth: 160,
+                          border: "1px solid #1f2937",
+                          borderRadius: 10,
+                          background: "#0f172a",
+                          padding: "0.75rem",
+                          boxShadow: depth
+                            ? "inset 0 0 0 1px rgba(56, 189, 248, 0.15)"
+                            : "inset 0 0 0 1px rgba(148, 163, 184, 0.2)",
+                        }}
+                      >
+                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                          {depth === 0 ? "Root span" : `Depth ${depth}`}
+                        </div>
+                        <div style={{ fontWeight: 600 }}>{node.span_id}</div>
+                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                          Parent: {node.parent_span_id ?? "—"}
+                        </div>
+                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                          Lines {node.first_ln} – {node.last_ln}
+                        </div>
+                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                          Events {node.events.length}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
+                    No span hierarchy available for this selection.
+                  </p>
+                )}
               </div>
               {branch.messages.length > 0 && (
                 <div>
@@ -351,6 +401,12 @@ function renderBranchNode(node: BranchNode, depth = 0): JSX.Element {
       {node.children.map((child: BranchNode) => renderBranchNode(child, depth + 1))}
     </div>
   );
+}
+
+function flattenBranchNodes(node: BranchNode, depth = 0): Array<{ node: BranchNode; depth: number }> {
+  const current = [{ node, depth }];
+  const children = node.children.flatMap((child) => flattenBranchNodes(child, depth + 1));
+  return [...current, ...children];
 }
 
 export default LogFlowPanel;

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -83,6 +83,13 @@ export type CoreEvent =
   | { type: "final"; outputs: any; reason?: string }
   | { type: "log"; level: LogLevel; message: string; detail?: any };
 
+export interface EventMetadata {
+  spanId?: string;
+  parentSpanId?: string;
+  topic?: string;
+  level?: LogLevel;
+}
+
 export interface AgentContext {
   traceId: string;
   input?: any;
@@ -113,7 +120,7 @@ const ensurePromise = async <T>(value: T | Promise<T>): Promise<T> => value;
 
 export async function runLoop(
   kernel: AgentKernel,
-  emit: (event: CoreEvent) => void | Promise<void>,
+  emit: (event: CoreEvent, meta?: EventMetadata) => void | Promise<void>,
   options: RunLoopOptions = {},
 ): Promise<RunLoopResult> {
   const maxIterations = options.maxIterations ?? 3;
@@ -131,13 +138,17 @@ export async function runLoop(
     const plan = await kernel.plan();
     const steps = plan?.steps ?? [];
     const revision = plan?.revision ?? iteration;
+    const planSpanId = `plan-${iteration}-${revision}`;
     await ensurePromise(
-      emit({
-        type: "plan",
-        steps,
-        revision,
-        reason: plan?.reason ?? (iteration === 1 ? "initial" : "retry"),
-      }),
+      emit(
+        {
+          type: "plan",
+          steps,
+          revision,
+          reason: plan?.reason ?? (iteration === 1 ? "initial" : "retry"),
+        },
+        { spanId: planSpanId },
+      ),
     );
 
     if (!steps.length) {
@@ -157,14 +168,17 @@ export async function runLoop(
       const outcome = await kernel.act(fallbackStep);
       actions.push(outcome);
       await ensurePromise(
-        emit({
-          type: "tool",
-          name: fallbackStep.op,
-          args: fallbackStep.args,
-          result: outcome.result,
-          cost: outcome.result.ok ? outcome.result.cost : undefined,
-          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
-        }),
+        emit(
+          {
+            type: "tool",
+            name: fallbackStep.op,
+            args: fallbackStep.args,
+            result: outcome.result,
+            cost: outcome.result.ok ? outcome.result.cost : undefined,
+            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+          },
+          { spanId: fallbackStep.id },
+        ),
       );
       const finalOutputs = await kernel.renderFinal(actions);
       await ensurePromise(emit({ type: "final", outputs: finalOutputs, reason: "no-plan" }));
@@ -172,27 +186,38 @@ export async function runLoop(
     }
 
     for (const step of steps) {
-      await ensurePromise(emit({ type: "progress", step: "act", pct: 0.4 }));
+      await ensurePromise(
+        emit(
+          { type: "progress", step: "act", pct: 0.4 },
+          { spanId: step.id, parentSpanId: planSpanId },
+        ),
+      );
       const outcome = await kernel.act(step);
       actions.push(outcome);
       await ensurePromise(
-        emit({
-          type: "tool",
-          name: step.op,
-          args: step.args,
-          result: outcome.result,
-          cost: outcome.result.ok ? outcome.result.cost : undefined,
-          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
-        }),
+        emit(
+          {
+            type: "tool",
+            name: step.op,
+            args: step.args,
+            result: outcome.result,
+            cost: outcome.result.ok ? outcome.result.cost : undefined,
+            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+          },
+          { spanId: step.id, parentSpanId: planSpanId },
+        ),
       );
 
       if (outcome.ask) {
         await ensurePromise(
-          emit({
-            type: "ask",
-            question: outcome.ask.question,
-            origin_step: outcome.ask.origin_step ?? step.id,
-          }),
+          emit(
+            {
+              type: "ask",
+              question: outcome.ask.question,
+              origin_step: outcome.ask.origin_step ?? step.id,
+            },
+            { spanId: step.id, parentSpanId: planSpanId },
+          ),
         );
         return { actions, reason: "ask" };
       }

--- a/lib/logflow.ts
+++ b/lib/logflow.ts
@@ -106,6 +106,20 @@ export function buildBranchTree(
     node.events.push(message);
     node.first_ln = Math.min(node.first_ln, message.ln);
     node.last_ln = Math.max(node.last_ln, message.ln);
+
+    if (message.parent_span_id && !nodes.has(message.parent_span_id)) {
+      nodes.set(
+        message.parent_span_id,
+        {
+          span_id: message.parent_span_id,
+          parent_span_id: undefined,
+          first_ln: message.ln,
+          last_ln: message.ln,
+          events: [],
+          children: [],
+        } satisfies MutableBranchNode,
+      );
+    }
   }
 
   if (!nodes.size || !nodes.has(originSpanId)) {
@@ -121,6 +135,8 @@ export function buildBranchTree(
     const parent = nodes.get(node.parent_span_id);
     if (parent && !parent.children.includes(node)) {
       parent.children.push(node);
+      parent.first_ln = Math.min(parent.first_ln, node.first_ln);
+      parent.last_ln = Math.max(parent.last_ln, node.last_ln);
     }
   }
 
@@ -141,13 +157,22 @@ export function buildBranchTree(
       } satisfies BranchNode;
     }
     visited.add(node.span_id);
+    const children = node.children.map(toBranch);
+    const firstLn = children.reduce(
+      (min, child) => Math.min(min, child.first_ln),
+      node.events.length ? Math.min(...node.events.map((evt) => evt.ln), node.first_ln) : node.first_ln,
+    );
+    const lastLn = children.reduce(
+      (max, child) => Math.max(max, child.last_ln),
+      node.events.length ? Math.max(...node.events.map((evt) => evt.ln), node.last_ln) : node.last_ln,
+    );
     return {
       span_id: node.span_id,
       parent_span_id: node.parent_span_id,
-      first_ln: node.first_ln,
-      last_ln: node.last_ln,
+      first_ln: firstLn,
+      last_ln: lastLn,
       events: node.events,
-      children: node.children.map(toBranch),
+      children,
     } satisfies BranchNode;
   };
 

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -3,14 +3,20 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import { createChatKernel, createDefaultToolInvoker } from "../../adapters/core";
-import { runLoop, type CoreEvent } from "../../core/agent";
+import { runLoop, type CoreEvent, type EventMetadata } from "../../core/agent";
 import { EpisodeLogger } from "../../runtime/episode";
 import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../runtime/events";
 
 interface RunResponse {
   trace_id: string;
   result: unknown;
-  events: Array<{ ts: string; type: string; data: CoreEvent }>;
+  events: Array<{
+    ts: string;
+    type: string;
+    span_id?: string;
+    parent_span_id?: string;
+    data: CoreEvent;
+  }>;
 }
 
 const episodesDir = join(process.cwd(), "episodes");
@@ -89,8 +95,8 @@ export default async function handler(
   });
 
   try {
-    const emit = async (event: CoreEvent): Promise<void> => {
-      await bus.publish(wrapCoreEvent(traceId, event));
+    const emit = async (event: CoreEvent, meta?: EventMetadata): Promise<void> => {
+      await bus.publish(wrapCoreEvent(traceId, event, meta));
     };
     const result = await runLoop(kernel, emit, {
       context: { traceId, input: message },
@@ -102,6 +108,8 @@ export default async function handler(
       events: events.map((evt: EventEnvelope<CoreEvent>) => ({
         ts: evt.ts,
         type: evt.type,
+        span_id: evt.span_id,
+        parent_span_id: evt.parent_span_id,
         data: evt.data,
       })),
     });

--- a/runtime/events.ts
+++ b/runtime/events.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { CoreEvent } from "../core/agent";
+import type { CoreEvent, EventMetadata } from "../core/agent";
 
 export interface EventEnvelope<T = any> {
   id: string;
@@ -50,11 +50,7 @@ export class EventBus {
   }
 }
 
-export interface WrapEventOptions {
-  spanId?: string;
-  parentSpanId?: string;
-  topic?: string;
-  level?: "debug" | "info" | "warn" | "error";
+export interface WrapEventOptions extends EventMetadata {
   version?: number;
 }
 
@@ -63,6 +59,8 @@ export function wrapCoreEvent(
   event: CoreEvent,
   options: WrapEventOptions = {},
 ): EventEnvelope<CoreEvent> {
+  const level =
+    options.level ?? (event.type === "log" ? (event.level as WrapEventOptions["level"]) : undefined);
   return {
     id: randomUUID(),
     ts: new Date().toISOString(),
@@ -72,7 +70,7 @@ export function wrapCoreEvent(
     span_id: options.spanId,
     parent_span_id: options.parentSpanId,
     topic: options.topic,
-    level: options.level,
+    level,
     data: event,
   };
 }

--- a/tests/logflow.test.ts
+++ b/tests/logflow.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import type { BranchNode, LogFlowMessage } from "../types/logflow";
+import { buildBranchTree } from "../lib/logflow";
+
+describe("buildBranchTree", () => {
+  const baseMessage = {
+    type: "agent.tool",
+    ts: "2024-01-01T00:00:00.000Z",
+    message: "",
+    data: {},
+  } as const;
+
+  it("creates a hierarchical tree for plan and step spans", () => {
+    const messages: LogFlowMessage[] = [
+      {
+        id: "1",
+        ln: 1,
+        span_id: "plan-1-1",
+        parent_span_id: undefined,
+        ...baseMessage,
+      },
+      {
+        id: "2",
+        ln: 2,
+        span_id: "step-a",
+        parent_span_id: "plan-1-1",
+        ...baseMessage,
+      },
+      {
+        id: "3",
+        ln: 3,
+        span_id: "step-b",
+        parent_span_id: "plan-1-1",
+        ...baseMessage,
+      },
+      {
+        id: "4",
+        ln: 4,
+        span_id: "tool-a",
+        parent_span_id: "step-a",
+        ...baseMessage,
+      },
+    ];
+
+    const tree = buildBranchTree(messages, "plan-1-1") as BranchNode;
+    expect(tree.span_id).toBe("plan-1-1");
+    expect(tree.children).toHaveLength(2);
+    const [stepA, stepB] = tree.children;
+    expect(stepA.span_id).toBe("step-a");
+    expect(stepA.parent_span_id).toBe("plan-1-1");
+    expect(stepA.children).toHaveLength(1);
+    expect(stepA.children[0]?.span_id).toBe("tool-a");
+    expect(stepB.span_id).toBe("step-b");
+    expect(tree.first_ln).toBe(1);
+    expect(tree.last_ln).toBe(4);
+  });
+
+  it("creates placeholder nodes when parent spans are missing events", () => {
+    const messages: LogFlowMessage[] = [
+      {
+        id: "child",
+        ln: 10,
+        span_id: "child-span",
+        parent_span_id: "missing-parent",
+        ...baseMessage,
+      },
+    ];
+
+    const tree = buildBranchTree(messages, "missing-parent") as BranchNode;
+    expect(tree.span_id).toBe("missing-parent");
+    expect(tree.events).toHaveLength(0);
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0]?.span_id).toBe("child-span");
+    expect(tree.first_ln).toBe(10);
+    expect(tree.last_ln).toBe(10);
+  });
+});

--- a/tests/runLoop.test.ts
+++ b/tests/runLoop.test.ts
@@ -6,11 +6,21 @@ import {
   type ActionOutcome,
   type ToolResult,
   type CoreEvent,
+  type EventMetadata,
 } from "../core/agent";
+
+type FinalEventEntry = {
+  event: Extract<CoreEvent, { type: "final" }>;
+  meta?: EventMetadata;
+};
+
+function isFinalEvent(entry: { event: CoreEvent; meta?: EventMetadata }): entry is FinalEventEntry {
+  return entry.event.type === "final";
+}
 
 describe("runLoop", () => {
   it("executes plan steps and resolves when review passes", async () => {
-    const emitted: CoreEvent[] = [];
+    const emitted: Array<{ event: CoreEvent; meta?: EventMetadata }> = [];
     const kernel: AgentKernel = {
       async perceive() {
         /* no-op */
@@ -40,25 +50,37 @@ describe("runLoop", () => {
 
     const result = await runLoop(
       kernel,
-      (event: CoreEvent) => {
-        emitted.push(event);
+      (event: CoreEvent, meta?: EventMetadata) => {
+        emitted.push({ event, meta });
       },
       { maxIterations: 3 },
     );
 
     expect(result.reason).toBe("completed");
     expect(result.final).toBe("HI THERE");
-    expect(emitted.some((event) => event.type === "plan")).toBeTruthy();
-    expect(emitted.filter((event) => event.type === "tool")).toHaveLength(2);
+    expect(emitted.some(({ event }) => event.type === "plan")).toBeTruthy();
+    expect(emitted.filter(({ event }) => event.type === "tool")).toHaveLength(2);
     expect(
-      emitted.some((event) => event.type === "tool" && event.name === "tool.echo"),
+      emitted.some(({ event }) => event.type === "tool" && event.name === "tool.echo"),
     ).toBeTruthy();
-    const finalEvent = emitted.find((event) => event.type === "final");
-    expect(finalEvent && finalEvent.reason).toBe("completed");
+    const finalEvent = emitted.find(isFinalEvent);
+    expect(finalEvent?.event.reason).toBe("completed");
+
+    const planEvent = emitted.find(({ event }) => event.type === "plan");
+    expect(planEvent?.meta?.spanId).toBe("plan-1-1");
+
+    const toolSpanIds = emitted
+      .filter(({ event }) => event.type === "tool")
+      .map(({ meta }) => meta?.spanId);
+    expect(toolSpanIds).toEqual(["s1", "s2"]);
+    const toolParents = emitted
+      .filter(({ event }) => event.type === "tool")
+      .map(({ meta }) => meta?.parentSpanId);
+    expect(toolParents.every((value) => value === planEvent?.meta?.spanId)).toBe(true);
   });
 
   it("falls back to final output when no plan is produced", async () => {
-    const emitted: CoreEvent[] = [];
+    const emitted: Array<{ event: CoreEvent; meta?: EventMetadata }> = [];
     const kernel: AgentKernel = {
       async perceive() {
         /* no-op */
@@ -78,16 +100,19 @@ describe("runLoop", () => {
       },
     };
 
-    const result = await runLoop(kernel, (event: CoreEvent) => {
-      emitted.push(event);
+    const result = await runLoop(kernel, (event: CoreEvent, meta?: EventMetadata) => {
+      emitted.push({ event, meta });
     });
 
     expect(result.reason).toBe("no-plan");
     expect(result.final).toEqual([{ fallback: true, reason: undefined }]);
-    const finalEvent = emitted.find((event) => event.type === "final");
-    expect(finalEvent && finalEvent.reason).toBe("no-plan");
+    const finalEvent = emitted.find(isFinalEvent);
+    expect(finalEvent?.event.reason).toBe("no-plan");
     expect(
-      emitted.some((event) => event.type === "tool" && event.name === "llm.chat"),
+      emitted.some(({ event }) => event.type === "tool" && event.name === "llm.chat"),
     ).toBeTruthy();
+
+    const fallbackTool = emitted.find(({ event }) => event.type === "tool");
+    expect(fallbackTool?.meta?.spanId?.startsWith("fallback-")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add span metadata support to the run loop emitter and propagate it through the event envelope and API so spans include parent information
- enhance logflow tree building and the LogFlow panel UI to surface span cards and task hierarchies based on the new metadata
- extend unit coverage for runLoop and logflow to assert span ids and branch tree construction

## Testing
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca43946f34832b90a97b2602347814