### PR TITLE
Propagate span metadata through run loop events

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
-import { runLoop, type CoreEvent } from "./core/agent";
+import { runLoop, type CoreEvent, type EmitSpanOptions } from "./core/agent";
 import { EventBus, wrapCoreEvent } from "./runtime/events";
 import { EpisodeLogger } from "./runtime/episode";
 import { replayEpisode } from "./runtime/replay";
@@ -18,8 +18,8 @@ async function runOnce(message: string) {
     logger.append(event).catch(console.error);
   });
 
-  const emit = (event: CoreEvent) => {
-    bus.publish(wrapCoreEvent(traceId, event)).catch(console.error);
+  const emit = (event: CoreEvent, span?: EmitSpanOptions) => {
+    bus.publish(wrapCoreEvent(traceId, event, span)).catch(console.error);
   };
   const result = await runLoop(kernel, emit, {
     context: { traceId, input: message },

--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -84,12 +84,17 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
       setBranch(null);
       setBranchState({ loading: true, error: null });
 
-      const params = new URLSearchParams({ trace_id: traceId });
-      if (message.span_id) {
-        params.set("span_id", message.span_id);
-      } else {
-        params.set("ln", String(message.ln));
+      if (!message.span_id) {
+        setBranch(null);
+        setBranchState({
+          loading: false,
+          error: "Selected event is missing span information",
+        });
+        return;
       }
+
+      const params = new URLSearchParams({ trace_id: traceId });
+      params.set("span_id", message.span_id);
 
       fetch(`/api/logflow/branch?${params.toString()}`)
         .then(async (resp) => {

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -111,17 +111,28 @@ export interface RunLoopResult {
 
 const ensurePromise = async <T>(value: T | Promise<T>): Promise<T> => value;
 
+export interface EmitSpanOptions {
+  spanId?: string;
+  parentSpanId?: string;
+}
+
 export async function runLoop(
   kernel: AgentKernel,
-  emit: (event: CoreEvent) => void | Promise<void>,
+  emit: (event: CoreEvent, span?: EmitSpanOptions) => void | Promise<void>,
   options: RunLoopOptions = {},
 ): Promise<RunLoopResult> {
   const maxIterations = options.maxIterations ?? 3;
   const actions: ActionOutcome[] = [];
   const context = options.context ?? { traceId: randomUUID() };
+  const traceSpanId = context.traceId;
 
   await ensurePromise(kernel.perceive(context));
-  await ensurePromise(emit({ type: "progress", step: "perceive", pct: 0.2 }));
+  await ensurePromise(
+    emit(
+      { type: "progress", step: "perceive", pct: 0.2 },
+      { spanId: traceSpanId },
+    ),
+  );
 
   let iteration = 0;
   let lastReview: ReviewResult | undefined;
@@ -131,22 +142,29 @@ export async function runLoop(
     const plan = await kernel.plan();
     const steps = plan?.steps ?? [];
     const revision = plan?.revision ?? iteration;
+    const planSpanId = `plan-${revision}`;
     await ensurePromise(
-      emit({
-        type: "plan",
-        steps,
-        revision,
-        reason: plan?.reason ?? (iteration === 1 ? "initial" : "retry"),
-      }),
+      emit(
+        {
+          type: "plan",
+          steps,
+          revision,
+          reason: plan?.reason ?? (iteration === 1 ? "initial" : "retry"),
+        },
+        { spanId: planSpanId, parentSpanId: traceSpanId },
+      ),
     );
 
     if (!steps.length) {
       await ensurePromise(
-        emit({
-          type: "log",
-          level: "warn",
-          message: "plan returned no executable steps, using fallback response",
-        }),
+        emit(
+          {
+            type: "log",
+            level: "warn",
+            message: "plan returned no executable steps, using fallback response",
+          },
+          { spanId: planSpanId, parentSpanId: traceSpanId },
+        ),
       );
 
       const fallbackStep: PlanStep = {
@@ -157,42 +175,64 @@ export async function runLoop(
       const outcome = await kernel.act(fallbackStep);
       actions.push(outcome);
       await ensurePromise(
-        emit({
-          type: "tool",
-          name: fallbackStep.op,
-          args: fallbackStep.args,
-          result: outcome.result,
-          cost: outcome.result.ok ? outcome.result.cost : undefined,
-          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
-        }),
+        emit(
+          {
+            type: "tool",
+            name: fallbackStep.op,
+            args: fallbackStep.args,
+            result: outcome.result,
+            cost: outcome.result.ok ? outcome.result.cost : undefined,
+            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+          },
+          { spanId: fallbackStep.id, parentSpanId: planSpanId },
+        ),
       );
       const finalOutputs = await kernel.renderFinal(actions);
-      await ensurePromise(emit({ type: "final", outputs: finalOutputs, reason: "no-plan" }));
+      await ensurePromise(
+        emit(
+          { type: "final", outputs: finalOutputs, reason: "no-plan" },
+          { spanId: traceSpanId },
+        ),
+      );
       return { actions, final: finalOutputs, reason: "no-plan" };
     }
 
     for (const step of steps) {
-      await ensurePromise(emit({ type: "progress", step: "act", pct: 0.4 }));
+      await ensurePromise(
+        emit(
+          { type: "progress", step: "act", pct: 0.4 },
+          { spanId: step.id, parentSpanId: planSpanId },
+        ),
+      );
       const outcome = await kernel.act(step);
       actions.push(outcome);
       await ensurePromise(
-        emit({
-          type: "tool",
-          name: step.op,
-          args: step.args,
-          result: outcome.result,
-          cost: outcome.result.ok ? outcome.result.cost : undefined,
-          latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
-        }),
+        emit(
+          {
+            type: "tool",
+            name: step.op,
+            args: step.args,
+            result: outcome.result,
+            cost: outcome.result.ok ? outcome.result.cost : undefined,
+            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+          },
+          { spanId: step.id, parentSpanId: planSpanId },
+        ),
       );
 
       if (outcome.ask) {
         await ensurePromise(
-          emit({
-            type: "ask",
-            question: outcome.ask.question,
-            origin_step: outcome.ask.origin_step ?? step.id,
-          }),
+          emit(
+            {
+              type: "ask",
+              question: outcome.ask.question,
+              origin_step: outcome.ask.origin_step ?? step.id,
+            },
+            {
+              spanId: outcome.ask.origin_step ?? step.id,
+              parentSpanId: planSpanId,
+            },
+          ),
         );
         return { actions, reason: "ask" };
       }
@@ -200,17 +240,25 @@ export async function runLoop(
 
     lastReview = await kernel.review(actions);
     await ensurePromise(
-      emit({
-        type: "score",
-        value: lastReview.score,
-        passed: lastReview.passed,
-        notes: lastReview.notes,
-      }),
+      emit(
+        {
+          type: "score",
+          value: lastReview.score,
+          passed: lastReview.passed,
+          notes: lastReview.notes,
+        },
+        { spanId: planSpanId, parentSpanId: traceSpanId },
+      ),
     );
 
     if (lastReview.passed) {
       const finalOutputs = await kernel.renderFinal(actions);
-      await ensurePromise(emit({ type: "final", outputs: finalOutputs, reason: "completed" }));
+      await ensurePromise(
+        emit(
+          { type: "final", outputs: finalOutputs, reason: "completed" },
+          { spanId: traceSpanId },
+        ),
+      );
       return {
         actions,
         final: finalOutputs,
@@ -221,11 +269,14 @@ export async function runLoop(
   }
 
   await ensurePromise(
-    emit({
-      type: "log",
-      level: "warn",
-      message: "max iterations reached without passing review",
-    }),
+    emit(
+      {
+        type: "log",
+        level: "warn",
+        message: "max iterations reached without passing review",
+      },
+      { spanId: traceSpanId },
+    ),
   );
   return { actions, reason: "max-iterations", review: lastReview };
 }

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import { createChatKernel, createDefaultToolInvoker } from "../../adapters/core";
-import { runLoop, type CoreEvent } from "../../core/agent";
+import { runLoop, type CoreEvent, type EmitSpanOptions } from "../../core/agent";
 import { EpisodeLogger } from "../../runtime/episode";
 import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../runtime/events";
 
@@ -89,8 +89,8 @@ export default async function handler(
   });
 
   try {
-    const emit = async (event: CoreEvent): Promise<void> => {
-      await bus.publish(wrapCoreEvent(traceId, event));
+    const emit = async (event: CoreEvent, span?: EmitSpanOptions): Promise<void> => {
+      await bus.publish(wrapCoreEvent(traceId, event, span));
     };
     const result = await runLoop(kernel, emit, {
       context: { traceId, input: message },

--- a/tests/logflow.test.ts
+++ b/tests/logflow.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildBranchTree } from "../lib/logflow";
+import type { LogFlowMessage } from "../types/logflow";
+
+describe("logflow branch tree", () => {
+  it("constructs branch tree from span relationships", () => {
+    const messages: LogFlowMessage[] = [
+      {
+        id: "evt-1",
+        ln: 1,
+        span_id: "trace-root",
+        type: "agent.progress",
+        ts: new Date().toISOString(),
+        message: "root progress",
+        data: { step: "perceive" },
+      },
+      {
+        id: "evt-2",
+        ln: 2,
+        span_id: "plan-1",
+        parent_span_id: "trace-root",
+        type: "agent.plan",
+        ts: new Date().toISOString(),
+        message: "plan",
+        data: { revision: 1 },
+      },
+      {
+        id: "evt-3",
+        ln: 3,
+        span_id: "step-a",
+        parent_span_id: "plan-1",
+        type: "agent.progress",
+        ts: new Date().toISOString(),
+        message: "progress",
+        data: { step: "act" },
+      },
+      {
+        id: "evt-4",
+        ln: 4,
+        span_id: "step-a",
+        parent_span_id: "plan-1",
+        type: "agent.tool",
+        ts: new Date().toISOString(),
+        message: "tool",
+        data: { name: "tool.echo" },
+      },
+      {
+        id: "evt-5",
+        ln: 5,
+        span_id: "step-b",
+        parent_span_id: "plan-1",
+        type: "agent.tool",
+        ts: new Date().toISOString(),
+        message: "tool",
+        data: { name: "tool.calc" },
+      },
+    ];
+
+    const tree = buildBranchTree(messages, "plan-1");
+
+    expect(tree).not.toEqual(null);
+    expect(tree?.span_id).toBe("plan-1");
+    expect(tree?.children.map((child) => child.span_id)).toEqual(["step-a", "step-b"]);
+    const stepANode = tree?.children.find((child) => child.span_id === "step-a");
+    expect(stepANode?.events).toHaveLength(2);
+    expect(stepANode?.events.map((evt) => evt.type)).toEqual([
+      "agent.progress",
+      "agent.tool",
+    ]);
+  });
+});

--- a/tests/runLoop.test.ts
+++ b/tests/runLoop.test.ts
@@ -6,11 +6,12 @@ import {
   type ActionOutcome,
   type ToolResult,
   type CoreEvent,
+  type EmitSpanOptions,
 } from "../core/agent";
 
 describe("runLoop", () => {
   it("executes plan steps and resolves when review passes", async () => {
-    const emitted: CoreEvent[] = [];
+    const emitted: Array<{ event: CoreEvent; span?: EmitSpanOptions }> = [];
     const kernel: AgentKernel = {
       async perceive() {
         /* no-op */
@@ -40,25 +41,36 @@ describe("runLoop", () => {
 
     const result = await runLoop(
       kernel,
-      (event: CoreEvent) => {
-        emitted.push(event);
+      (event: CoreEvent, span?: EmitSpanOptions) => {
+        emitted.push({ event, span });
       },
-      { maxIterations: 3 },
+      { maxIterations: 3, context: { traceId: "trace-run-loop", input: "hi" } },
     );
 
     expect(result.reason).toBe("completed");
     expect(result.final).toBe("HI THERE");
-    expect(emitted.some((event) => event.type === "plan")).toBeTruthy();
-    expect(emitted.filter((event) => event.type === "tool")).toHaveLength(2);
-    expect(
-      emitted.some((event) => event.type === "tool" && event.name === "tool.echo"),
-    ).toBeTruthy();
-    const finalEvent = emitted.find((event) => event.type === "final");
-    expect(finalEvent && finalEvent.reason).toBe("completed");
+    expect(emitted.some((item) => item.event.type === "plan")).toBeTruthy();
+    const planEvent = emitted.find((item) => item.event.type === "plan");
+    expect(planEvent?.span?.spanId).toBe("plan-1");
+    expect(planEvent?.span?.parentSpanId).toBe("trace-run-loop");
+    const toolEvents = emitted.filter(
+      (item): item is { event: Extract<CoreEvent, { type: "tool" }>; span?: EmitSpanOptions } =>
+        item.event.type === "tool",
+    );
+    expect(toolEvents).toHaveLength(2);
+    expect(toolEvents.every((item) => item.span?.parentSpanId === "plan-1")).toBe(true);
+    expect(toolEvents.map((item) => item.span?.spanId)).toEqual(["s1", "s2"]);
+    expect(toolEvents.some((item) => item.event.name === "tool.echo")).toBeTruthy();
+    const finalEvent = emitted.find(
+      (item): item is { event: Extract<CoreEvent, { type: "final" }>; span?: EmitSpanOptions } =>
+        item.event.type === "final",
+    );
+    expect(finalEvent?.event.reason).toBe("completed");
+    expect(finalEvent?.span?.spanId).toBe("trace-run-loop");
   });
 
   it("falls back to final output when no plan is produced", async () => {
-    const emitted: CoreEvent[] = [];
+    const emitted: Array<{ event: CoreEvent; span?: EmitSpanOptions }> = [];
     const kernel: AgentKernel = {
       async perceive() {
         /* no-op */
@@ -78,16 +90,65 @@ describe("runLoop", () => {
       },
     };
 
-    const result = await runLoop(kernel, (event: CoreEvent) => {
-      emitted.push(event);
-    });
+    const result = await runLoop(
+      kernel,
+      (event: CoreEvent, span?: EmitSpanOptions) => {
+        emitted.push({ event, span });
+      },
+      { context: { traceId: "trace-fallback", input: "hello" } },
+    );
 
     expect(result.reason).toBe("no-plan");
     expect(result.final).toEqual([{ fallback: true, reason: undefined }]);
-    const finalEvent = emitted.find((event) => event.type === "final");
-    expect(finalEvent && finalEvent.reason).toBe("no-plan");
-    expect(
-      emitted.some((event) => event.type === "tool" && event.name === "llm.chat"),
-    ).toBeTruthy();
+    const finalEvent = emitted.find(
+      (item): item is { event: Extract<CoreEvent, { type: "final" }>; span?: EmitSpanOptions } =>
+        item.event.type === "final",
+    );
+    expect(finalEvent?.event.reason).toBe("no-plan");
+    expect(finalEvent?.span?.spanId).toBe("trace-fallback");
+    const planEvent = emitted.find((item) => item.event.type === "plan");
+    expect(planEvent?.span?.spanId).toBe("plan-1");
+    const toolEvent = emitted.find(
+      (item): item is { event: Extract<CoreEvent, { type: "tool" }>; span?: EmitSpanOptions } =>
+        item.event.type === "tool",
+    );
+    expect(toolEvent?.event.name).toBe("llm.chat");
+    expect(toolEvent?.span).toEqual({ spanId: "fallback-1", parentSpanId: "plan-1" });
+  });
+
+  it("propagates ask span ids when kernel requests clarification", async () => {
+    const emitted: Array<{ event: CoreEvent; span?: EmitSpanOptions }> = [];
+    const kernel: AgentKernel = {
+      async perceive() {
+        /* noop */
+      },
+      async plan(): Promise<Plan> {
+        return {
+          steps: [{ id: "ask-step", op: "tool.ask", args: { question: "?" } }],
+        };
+      },
+      async act(step) {
+        const ask = { question: "Need more info", origin_step: step.id };
+        return { step, result: { ok: true, data: null }, ask } as ActionOutcome;
+      },
+      async review() {
+        return { score: 0, passed: false };
+      },
+      async renderFinal() {
+        return null;
+      },
+    };
+
+    const result = await runLoop(
+      kernel,
+      (event: CoreEvent, span?: EmitSpanOptions) => {
+        emitted.push({ event, span });
+      },
+      { context: { traceId: "trace-ask" } },
+    );
+
+    expect(result.reason).toBe("ask");
+    const askEvent = emitted.find((item) => item.event.type === "ask");
+    expect(askEvent?.span).toEqual({ spanId: "ask-step", parentSpanId: "plan-1" });
   });
 });


### PR DESCRIPTION
## Summary
- enrich `runLoop` emissions with span metadata and expose an `EmitSpanOptions` contract
- thread span information through the API and CLI emitters so episode events carry `span_id` and `parent_span_id`
- require span ids when selecting LogFlow branches and add tests covering span-aware branch construction and runLoop spans

## Testing
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca45b3c514832b85d51167bf7b13fc