### PR TITLE
Log chat messages in run API episodes

### DIFF
--- a/core/agent.ts
+++ b/core/agent.ts
@@ -81,7 +81,15 @@ export type CoreEvent =
   | { type: "ask"; question: string; origin_step?: string }
   | { type: "score"; value: number; passed: boolean; notes?: string[] }
   | { type: "final"; outputs: any; reason?: string }
-  | { type: "log"; level: LogLevel; message: string; detail?: any };
+  | { type: "log"; level: LogLevel; message: string; detail?: any }
+  | {
+      type: "chat.msg";
+      msg_id: string;
+      role: string;
+      text: string;
+      trace_id: string;
+      reply_to?: string;
+    };
 
 export interface AgentContext {
   traceId: string;

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -92,9 +92,54 @@ export default async function handler(
     const emit = async (event: CoreEvent): Promise<void> => {
       await bus.publish(wrapCoreEvent(traceId, event));
     };
+
+    let lastPublishedKey: string | undefined;
+    let lastUserMessageId: string | undefined;
+
+    const publishChatMessage = async (role: string, text: string): Promise<string | undefined> => {
+      const normalizedText = typeof text === "string" ? text : "";
+      const key = `${role}:${normalizedText}`;
+      if (key === lastPublishedKey) {
+        return undefined;
+      }
+      lastPublishedKey = key;
+      const msgId = randomUUID();
+      await emit({
+        type: "chat.msg",
+        msg_id: msgId,
+        role,
+        text: normalizedText,
+        trace_id: traceId,
+      });
+      if (role === "user") {
+        lastUserMessageId = msgId;
+      }
+      return msgId;
+    };
+
+    for (const entry of history) {
+      await publishChatMessage(entry.role, entry.content);
+    }
+
+    if (message) {
+      await publishChatMessage("user", message);
+    }
+
     const result = await runLoop(kernel, emit, {
       context: { traceId, input: message },
     });
+
+    if (result.final !== undefined) {
+      const assistantText = normaliseAssistantText(result.final);
+      await emit({
+        type: "chat.msg",
+        msg_id: randomUUID(),
+        role: "assistant",
+        text: assistantText,
+        trace_id: traceId,
+        ...(lastUserMessageId ? { reply_to: lastUserMessageId } : {}),
+      });
+    }
 
     res.status(200).json({
       trace_id: traceId,
@@ -110,4 +155,27 @@ export default async function handler(
     const message = err instanceof Error ? err.message : "unknown error";
     res.status(500).json({ error: "internal_error", message });
   }
+}
+
+function normaliseAssistantText(finalOutput: unknown): string {
+  if (finalOutput == null) {
+    return "";
+  }
+  if (typeof finalOutput === "string") {
+    return finalOutput;
+  }
+  if (typeof finalOutput === "object") {
+    if (typeof (finalOutput as any).text === "string") {
+      return (finalOutput as any).text;
+    }
+    if (typeof (finalOutput as any).content === "string") {
+      return (finalOutput as any).content;
+    }
+    try {
+      return JSON.stringify(finalOutput);
+    } catch {
+      return String(finalOutput);
+    }
+  }
+  return String(finalOutput);
 }

--- a/tests/runApi.test.ts
+++ b/tests/runApi.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it } from "vitest";
+
+interface MockResponseState {
+  statusCode: number;
+  body?: any;
+}
+
+function createMockResponse(): { res: NextApiResponse; state: MockResponseState } {
+  const state: MockResponseState = { statusCode: 0 };
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      state.body = payload;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  } as unknown as NextApiResponse;
+  return { res, state };
+}
+
+describe("POST /api/run", () => {
+  it("records chat.msg events for history and final reply", async () => {
+    const originalEnv = { ...process.env };
+    const originalFetch = globalThis.fetch;
+    const tempRoot = await mkdtemp(join(tmpdir(), "run-api-"));
+    const originalCwd = process.cwd;
+    (process as any).cwd = () => tempRoot;
+
+    process.env = {
+      ...originalEnv,
+      OPENAI_API_KEY: "test-key",
+      OPENAI_MODEL: "gpt-mock",
+    };
+
+    const fetchMock = async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => ({
+        id: "chatcmpl-test",
+        choices: [
+          {
+            message: { content: "Sure, I can help with that." },
+            finish_reason: "stop",
+          },
+        ],
+        model: "gpt-mock",
+        usage: {},
+      }),
+      text: async () => "",
+    } as Response);
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const { default: handler } = await import("../pages/api/run");
+
+      const history = [
+        { role: "system", content: "You are a helpful agent." },
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+      ];
+
+      const req = {
+        method: "POST",
+        body: { message: "How can you assist me today?", messages: history },
+      } as unknown as NextApiRequest;
+
+      const { res, state } = createMockResponse();
+
+      await handler(req, res);
+
+      expect(state.statusCode).toBe(200);
+      expect(state.body?.trace_id).toBeTruthy();
+
+      const traceId: string = state.body.trace_id;
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const logPath = join(tempRoot, "episodes", `${traceId}.jsonl`);
+      const content = await readFile(logPath, "utf8");
+      const chatEvents = content
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, any>)
+        .filter((event) => event.type === "agent.chat.msg");
+
+      expect(chatEvents).toHaveLength(history.length + 2);
+      const roles = chatEvents.map((event) => event.data.role);
+      expect(roles).toEqual([...history.map((msg) => msg.role), "user", "assistant"]);
+      const assistantEvent = chatEvents.at(-1);
+      expect((assistantEvent?.data.text ?? "").includes("Sure, I can help")).toBe(true);
+      expect(assistantEvent?.data.role).toBe("assistant");
+      expect(assistantEvent?.data.trace_id).toBe(traceId);
+    } finally {
+      (process as any).cwd = originalCwd;
+      process.env = { ...originalEnv };
+      if (originalFetch) {
+        globalThis.fetch = originalFetch;
+      } else {
+        // @ts-expect-error deleting fetch when undefined
+        delete globalThis.fetch;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extend `CoreEvent` to include `chat.msg` entries for conversation logging
- emit chat message events for history, new user input, and assistant replies in the run API handler
- add a regression test ensuring the run API writes matching `chat.msg` events to the episode log

## Testing
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca45b18ba8832ba177aa02fa990908