### PR TITLE
feat: reuse trace id across agent runs

### DIFF
--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -73,7 +73,8 @@ export default async function handler(
   const messageRaw = payload.message ?? payload.input ?? "";
   const message = typeof messageRaw === "string" ? messageRaw : "";
   const history = normaliseHistory(payload.messages);
-  const traceId = randomUUID();
+  const traceIdInput = typeof payload.trace_id === "string" ? payload.trace_id.trim() : undefined;
+  const traceId = traceIdInput && traceIdInput.length > 0 ? traceIdInput : randomUUID();
 
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId, dir: episodesDir });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,13 +29,20 @@ const HomePage: NextPage = () => {
     setChatHistory(nextHistory);
     setIsRunning(true);
     setRunError(null);
-    setTraceId(undefined);
     setLatestResponse(null);
     try {
+      const payload: Record<string, unknown> = {
+        message: prompt,
+        messages: previousHistory,
+      };
+      if (traceId) {
+        payload.trace_id = traceId;
+      }
+
       const response = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: prompt, messages: previousHistory }),
+        body: JSON.stringify(payload),
       });
       const data = await response.json().catch(() => null);
       if (!response.ok || !data) {
@@ -58,7 +65,7 @@ const HomePage: NextPage = () => {
     } finally {
       setIsRunning(false);
     }
-  }, [input, isRunning, chatHistory]);
+  }, [input, isRunning, chatHistory, traceId]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {

--- a/runtime/episode.ts
+++ b/runtime/episode.ts
@@ -58,11 +58,10 @@ export class EpisodeLogger {
     this.queue = this.queue.then(async () => {
       await this.ensureReady();
       const enriched = event;
-      if (typeof enriched.ln === "number") {
-        this.line = Math.max(this.line, enriched.ln);
-      } else {
-        enriched.ln = ++this.line;
-      }
+      const nextLine =
+        typeof enriched.ln === "number" && enriched.ln > this.line ? enriched.ln : this.line + 1;
+      enriched.ln = nextLine;
+      this.line = nextLine;
       const startOffset = enriched.byte_offset ?? this.byteOffset;
       enriched.byte_offset = startOffset;
       const payload = JSON.stringify(enriched) + "\n";

--- a/tests/apiRun.test.ts
+++ b/tests/apiRun.test.ts
@@ -1,0 +1,226 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function createResponseCapture() {
+  let statusCode = 200;
+  let jsonBody: any = null;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      jsonBody = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+  } as unknown as NextApiResponse;
+
+  return {
+    res,
+    get status() {
+      return statusCode;
+    },
+    get body() {
+      return jsonBody;
+    },
+  };
+}
+
+async function readFileWithRetry(path: string, attempts = 10, delayMs = 5): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await readFile(path, "utf8");
+    } catch (error: any) {
+      if (!error || error.code !== "ENOENT") {
+        throw error;
+      }
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function readEventsWithRetry(
+  reader: (traceId: string) => Promise<any[]>,
+  traceId: string,
+  minLength: number,
+  attempts = 20,
+  delayMs = 5,
+) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const events = await reader(traceId);
+      if (events.length >= minLength) {
+        return events;
+      }
+      lastError = new Error("insufficient events");
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function readIndexLinesWithRetry(
+  path: string,
+  expectedLength: number,
+  attempts = 20,
+  delayMs = 5,
+) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const text = await readFile(path, "utf8");
+      const lines = text.split("\n").filter(Boolean);
+      if (lines.length >= expectedLength) {
+        return lines;
+      }
+      lastError = new Error("index incomplete");
+    } catch (error: any) {
+      if (!error || error.code !== "ENOENT") {
+        throw error;
+      }
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+describe("POST /api/run", () => {
+  it("reuses an existing trace when trace_id is provided", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "aos-trace-"));
+    const originalCwd = process.cwd();
+    const previousFetch = global.fetch;
+    const prevApiKey = process.env.OPENAI_API_KEY;
+    const prevModel = process.env.OPENAI_MODEL;
+
+    try {
+      process.chdir(tmpDir);
+      process.env.OPENAI_API_KEY = "test-key";
+      process.env.OPENAI_MODEL = "gpt-test";
+
+      const responses = [
+        {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            id: "call-1",
+            model: "gpt-test",
+            choices: [{ message: { content: "first reply" }, finish_reason: "stop" }],
+          }),
+        },
+        {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            id: "call-2",
+            model: "gpt-test",
+            choices: [{ message: { content: "second reply" }, finish_reason: "stop" }],
+          }),
+        },
+      ];
+      let fetchCalls = 0;
+      (globalThis as any).fetch = async () => {
+        if (fetchCalls >= responses.length) {
+          throw new Error("unexpected fetch call");
+        }
+        const response = responses[fetchCalls];
+        fetchCalls += 1;
+        return response as any;
+      };
+
+      const { default: handler } = await import("../pages/api/run");
+      const { readEpisodeEvents } = await import("../lib/logflow");
+
+      const invoke = async (body: Record<string, unknown>) => {
+        const req = { method: "POST", body } as NextApiRequest;
+        const capture = createResponseCapture();
+        await handler(req, capture.res);
+        return { status: capture.status, body: capture.body };
+      };
+
+      const first = await invoke({ message: "hello there", messages: [] });
+      expect(first.status).toBe(200);
+      expect(typeof first.body?.trace_id).toBe("string");
+      const traceId = first.body.trace_id as string;
+      expect(fetchCalls).toBe(1);
+
+      const episodePath = join(tmpDir, "episodes", `${traceId}.jsonl`);
+      const indexPath = join(tmpDir, "episodes", `${traceId}.index.jsonl`);
+      await readFileWithRetry(episodePath);
+      const initialEvents = await readEventsWithRetry(readEpisodeEvents, traceId, 1);
+      expect(initialEvents.length > 0).toBe(true);
+      const lastInitialLn = initialEvents.at(-1)?.ln ?? 0;
+
+      const chatHistory = [
+        { role: "user", content: "hello there" },
+        {
+          role: "assistant",
+          content:
+            typeof first.body?.result?.text === "string"
+              ? first.body.result.text
+              : JSON.stringify(first.body?.result ?? {}),
+        },
+      ];
+
+      const second = await invoke({
+        trace_id: traceId,
+        message: "and now?",
+        messages: chatHistory,
+      });
+      expect(second.status).toBe(200);
+      expect(second.body?.trace_id).toBe(traceId);
+      expect(fetchCalls).toBe(2);
+
+      await readFileWithRetry(episodePath);
+      const updatedEvents = await readEventsWithRetry(
+        readEpisodeEvents,
+        traceId,
+        initialEvents.length + 1,
+      );
+      expect(updatedEvents.length > initialEvents.length).toBe(true);
+      const lastUpdatedLn = updatedEvents.at(-1)?.ln ?? 0;
+      expect(lastUpdatedLn > lastInitialLn).toBe(true);
+      const indexLines = await readIndexLinesWithRetry(indexPath, updatedEvents.length);
+      expect(indexLines.length).toBe(updatedEvents.length);
+
+      const lineNumbers = updatedEvents.map((event) => event.ln);
+      expect(lineNumbers).toEqual(
+        [...lineNumbers].sort((a, b) => (a ?? 0) - (b ?? 0)),
+      );
+      const finalEvents = updatedEvents.filter((event) => event.type === "agent.final");
+      expect(finalEvents.length >= 1).toBe(true);
+      const lastFinal = finalEvents.at(-1);
+      expect((lastFinal?.data as any)?.reason).toBe("completed");
+    } finally {
+      process.chdir(originalCwd);
+      if (previousFetch) {
+        (globalThis as any).fetch = previousFetch;
+      } else {
+        delete (globalThis as any).fetch;
+      }
+      if (prevApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = prevApiKey;
+      }
+      if (prevModel === undefined) {
+        delete process.env.OPENAI_MODEL;
+      } else {
+        process.env.OPENAI_MODEL = prevModel;
+      }
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- reuse the existing trace id from the UI when rerunning the agent and include it in POST payloads
- allow /api/run to accept an optional trace_id and continue appending to the same episode log with monotonic line numbers
- cover the trace reuse flow with an integration test that exercises two sequential runs and validates LogFlow data

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca45b17430832b8fab40cf4ecc328e