### PR TITLE
Surface chat run failures with assistant metadata

### DIFF
--- a/components/ChatMessageList.tsx
+++ b/components/ChatMessageList.tsx
@@ -11,6 +11,8 @@ export type ChatHistoryMessage = {
   latencyMs?: number | null;
   cost?: number | null;
   error?: string | null;
+  failureReason?: string | null;
+  reviewNotes?: string[] | undefined;
 };
 
 interface ChatMessageListProps {
@@ -154,6 +156,14 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
                             : "Sent"}
                     </span>
                     {message.traceId ? <span>trace_id: {message.traceId}</span> : null}
+                    {message.failureReason ? (
+                      <span>reason: {message.failureReason}</span>
+                    ) : null}
+                    {message.reviewNotes && message.reviewNotes.length > 0 ? (
+                      <span>
+                        review notes: {message.reviewNotes.filter(Boolean).join(" · ")}
+                      </span>
+                    ) : null}
                     {typeof message.latencyMs === "number" ? (
                       <span>latency: {message.latencyMs.toFixed(0)} ms</span>
                     ) : null}

--- a/pages/api/chat/send.ts
+++ b/pages/api/chat/send.ts
@@ -11,6 +11,14 @@ interface ChatSendResponse {
   trace_id: string;
   msg_id: string;
   result: unknown;
+  reason: "completed" | "no-plan" | "ask" | "max-iterations";
+  review?: unknown;
+  message: null | {
+    msg_id: string;
+    ts: string;
+    text?: string;
+    error?: string;
+  };
   events: Array<{
     ts: string;
     type: string;
@@ -25,6 +33,13 @@ type RequestMessage = { role: string; content: string };
 type ChatSendError = { error: string; message: string };
 
 type ParsedBody = Record<string, unknown>;
+
+type AssistantMessagePayload = {
+  msg_id: string;
+  ts: string;
+  text?: string;
+  error?: string;
+};
 
 function parseRequestBody(req: NextApiRequest): ParsedBody {
   const { body } = req;
@@ -85,6 +100,79 @@ function normaliseReplyTo(raw: unknown): string | null {
     return trimmed ? trimmed : null;
   }
   return null;
+}
+
+type RunReason = "completed" | "no-plan" | "ask" | "max-iterations";
+
+function normaliseAssistantMessage(
+  finalOutput: unknown,
+  reason: RunReason,
+  review: unknown,
+): AssistantMessagePayload | null {
+  const base: AssistantMessagePayload = {
+    msg_id: randomUUID(),
+    ts: new Date().toISOString(),
+  };
+
+  if (finalOutput == null) {
+    if (reason === "completed") {
+      return null;
+    }
+
+    const reviewNotes = Array.isArray((review as any)?.notes)
+      ? ((review as any).notes as unknown[]).filter((note): note is string => typeof note === "string")
+      : [];
+    const noteSummary = reviewNotes.join(" · ");
+    const message = noteSummary || `run ended with reason: ${reason}`;
+    return { ...base, error: message };
+  }
+
+  if (typeof finalOutput === "string") {
+    const text = finalOutput.trim();
+    if (!text) {
+      return { ...base, text: "" };
+    }
+    return { ...base, text };
+  }
+
+  if (typeof finalOutput === "object") {
+    const record = finalOutput as Record<string, unknown>;
+    const msgId = typeof record.msg_id === "string" && record.msg_id.trim()
+      ? record.msg_id.trim()
+      : base.msg_id;
+    const ts = typeof record.ts === "string" && record.ts.trim() ? record.ts : base.ts;
+
+    const textValue = typeof record.text === "string" ? record.text : undefined;
+    const errorValue = record.error;
+    const errorText =
+      typeof errorValue === "string"
+        ? errorValue
+        : errorValue && typeof errorValue === "object"
+          ? typeof (errorValue as any).message === "string"
+            ? (errorValue as any).message
+            : JSON.stringify(errorValue)
+          : undefined;
+
+    if (textValue || errorText) {
+      return {
+        msg_id: msgId,
+        ts,
+        ...(textValue ? { text: textValue } : {}),
+        ...(errorText ? { error: errorText } : {}),
+      };
+    }
+
+    return {
+      msg_id: msgId,
+      ts,
+      text: JSON.stringify(finalOutput),
+    };
+  }
+
+  return {
+    ...base,
+    text: String(finalOutput),
+  };
 }
 
 export default async function handler(
@@ -161,10 +249,15 @@ export default async function handler(
       context: { traceId, input: text, metadata: { history } },
     });
 
+    const assistantMessage = normaliseAssistantMessage(result.final, result.reason, result.review);
+
     res.status(200).json({
       trace_id: traceId,
       msg_id: msgId,
       result: result.final,
+      reason: result.reason,
+      review: result.review,
+      message: assistantMessage,
       events: events.map((evt: EventEnvelope) => ({
         ts: evt.ts,
         type: evt.type,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,13 +13,16 @@ interface ChatSendResponse {
     text?: string;
     ts?: string;
     trace_id?: string;
+    error?: string;
   };
-  result?: { text?: string; msg_id?: string; ts?: string };
-  output?: { text?: string; msg_id?: string; ts?: string };
-  final?: { text?: string; msg_id?: string; ts?: string };
+  result?: { text?: string; msg_id?: string; ts?: string; error?: string };
+  output?: { text?: string; msg_id?: string; ts?: string; error?: string };
+  final?: { text?: string; msg_id?: string; ts?: string; error?: string };
   metrics?: { latency_ms?: number; cost?: number };
   error?: { message?: string } | null;
   message_error?: string;
+  reason?: "completed" | "no-plan" | "ask" | "max-iterations";
+  review?: { notes?: string[]; score?: number; passed?: boolean } | null;
 }
 
 const generateLocalId = (): string => {
@@ -63,6 +66,10 @@ const HomePage: NextPage = () => {
       ...(typeof message.latencyMs === "number" ? { latency_ms: message.latencyMs } : {}),
       ...(typeof message.cost === "number" ? { cost: message.cost } : {}),
       ...(message.error ? { error: message.error } : {}),
+      ...(message.failureReason ? { failure_reason: message.failureReason } : {}),
+      ...(message.reviewNotes && message.reviewNotes.length
+        ? { review_notes: message.reviewNotes }
+        : {}),
     }));
 
     if (draftInput) {
@@ -167,21 +174,28 @@ const HomePage: NextPage = () => {
         msg_id?: string;
         ts?: string;
         trace_id?: string;
+        error?: string;
       };
+      const isCompleted = (data.reason ?? "completed") === "completed";
+      const assistantMsgId = assistantPayload.msg_id ?? data.msg_id ?? generateLocalId();
+      const assistantTs = assistantPayload.ts ?? new Date().toISOString();
+      const assistantErrorText =
+        typeof assistantPayload.error === "string"
+          ? assistantPayload.error
+          : undefined;
       const assistantContentRaw =
         typeof assistantPayload.content === "string"
           ? assistantPayload.content
           : typeof assistantPayload.text === "string"
             ? assistantPayload.text
-            : assistantPayload && typeof assistantPayload === "object"
-              ? JSON.stringify(assistantPayload)
-              : "";
+            : assistantErrorText ??
+              (assistantPayload && typeof assistantPayload === "object"
+                ? JSON.stringify(assistantPayload)
+                : "");
       const assistantContent =
         typeof assistantContentRaw === "string" && assistantContentRaw.length > 0
           ? assistantContentRaw
-          : "";
-      const assistantMsgId = assistantPayload.msg_id ?? data.msg_id ?? generateLocalId();
-      const assistantTs = assistantPayload.ts ?? new Date().toISOString();
+          : assistantErrorText ?? "";
 
       setChatHistory((history) => {
         const updatedHistory: ChatHistoryMessage[] = history.map((message) =>
@@ -200,10 +214,13 @@ const HomePage: NextPage = () => {
           role: "assistant",
           content: assistantContent,
           ts: assistantTs,
-          status: "done" as const,
+          status: isCompleted ? ("done" as const) : ("error" as const),
           traceId: resolvedTraceId,
           latencyMs: typeof computedLatency === "number" ? computedLatency : null,
           cost: typeof computedCost === "number" ? computedCost : null,
+          error: isCompleted ? null : assistantContent || assistantErrorText || null,
+          failureReason: isCompleted ? null : data.reason ?? null,
+          reviewNotes: Array.isArray(data.review?.notes) ? data.review?.notes ?? [] : undefined,
         };
         return [...updatedHistory, assistantMessage];
       });

--- a/tests/chatMessageList.test.tsx
+++ b/tests/chatMessageList.test.tsx
@@ -47,4 +47,35 @@ describe("ChatMessageList", () => {
     expect(html.includes("cost: 0.0042")).toBe(true);
     expect(html.includes('data-role="status"')).toBe(true);
   });
+
+  it("highlights failed assistant messages with review metadata", () => {
+    const messages: ChatHistoryMessage[] = [
+      {
+        id: "u-1",
+        role: "user",
+        content: "ping",
+        ts: new Date("2023-06-01T00:00:00Z").toISOString(),
+        status: "done",
+        msgId: "msg-user-1",
+      },
+      {
+        id: "a-err",
+        role: "assistant",
+        content: "tool invocation failed",
+        ts: new Date("2023-06-01T00:00:01Z").toISOString(),
+        status: "error",
+        msgId: "msg-assistant-err",
+        error: "tool invocation failed",
+        failureReason: "max-iterations",
+        reviewNotes: ["tool invocation failed"],
+      },
+    ];
+
+    const html = renderToStaticMarkup(<ChatMessageList messages={messages} />);
+
+    expect(html.includes('data-status="error"')).toBe(true);
+    expect(html.includes("tool invocation failed")).toBe(true);
+    expect(html.includes("reason: max-iterations")).toBe(true);
+    expect(html.includes("review notes: tool invocation failed")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- include run-loop reason, review metadata, and a normalized assistant message payload in the chat send API response so failures surface with readable text
- update the chat page to honor the new response fields, generate assistant IDs when missing, and persist failure notes in saved transcripts while flagging unsuccessful runs
- expose failure reasons and review notes in the chat message list UI and cover the error rendering path with a regression test

## Testing
- pnpm test
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ca7893fa84832bb8044a54b84f01b0