### PR TITLE
Log assistant chat messages with responses

### DIFF
--- a/pages/api/chat/send.ts
+++ b/pages/api/chat/send.ts
@@ -11,6 +11,15 @@ interface ChatSendResponse {
   trace_id: string;
   msg_id: string;
   result: unknown;
+  message: {
+    msg_id: string;
+    role: "assistant";
+    trace_id: string;
+    reply_to: string;
+    text?: string;
+    error?: unknown;
+    raw?: unknown;
+  };
   events: Array<{
     ts: string;
     type: string;
@@ -161,10 +170,55 @@ export default async function handler(
       context: { traceId, input: text, metadata: { history } },
     });
 
+    const assistantMsgId = randomUUID();
+    const assistantPayload: {
+      msg_id: string;
+      role: "assistant";
+      trace_id: string;
+      reply_to: string;
+      text?: string;
+      error?: unknown;
+      raw?: unknown;
+    } = {
+      msg_id: assistantMsgId,
+      role: "assistant",
+      trace_id: traceId,
+      reply_to: msgId,
+    };
+
+    const final = result?.final;
+    if (final && typeof final === "object") {
+      if (typeof (final as any).text === "string") {
+        assistantPayload.text = (final as any).text;
+      }
+      if ("error" in final) {
+        assistantPayload.error = (final as any).error;
+      }
+      if ("raw" in final) {
+        assistantPayload.raw = (final as any).raw;
+      }
+    } else if (typeof final === "string") {
+      assistantPayload.text = final;
+    } else if (final != null) {
+      assistantPayload.text = JSON.stringify(final);
+    } else if (result?.reason) {
+      assistantPayload.error = { reason: result.reason };
+    }
+
+    await bus.publish({
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: "chat.msg",
+      version: 1,
+      trace_id: traceId,
+      data: assistantPayload,
+    });
+
     res.status(200).json({
       trace_id: traceId,
       msg_id: msgId,
       result: result.final,
+      message: assistantPayload,
       events: events.map((evt: EventEnvelope) => ({
         ts: evt.ts,
         type: evt.type,

--- a/tests/chatSendApi.test.ts
+++ b/tests/chatSendApi.test.ts
@@ -115,22 +115,36 @@ describe("POST /api/chat/send", () => {
     expect(record.body === null).toBe(false);
     const responseTraceId = record.body?.trace_id as string;
     const responseMsgId = record.body?.msg_id as string;
+    const assistantMessage = record.body?.message;
     expect(typeof responseTraceId).toBe("string");
     expect(typeof responseMsgId).toBe("string");
+    expect(typeof assistantMessage?.msg_id).toBe("string");
+    expect(assistantMessage?.role).toBe("assistant");
+    expect(assistantMessage?.trace_id).toBe(responseTraceId);
+    expect(assistantMessage?.reply_to).toBe(responseMsgId);
     expect(Array.isArray(record.body?.events)).toBe(true);
     expect(record.body?.events?.[0]?.type).toBe("chat.msg");
 
     const events = await parseEpisode(responseTraceId);
     expect(events.length > 0).toBe(true);
-    const first = events[0];
-    expect(first.type).toBe("chat.msg");
-    expect(first.trace_id).toBe(responseTraceId);
-    expect(first.data).toMatchObject({
+    const chatEvents = events.filter((event) => event.type === "chat.msg");
+    expect(chatEvents).toHaveLength(2);
+    const [userEvent, assistantEvent] = chatEvents;
+    expect(userEvent.trace_id).toBe(responseTraceId);
+    expect(userEvent.data).toMatchObject({
       msg_id: responseMsgId,
       role: "user",
       text: "hello",
       trace_id: responseTraceId,
       reply_to: null,
+    });
+    expect(assistantEvent.trace_id).toBe(responseTraceId);
+    expect(assistantEvent.data).toMatchObject({
+      msg_id: assistantMessage?.msg_id,
+      role: "assistant",
+      text: "ok",
+      trace_id: responseTraceId,
+      reply_to: responseMsgId,
     });
 
     const indexContent = await readFile(
@@ -145,16 +159,38 @@ describe("POST /api/chat/send", () => {
     expect(first.statusCode).toBe(200);
     const traceId = first.body?.trace_id as string;
     expect(typeof traceId).toBe("string");
+    const firstAssistant = first.body?.message;
+    expect(firstAssistant?.role).toBe("assistant");
+
+    const initialEvents = await parseEpisode(traceId);
+    const initialChatMessages = initialEvents.filter((evt) => evt.type === "chat.msg");
+    expect(initialChatMessages).toHaveLength(2);
+    expect(initialChatMessages.map((evt) => evt.data.role)).toEqual(["user", "assistant"]);
 
     const second = await invokeHandler({ text: "follow up", trace_id: traceId });
     expect(second.statusCode).toBe(200);
     expect(second.body?.trace_id).toBe(traceId);
+    const secondMsgId = second.body?.msg_id as string;
+    expect(typeof secondMsgId).toBe("string");
+    expect(second.body?.message?.reply_to).toBe(secondMsgId);
 
     const events = await parseEpisode(traceId);
     const chatMessages = events.filter((evt) => evt.type === "chat.msg");
-    expect(chatMessages.length >= 2).toBe(true);
-    const latest = chatMessages.at(-1);
-    expect(latest?.data?.text).toBe("follow up");
-    expect(latest?.data?.trace_id).toBe(traceId);
+    expect(chatMessages).toHaveLength(4);
+    const latestPair = chatMessages.slice(-2);
+    const [latestUser, latestAssistant] = latestPair;
+    expect(latestUser.data).toMatchObject({
+      role: "user",
+      text: "follow up",
+      trace_id: traceId,
+      reply_to: null,
+    });
+    expect(typeof latestUser.data.msg_id).toBe("string");
+    expect(latestAssistant.data).toMatchObject({
+      role: "assistant",
+      trace_id: traceId,
+      reply_to: latestUser.data.msg_id,
+    });
+    expect(latestAssistant.data.msg_id).toBe(second.body?.message?.msg_id);
   });
 });


### PR DESCRIPTION
## Summary
- publish an assistant chat.msg event when chat/send produces a reply and return the payload in the API response
- extend chat send API tests to assert both user and assistant chat messages are stored per run

## Testing
- pnpm test --filter chatSendApi

------
https://chatgpt.com/codex/tasks/task_e_68ca78895a38832ba28a7b1d7796407c