### PR TITLE
Handle non-retryable tool failures gracefully

### DIFF
--- a/core/agent.ts
+++ b/core/agent.ts
@@ -120,7 +120,7 @@ export interface RunLoopOptions {
 export interface RunLoopResult {
   actions: ActionOutcome[];
   final?: any;
-  reason: "completed" | "no-plan" | "ask" | "max-iterations";
+  reason: "completed" | "no-plan" | "ask" | "max-iterations" | "non-retryable-error";
   review?: ReviewResult;
 }
 
@@ -225,6 +225,28 @@ export async function runLoop(
           { spanId: step.id, parentSpanId: planSpanId },
         ),
       );
+
+      if (!outcome.result.ok && outcome.result.retryable === false) {
+        await ensurePromise(
+          emit(
+            {
+              type: "log",
+              level: "error",
+              message: "non-retryable tool error encountered",
+              detail: { step: step.id, error: outcome.result },
+            },
+            { spanId: step.id, parentSpanId: planSpanId },
+          ),
+        );
+        const finalOutputs = await kernel.renderFinal(actions);
+        await ensurePromise(
+          emit(
+            { type: "final", outputs: finalOutputs, reason: "non-retryable-error" },
+            { spanId: traceSpanId },
+          ),
+        );
+        return { actions, final: finalOutputs, reason: "non-retryable-error" };
+      }
 
       if (outcome.ask) {
         await ensurePromise(

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -3,13 +3,19 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
 import { createChatKernel, createDefaultToolInvoker } from "../../adapters/core";
-import { runLoop, type CoreEvent, type EmitSpanOptions } from "../../core/agent";
+import {
+  runLoop,
+  type CoreEvent,
+  type EmitSpanOptions,
+  type RunLoopResult,
+} from "../../core/agent";
 import { EpisodeLogger } from "../../runtime/episode";
 import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../runtime/events";
 
 interface RunResponse {
   trace_id: string;
   result: unknown;
+  reason: RunResultReason;
   events: Array<{
     ts: string;
     type: string;
@@ -55,6 +61,8 @@ function normaliseHistory(raw: unknown): RequestMessage[] {
   }
   return history;
 }
+
+type RunResultReason = RunLoopResult["reason"];
 
 export default async function handler(
   req: NextApiRequest,
@@ -157,6 +165,7 @@ export default async function handler(
     res.status(200).json({
       trace_id: traceId,
       result: result.final,
+      reason: result.reason,
       events: events.map((evt) => ({
         ts: evt.ts,
         type: evt.type,

--- a/tests/runLoop.test.ts
+++ b/tests/runLoop.test.ts
@@ -3,6 +3,7 @@ import {
   runLoop,
   type AgentKernel,
   type Plan,
+  type PlanStep,
   type ActionOutcome,
   type ToolResult,
   type CoreEvent,
@@ -160,5 +161,77 @@ describe("runLoop", () => {
     expect(result.reason).toBe("ask");
     const askEvent = emitted.find((item) => item.event.type === "ask");
     expect(askEvent?.span).toEqual({ spanId: "ask-step", parentSpanId: "plan-1" });
+  });
+
+  it("terminates when a tool returns a non-retryable error", async () => {
+    const emitted: EmittedEntry[] = [];
+    const actCalls: PlanStep[] = [];
+    const act = async (step: PlanStep): Promise<ActionOutcome> => {
+      actCalls.push(step);
+      if (step.id === "s1") {
+        return {
+          step,
+          result: { ok: false, code: "fatal", message: "boom", retryable: false },
+        } satisfies ActionOutcome;
+      }
+      return {
+        step,
+        result: { ok: true, data: "should-not-run" },
+      } satisfies ActionOutcome;
+    };
+
+    let renderFinalCalls = 0;
+    const renderFinal = async () => {
+      renderFinalCalls += 1;
+      return { text: "failed" };
+    };
+    let reviewCalled = false;
+    const review = async () => {
+      reviewCalled = true;
+      return { score: 0, passed: false };
+    };
+
+    const kernel: AgentKernel = {
+      async perceive() {
+        /* no-op */
+      },
+      async plan(): Promise<Plan> {
+        return {
+          steps: [
+            { id: "s1", op: "tool.fail", args: {} },
+            { id: "s2", op: "tool.next", args: {} },
+          ],
+        } satisfies Plan;
+      },
+      act: act as AgentKernel["act"],
+      review: review as AgentKernel["review"],
+      renderFinal: renderFinal as AgentKernel["renderFinal"],
+    };
+
+    const result = await runLoop(
+      kernel,
+      (event: CoreEvent, span?: EmitSpanOptions) => {
+        emitted.push({ event, span });
+      },
+      { context: { traceId: "trace-non-retry" } },
+    );
+
+    expect(result.reason).toBe("non-retryable-error");
+    expect(renderFinalCalls).toBe(1);
+    expect(reviewCalled).toBe(false);
+    expect(actCalls).toHaveLength(1);
+
+    const toolEvents = emitted.filter(
+      (item): item is { event: Extract<CoreEvent, { type: "tool" }>; span?: EmitSpanOptions } =>
+        item.event.type === "tool",
+    );
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.event.result?.ok).toBe(false);
+
+    const planEvents = emitted.filter((item) => item.event.type === "plan");
+    expect(planEvents).toHaveLength(1);
+
+    const finalEvent = emitted.find(isFinalEvent);
+    expect(finalEvent?.event.reason).toBe("non-retryable-error");
   });
 });


### PR DESCRIPTION
## Summary
- stop the run loop when a tool reports a non-retryable error and emit a final event with the new termination reason
- surface the run loop termination reason in the API response for downstream consumers
- cover the non-retryable branch in the run loop test suite

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca788c9910832b92b35db5dc7bd506