### PR TITLE
feat: enforce chinese defaults for chat kernel

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -14,6 +14,11 @@ import {
 import type { ChatMessage } from "../types/chat";
 import { buildChatCompletionsUrl, loadLLMConfig } from "../config/llm";
 
+export const DEFAULT_SYSTEM_PROMPT = {
+  role: "system",
+  content: "你是一位中文助手，请始终使用简体中文回答。",
+} satisfies ChatMessage;
+
 async function handleHttpGet(args: any): Promise<ToolResult> {
   const url = args?.url;
   if (!url) {
@@ -229,9 +234,19 @@ class ChatKernel implements AgentKernel {
   private readonly history: ChatMessage[];
 
   constructor(private readonly options: ChatKernelOptions) {
-    this.history = Array.isArray(options.history)
+    const baseHistory = Array.isArray(options.history)
       ? options.history.map((msg) => ({ role: msg.role, content: msg.content }))
       : [];
+
+    const filteredHistory = baseHistory.filter(
+      (msg) =>
+        !(
+          msg.role === DEFAULT_SYSTEM_PROMPT.role &&
+          msg.content === DEFAULT_SYSTEM_PROMPT.content
+        ),
+    );
+
+    this.history = [DEFAULT_SYSTEM_PROMPT, ...filteredHistory];
   }
 
   async perceive(): Promise<void> {

--- a/config/llm.ts
+++ b/config/llm.ts
@@ -1,4 +1,5 @@
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1/";
+export const DEFAULT_CHINESE_MODEL = "gpt-4o-mini";
 
 export interface LLMConfig {
   baseUrl: string;
@@ -22,14 +23,17 @@ export function loadLLMConfig(options: LoadLLMConfigOptions = {}): LLMConfig {
   const env = options.env ?? process.env;
   const baseUrlRaw = env.OPENAI_BASE_URL?.trim();
   const apiKey = env.OPENAI_API_KEY?.trim();
-  const model = env.OPENAI_MODEL?.trim();
+  const providedModel = env.OPENAI_MODEL?.trim();
   const organization = env.OPENAI_ORG?.trim();
 
   if (!apiKey) {
-    throw new LLMConfigError("OPENAI_API_KEY is not configured");
+    throw new LLMConfigError("请在环境变量 OPENAI_API_KEY 中配置访问密钥。");
   }
+
+  const model = providedModel || DEFAULT_CHINESE_MODEL;
+
   if (!model) {
-    throw new LLMConfigError("OPENAI_MODEL is not configured");
+    throw new LLMConfigError("未能确定可用的中文模型，请设置 OPENAI_MODEL。");
   }
 
   const baseUrl = normaliseBaseUrl(baseUrlRaw || DEFAULT_OPENAI_BASE_URL);

--- a/pages/api/chat/send.ts
+++ b/pages/api/chat/send.ts
@@ -93,7 +93,9 @@ export default async function handler(
 ) {
   if (req.method !== "POST") {
     res.setHeader("Allow", "POST");
-    res.status(405).json({ error: "method_not_allowed", message: "only POST is allowed" });
+    res
+      .status(405)
+      .json({ error: "method_not_allowed", message: "仅支持 POST 请求" });
     return;
   }
 
@@ -101,7 +103,9 @@ export default async function handler(
   try {
     payload = parseRequestBody(req);
   } catch {
-    res.status(400).json({ error: "invalid_json", message: "request body must be valid json" });
+    res
+      .status(400)
+      .json({ error: "invalid_json", message: "请求体必须是合法的 JSON" });
     return;
   }
 
@@ -109,7 +113,7 @@ export default async function handler(
   const text = normaliseText(payload.text ?? payload.message ?? payload.input);
 
   if (!text.trim()) {
-    res.status(400).json({ error: "invalid_input", message: "text is required" });
+    res.status(400).json({ error: "invalid_input", message: "必须提供文本内容" });
     return;
   }
 
@@ -176,6 +180,8 @@ export default async function handler(
   } catch (err) {
     console.error("chat send request failed", err);
     const message = err instanceof Error ? err.message : "unknown error";
-    res.status(500).json({ error: "internal_error", message });
+    res
+      .status(500)
+      .json({ error: "internal_error", message: `服务器内部错误：${message}` });
   }
 }

--- a/tests/chatKernel.test.ts
+++ b/tests/chatKernel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createChatKernel } from "../adapters/core";
+import { DEFAULT_SYSTEM_PROMPT, createChatKernel } from "../adapters/core";
 import type { ToolInvoker } from "../core/agent";
 
 describe("createChatKernel", () => {
@@ -31,7 +31,11 @@ describe("createChatKernel", () => {
 
     const step = nonNullPlan.steps[0];
     expect(step.args).toEqual({
-      messages: [...history, { role: "user", content: "what's next?" }],
+      messages: [
+        DEFAULT_SYSTEM_PROMPT,
+        ...history,
+        { role: "user", content: "what's next?" },
+      ],
     });
 
     const outcome = await kernel.act(step);
@@ -41,5 +45,31 @@ describe("createChatKernel", () => {
       args: step.args,
     });
     expect(outcome.result.ok).toBe(true);
+  });
+  it("does not duplicate the system prompt when planning multiple times", async () => {
+    const toolInvoker: ToolInvoker = async () => ({
+      ok: true,
+      data: { content: "ack" },
+    });
+
+    const kernel = createChatKernel({
+      message: "第一轮", 
+      traceId: "trace-dup", 
+      toolInvoker,
+    });
+
+    await kernel.perceive({ traceId: "trace-dup" });
+    const firstPlan = await kernel.plan();
+    const secondPlan = await kernel.plan();
+
+    const extractMessages = (plan: any) => plan.steps[0]?.args?.messages ?? [];
+
+    const firstMessages = extractMessages(firstPlan);
+    const secondMessages = extractMessages(secondPlan);
+
+    expect(firstMessages.filter((msg: any) => msg.role === "system")).toHaveLength(1);
+    expect(secondMessages.filter((msg: any) => msg.role === "system")).toHaveLength(1);
+    expect(firstMessages[0]).toEqual(DEFAULT_SYSTEM_PROMPT);
+    expect(secondMessages[0]).toEqual(DEFAULT_SYSTEM_PROMPT);
   });
 });

--- a/tests/chatSendApi.test.ts
+++ b/tests/chatSendApi.test.ts
@@ -157,4 +157,25 @@ describe("POST /api/chat/send", () => {
     expect(latest?.data?.text).toBe("follow up");
     expect(latest?.data?.trace_id).toBe(traceId);
   });
+
+  it("returns chinese error messages for unsupported methods", async () => {
+    const req = { method: "GET" } as unknown as NextApiRequest;
+    const { res, record } = createMockResponse();
+    await handler(req, res);
+
+    expect(record.statusCode).toBe(405);
+    expect(record.body).toEqual({
+      error: "method_not_allowed",
+      message: "仅支持 POST 请求",
+    });
+  });
+
+  it("validates missing text with chinese feedback", async () => {
+    const record = await invokeHandler({});
+    expect(record.statusCode).toBe(400);
+    expect(record.body).toEqual({
+      error: "invalid_input",
+      message: "必须提供文本内容",
+    });
+  });
 });

--- a/tests/llmConfig.test.ts
+++ b/tests/llmConfig.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_CHINESE_MODEL,
+  LLMConfigError,
+  loadLLMConfig,
+} from "../config/llm";
+
+describe("loadLLMConfig", () => {
+  it("falls back to the default chinese model when OPENAI_MODEL is missing", () => {
+    const env = {
+      OPENAI_API_KEY: "key-123",
+    } as NodeJS.ProcessEnv;
+
+    const config = loadLLMConfig({ env });
+    expect(config.model).toBe(DEFAULT_CHINESE_MODEL);
+  });
+
+  it("throws a chinese error message when api key is missing", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    try {
+      loadLLMConfig({ env });
+      throw new Error("expected loadLLMConfig to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(LLMConfigError);
+      expect((error as Error).message).toBe("请在环境变量 OPENAI_API_KEY 中配置访问密钥。");
+    }
+  });
+
+  it("uses the provided model when available", () => {
+    const env = {
+      OPENAI_API_KEY: "key-abc",
+      OPENAI_MODEL: "custom-zh-model",
+    } as NodeJS.ProcessEnv;
+
+    const config = loadLLMConfig({ env });
+    expect(config.model).toBe("custom-zh-model");
+  });
+});


### PR DESCRIPTION
## Summary
- prepend the chat kernel history with a single Chinese system prompt to avoid duplicate injections
- localize chat API validation and server error responses to Chinese and add coverage
- add a Chinese-default LLM configuration fallback with localized validation and dedicated tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7b3608ac832b9d5f7a9ba3b44896