### PR TITLE
feat: add i18n support for chat surfaces

### DIFF
--- a/components/ChatMessageList.tsx
+++ b/components/ChatMessageList.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
 
+import { useI18n } from "../lib/i18n/index";
+
 export type ChatHistoryMessage = {
   id: string;
   role: "user" | "assistant" | "system";
@@ -44,14 +46,14 @@ const groupMessagesByRole = (messages: ChatHistoryMessage[]) => {
   return groups;
 };
 
-const formatTimestamp = (ts: string): string => {
+const formatTimestamp = (ts: string, locale: string): string => {
   if (!ts) return "";
   try {
     const date = new Date(ts);
     if (Number.isNaN(date.getTime())) {
       return ts;
     }
-    return date.toLocaleTimeString(undefined, {
+    return date.toLocaleTimeString(locale, {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
@@ -62,6 +64,7 @@ const formatTimestamp = (ts: string): string => {
 };
 
 const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false }) => {
+  const { locale, t } = useI18n();
   const groups = groupMessagesByRole(messages);
 
   return (
@@ -79,7 +82,7 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
       }}
     >
       {messages.length === 0 ? (
-        <p style={{ margin: 0, color: "#94a3b8" }}>No messages yet.</p>
+        <p style={{ margin: 0, color: "#94a3b8" }}>{t("chat.empty")}</p>
       ) : (
         groups.map((group) => {
           const style = bubbleStyles[group.role];
@@ -107,7 +110,7 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
                   color: "#64748b",
                 }}
               >
-                {group.role}
+                {t(`roles.${group.role}`)}
               </span>
               {group.items.map((message) => (
                 <article
@@ -141,24 +144,34 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
                     }}
                   >
                     <span>
-                      {message.msgId ? `msg_id: ${message.msgId}` : `local_id: ${message.id}`}
+                      {message.msgId
+                        ? `${t("chat.message.labels.msgId")}: ${message.msgId}`
+                        : `${t("chat.message.labels.localId")}: ${message.id}`}
                     </span>
-                    <span>{formatTimestamp(message.ts)}</span>
+                    <span>{formatTimestamp(message.ts, locale)}</span>
                     <span>
                       {message.status === "error"
-                        ? (message.error ?? "Delivery failed")
+                        ? (message.error ?? t("chat.message.status.error"))
                         : message.status === "pending"
-                          ? "Pending"
+                          ? t("chat.message.status.pending")
                           : message.status === "done"
-                            ? "Delivered"
-                            : "Sent"}
+                            ? t("chat.message.status.done")
+                            : t("chat.message.status.sent")}
                     </span>
-                    {message.traceId ? <span>trace_id: {message.traceId}</span> : null}
+                    {message.traceId ? (
+                      <span>
+                        {t("chat.message.labels.traceId")}: {message.traceId}
+                      </span>
+                    ) : null}
                     {typeof message.latencyMs === "number" ? (
-                      <span>latency: {message.latencyMs.toFixed(0)} ms</span>
+                      <span>
+                        {t("chat.message.labels.latency")}: {message.latencyMs.toFixed(0)} ms
+                      </span>
                     ) : null}
                     {typeof message.cost === "number" ? (
-                      <span>cost: {message.cost.toFixed(4)}</span>
+                      <span>
+                        {t("chat.message.labels.cost")}: {message.cost.toFixed(4)}
+                      </span>
                     ) : null}
                   </footer>
                 </article>
@@ -176,7 +189,7 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
             fontStyle: "italic",
           }}
         >
-          Generating response…
+          {t("chat.generating")}
         </div>
       ) : null}
     </div>

--- a/config/i18n.d.ts
+++ b/config/i18n.d.ts
@@ -1,0 +1,6 @@
+export const SUPPORTED_LOCALES: readonly ["zh-CN", "en"];
+export const DEFAULT_LOCALE: "zh-CN";
+export const I18N_CONFIG: {
+  locales: typeof SUPPORTED_LOCALES;
+  defaultLocale: typeof DEFAULT_LOCALE;
+};

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -1,0 +1,7 @@
+export const SUPPORTED_LOCALES = ["zh-CN", "en"];
+export const DEFAULT_LOCALE = "zh-CN";
+
+export const I18N_CONFIG = {
+  locales: SUPPORTED_LOCALES,
+  defaultLocale: DEFAULT_LOCALE,
+};

--- a/lib/i18n/I18nProvider.tsx
+++ b/lib/i18n/I18nProvider.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useMemo } from "react";
+import type { FC, ReactNode } from "react";
+
+import { FALLBACK_LOCALE, type SupportedLocale } from "./config";
+import enMessages from "../../locales/en/common.json" with { type: "json" };
+import zhCNMessages from "../../locales/zh-CN/common.json" with { type: "json" };
+
+type MessageDictionary = typeof zhCNMessages;
+
+type MessageRecord = Record<SupportedLocale, MessageDictionary>;
+
+type InterpolationValues = Record<string, string | number>;
+
+type I18nContextValue = {
+  locale: SupportedLocale;
+  messages: MessageDictionary;
+  t: (key: string, values?: InterpolationValues) => string;
+};
+
+const messageStore: MessageRecord = {
+  "zh-CN": zhCNMessages,
+  en: enMessages,
+};
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: FALLBACK_LOCALE,
+  messages: messageStore[FALLBACK_LOCALE],
+  t: (key: string) => key,
+});
+
+const resolveMessage = (messages: MessageDictionary, key: string): string | undefined => {
+  return key.split(".").reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === "object" && part in acc) {
+      return (acc as Record<string, unknown>)[part];
+    }
+    return undefined;
+  }, messages) as string | undefined;
+};
+
+const interpolate = (template: string, values: InterpolationValues | undefined) => {
+  if (!values) {
+    return template;
+  }
+  return template.replace(/\{(\w+)\}/g, (match, token) => {
+    const value = values[token];
+    return value === undefined || value === null ? match : String(value);
+  });
+};
+
+export interface I18nProviderProps {
+  locale?: SupportedLocale | string | null;
+  children: ReactNode;
+}
+
+export const I18nProvider: FC<I18nProviderProps> = ({ locale, children }) => {
+  const targetLocale: SupportedLocale =
+    locale && locale in messageStore ? (locale as SupportedLocale) : FALLBACK_LOCALE;
+
+  const value = useMemo<I18nContextValue>(() => {
+    const messages = messageStore[targetLocale] ?? messageStore[FALLBACK_LOCALE];
+    const translate = (key: string, values?: InterpolationValues) => {
+      const resolved = resolveMessage(messages, key);
+      if (typeof resolved === "string") {
+        return interpolate(resolved, values);
+      }
+      return key;
+    };
+    return {
+      locale: targetLocale,
+      messages,
+      t: translate,
+    };
+  }, [targetLocale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+};
+
+export const useI18n = () => useContext(I18nContext);

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -1,0 +1,6 @@
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../../config/i18n.js";
+
+export const I18N_LOCALES = SUPPORTED_LOCALES as readonly ["zh-CN", "en"];
+export type SupportedLocale = (typeof I18N_LOCALES)[number];
+
+export const FALLBACK_LOCALE: SupportedLocale = DEFAULT_LOCALE as SupportedLocale;

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -1,0 +1,2 @@
+export { I18nProvider, useI18n } from "./I18nProvider";
+export { FALLBACK_LOCALE, I18N_LOCALES, type SupportedLocale } from "./config";

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,0 +1,65 @@
+{
+  "layout": {
+    "title": "AgentOS · Chat + LogFlow",
+    "subtitle": "Submit a prompt to run the local agent, inspect timeline events, and explore task branches.",
+    "tabs": {
+      "chat": "Chat",
+      "logflow": "LogFlow"
+    }
+  },
+  "conversation": {
+    "heading": "Conversation",
+    "traceNotice": "This conversation is logged to episodes/{traceId}.jsonl",
+    "downloadJsonl": "Download JSONL",
+    "saveButton": "Save conversation",
+    "draftLabel": "Draft input",
+    "finalOutputTitle": "Latest final output snapshot"
+  },
+  "chat": {
+    "inputLabel": "Chat input",
+    "placeholder": "Ask the agent for a summary or instruction...",
+    "metrics": {
+      "traceId": "Trace ID",
+      "latency": "Latency",
+      "cost": "Cost"
+    },
+    "submit": {
+      "run": "Run",
+      "running": "Running…"
+    },
+    "statusIndicator": {
+      "running": "Running agent",
+      "ready": "Ready",
+      "idle": "Idle"
+    },
+    "latestResponse": "Latest raw response",
+    "noResponse": "No response yet.",
+    "runFailure": "Failed to run agent",
+    "errorPrefix": "Error: {message}",
+    "empty": "No messages yet.",
+    "generating": "Generating response…",
+    "message": {
+      "labels": {
+        "msgId": "msg_id",
+        "localId": "local_id",
+        "traceId": "trace_id",
+        "latency": "latency",
+        "cost": "cost"
+      },
+      "status": {
+        "error": "Delivery failed",
+        "pending": "Pending",
+        "done": "Delivered",
+        "sent": "Sent"
+      }
+    }
+  },
+  "roles": {
+    "user": "user",
+    "assistant": "assistant",
+    "system": "system"
+  },
+  "errors": {
+    "requestFailed": "Request failed ({status})"
+  }
+}

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -1,0 +1,65 @@
+{
+  "layout": {
+    "title": "AgentOS · 对话与日志流",
+    "subtitle": "提交提示以运行本地代理，查看时间线事件并探索任务分支。",
+    "tabs": {
+      "chat": "聊天",
+      "logflow": "日志流"
+    }
+  },
+  "conversation": {
+    "heading": "对话",
+    "traceNotice": "此对话已写入 episodes/{traceId}.jsonl",
+    "downloadJsonl": "下载 JSONL",
+    "saveButton": "保存对话",
+    "draftLabel": "草稿输入",
+    "finalOutputTitle": "最新最终输出快照"
+  },
+  "chat": {
+    "inputLabel": "聊天输入",
+    "placeholder": "请向代理提问或发送指令…",
+    "metrics": {
+      "traceId": "Trace ID",
+      "latency": "延迟",
+      "cost": "成本"
+    },
+    "submit": {
+      "run": "运行",
+      "running": "运行中…"
+    },
+    "statusIndicator": {
+      "running": "代理运行中",
+      "ready": "就绪",
+      "idle": "空闲"
+    },
+    "latestResponse": "最新原始响应",
+    "noResponse": "暂未收到响应。",
+    "runFailure": "无法运行代理",
+    "errorPrefix": "错误：{message}",
+    "empty": "暂无消息。",
+    "generating": "正在生成回复…",
+    "message": {
+      "labels": {
+        "msgId": "消息 ID",
+        "localId": "本地 ID",
+        "traceId": "追踪 ID",
+        "latency": "延迟",
+        "cost": "成本"
+      },
+      "status": {
+        "error": "发送失败",
+        "pending": "等待中",
+        "done": "已送达",
+        "sent": "已发送"
+      }
+    }
+  },
+  "roles": {
+    "user": "用户",
+    "assistant": "助手",
+    "system": "系统"
+  },
+  "errors": {
+    "requestFailed": "请求失败（{status}）"
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,10 @@
 import { PHASE_PRODUCTION_BUILD } from "next/constants.js";
+import { I18N_CONFIG } from "./config/i18n.js";
 
 const baseConfig = {
   trailingSlash: true,
   skipTrailingSlashRedirect: true,
+  i18n: I18N_CONFIG,
 };
 
 /**

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from "next/app";
+import { I18nProvider } from "../lib/i18n/index";
+
+const App = ({ Component, pageProps, router }: AppProps) => {
+  const locale = router.locale ?? router.defaultLocale ?? undefined;
+  return (
+    <I18nProvider locale={locale}>
+      <Component {...pageProps} />
+    </I18nProvider>
+  );
+};
+
+export default App;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import { FormEventHandler, useCallback, useMemo, useState } from "react";
 import type { NextPage } from "next";
 import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 import LogFlowPanel from "../components/LogFlowPanel";
+import { useI18n } from "../lib/i18n/index";
 
 interface ChatSendResponse {
   trace_id?: string;
@@ -39,6 +40,7 @@ const serialiseHistoryForRequest = (messages: ChatHistoryMessage[]) =>
   }));
 
 const HomePage: NextPage = () => {
+  const { t } = useI18n();
   const [input, setInput] = useState("");
   const [isRunning, setIsRunning] = useState(false);
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
@@ -144,7 +146,7 @@ const HomePage: NextPage = () => {
           (data?.error as { message?: string } | undefined)?.message ??
           data?.message_error ??
           data?.message?.content ??
-          `Request failed (${response.status})`;
+          t("errors.requestFailed", { status: response.status });
         throw new Error(errorMessage);
       }
       setLatestResponse(data);
@@ -208,7 +210,7 @@ const HomePage: NextPage = () => {
         return [...updatedHistory, assistantMessage];
       });
     } catch (err: any) {
-      const errorMessage = err?.message ?? "Failed to run agent";
+      const errorMessage = err?.message ?? t("chat.runFailure");
       setRunError(errorMessage);
       setFinalOutput(null);
       setChatHistory((history) => {
@@ -226,7 +228,7 @@ const HomePage: NextPage = () => {
           {
             id: generateLocalId(),
             role: "system",
-            content: `Error: ${errorMessage}`,
+            content: t("chat.errorPrefix", { message: errorMessage }),
             ts: new Date().toISOString(),
             status: "error" as const,
             error: errorMessage,
@@ -237,7 +239,7 @@ const HomePage: NextPage = () => {
     } finally {
       setIsRunning(false);
     }
-  }, [input, isRunning, chatHistory, traceId]);
+  }, [chatHistory, input, isRunning, t, traceId]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -249,10 +251,10 @@ const HomePage: NextPage = () => {
 
   const tabItems = useMemo(
     () => [
-      { id: "chat" as const, label: "Chat" },
-      { id: "logflow" as const, label: "LogFlow" },
+      { id: "chat" as const, label: t("layout.tabs.chat") },
+      { id: "logflow" as const, label: t("layout.tabs.logflow") },
     ],
-    [],
+    [t],
   );
 
   return (
@@ -264,10 +266,9 @@ const HomePage: NextPage = () => {
           boxShadow: "0 1px 12px rgba(0,0,0,0.4)",
         }}
       >
-        <h1 style={{ margin: 0 }}>AgentOS · Chat + LogFlow</h1>
+        <h1 style={{ margin: 0 }}>{t("layout.title")}</h1>
         <p style={{ margin: "0.25rem 0 0", fontSize: "0.95rem", color: "#94a3b8" }}>
-          Submit a prompt to run the local agent, inspect timeline events, and explore task
-          branches.
+          {t("layout.subtitle")}
         </p>
       </header>
 
@@ -342,7 +343,7 @@ const HomePage: NextPage = () => {
                   gap: "0.75rem",
                 }}
               >
-                <h3 style={{ margin: 0 }}>Conversation</h3>
+                <h3 style={{ margin: 0 }}>{t("conversation.heading")}</h3>
                 <div
                   style={{
                     display: "flex",
@@ -354,9 +355,10 @@ const HomePage: NextPage = () => {
                 >
                   {traceId ? (
                     <span style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
-                      此对话已写入 episodes/{traceId}.jsonl ·{" "}
+                      {t("conversation.traceNotice", { traceId })}
+                      {" · "}
                       <a href={`/api/episodes/${traceId}`} style={{ color: "#38bdf8" }}>
-                        下载 JSONL
+                        {t("conversation.downloadJsonl")}
                       </a>
                     </span>
                   ) : null}
@@ -374,7 +376,7 @@ const HomePage: NextPage = () => {
                       cursor: !chatHistory.length && !draftInput ? "not-allowed" : "pointer",
                     }}
                   >
-                    保存对话
+                    {t("conversation.saveButton")}
                   </button>
                 </div>
               </div>
@@ -390,7 +392,7 @@ const HomePage: NextPage = () => {
                   }}
                 >
                   <div style={{ color: "#94a3b8", fontSize: "0.8rem", marginBottom: "0.25rem" }}>
-                    draft input
+                    {t("conversation.draftLabel")}
                   </div>
                   <div>{draftInput}</div>
                 </div>
@@ -404,7 +406,7 @@ const HomePage: NextPage = () => {
                   }}
                 >
                   <div style={{ color: "#94a3b8", fontSize: "0.8rem", marginBottom: "0.25rem" }}>
-                    Latest final output snapshot
+                    {t("conversation.finalOutputTitle")}
                   </div>
                   <pre
                     style={{
@@ -423,7 +425,7 @@ const HomePage: NextPage = () => {
 
             <form onSubmit={handleSubmit} style={{ display: "grid", gap: "1rem" }}>
               <label htmlFor="prompt" style={{ fontWeight: 600 }}>
-                Chat Input
+                {t("chat.inputLabel")}
               </label>
               <textarea
                 id="prompt"
@@ -435,7 +437,7 @@ const HomePage: NextPage = () => {
                     void handleRun();
                   }
                 }}
-                placeholder="Ask the agent for a summary or instruction..."
+                placeholder={t("chat.placeholder")}
                 style={{
                   width: "100%",
                   minHeight: 140,
@@ -469,7 +471,7 @@ const HomePage: NextPage = () => {
                     <span
                       style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}
                     >
-                      trace_id
+                      {t("chat.metrics.traceId")}
                     </span>
                     <span style={{ fontSize: "0.9rem" }}>{traceId ?? "-"}</span>
                   </div>
@@ -477,7 +479,7 @@ const HomePage: NextPage = () => {
                     <span
                       style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}
                     >
-                      latency
+                      {t("chat.metrics.latency")}
                     </span>
                     <span style={{ fontSize: "0.9rem" }}>
                       {typeof latencyMs === "number" ? `${latencyMs.toFixed(0)} ms` : "-"}
@@ -487,7 +489,7 @@ const HomePage: NextPage = () => {
                     <span
                       style={{ fontSize: "0.75rem", color: "#64748b", textTransform: "uppercase" }}
                     >
-                      cost
+                      {t("chat.metrics.cost")}
                     </span>
                     <span style={{ fontSize: "0.9rem" }}>
                       {typeof cost === "number" ? cost.toFixed(4) : "-"}
@@ -508,16 +510,16 @@ const HomePage: NextPage = () => {
                       cursor: isRunning ? "not-allowed" : "pointer",
                     }}
                   >
-                    {isRunning ? "Running…" : "Run"}
+                    {isRunning ? t("chat.submit.running") : t("chat.submit.run")}
                   </button>
                   <span style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
                     {runError
                       ? runError
                       : isRunning
-                        ? "Running agent"
+                        ? t("chat.statusIndicator.running")
                         : chatHistory.length > 0
-                          ? "Ready"
-                          : "Idle"}
+                          ? t("chat.statusIndicator.ready")
+                          : t("chat.statusIndicator.idle")}
                   </span>
                 </div>
               </div>
@@ -530,7 +532,9 @@ const HomePage: NextPage = () => {
                 padding: "1rem",
               }}
             >
-              <summary style={{ cursor: "pointer", fontWeight: 600 }}>Latest raw response</summary>
+              <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+                {t("chat.latestResponse")}
+              </summary>
               <pre
                 style={{
                   whiteSpace: "pre-wrap",
@@ -538,7 +542,7 @@ const HomePage: NextPage = () => {
                   marginTop: "0.75rem",
                 }}
               >
-                {latestResponse ? JSON.stringify(latestResponse, null, 2) : "No response yet."}
+                {latestResponse ? JSON.stringify(latestResponse, null, 2) : t("chat.noResponse")}
               </pre>
             </details>
           </section>

--- a/tests/chatMessageList.test.tsx
+++ b/tests/chatMessageList.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
+import { I18nProvider } from "../lib/i18n/index";
 
 describe("ChatMessageList", () => {
   it("renders multi-turn conversation bubbles with status", () => {
@@ -34,7 +35,11 @@ describe("ChatMessageList", () => {
       },
     ];
 
-    const html = renderToStaticMarkup(<ChatMessageList messages={messages} isRunning />);
+    const html = renderToStaticMarkup(
+      <I18nProvider locale="zh-CN">
+        <ChatMessageList messages={messages} isRunning />
+      </I18nProvider>,
+    );
 
     expect(html.includes('data-group-role="user"')).toBe(true);
     expect(html.includes('data-group-role="assistant"')).toBe(true);
@@ -43,8 +48,32 @@ describe("ChatMessageList", () => {
     expect(html.includes("Hello")).toBe(true);
     expect(html.includes("Hi, how can I help?")).toBe(true);
     expect(html.includes("Tell me a joke.")).toBe(true);
-    expect(html.includes("latency: 1200 ms")).toBe(true);
-    expect(html.includes("cost: 0.0042")).toBe(true);
+    expect(html.includes("延迟: 1200 ms")).toBe(true);
+    expect(html.includes("成本: 0.0042")).toBe(true);
     expect(html.includes('data-role="status"')).toBe(true);
+    expect(html.includes("正在生成回复…")).toBe(true);
+  });
+
+  it("renders english labels when locale is en", () => {
+    const messages: ChatHistoryMessage[] = [
+      {
+        id: "u-1",
+        role: "user",
+        content: "你好",
+        ts: new Date("2023-06-01T00:00:00Z").toISOString(),
+        status: "done",
+        msgId: "msg-user-1",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <I18nProvider locale="en">
+        <ChatMessageList messages={messages} />
+      </I18nProvider>,
+    );
+
+    expect(html.includes("msg_id")).toBe(true);
+    expect(html.includes("Delivered")).toBe(true);
+    expect(html.includes("No messages yet.")).toBe(false);
   });
 });

--- a/tests/homePage.i18n.test.tsx
+++ b/tests/homePage.i18n.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import HomePage from "../pages/index";
+import { I18nProvider } from "../lib/i18n/index";
+
+describe("HomePage internationalisation", () => {
+  it("renders Chinese copy by default", () => {
+    const html = renderToStaticMarkup(
+      <I18nProvider locale="zh-CN">
+        <HomePage />
+      </I18nProvider>,
+    );
+
+    expect(html.includes("AgentOS · 对话与日志流")).toBe(true);
+    expect(html.includes("保存对话")).toBe(true);
+    expect(html.includes("聊天输入")).toBe(true);
+  });
+
+  it("renders English copy when locale changes", () => {
+    const html = renderToStaticMarkup(
+      <I18nProvider locale="en">
+        <HomePage />
+      </I18nProvider>,
+    );
+
+    expect(html.includes("AgentOS · Chat + LogFlow")).toBe(true);
+    expect(html.includes("Save conversation")).toBe(true);
+    expect(html.includes("Chat input")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Next.js internationalization defaults and add a lightweight provider around the app
- replace hard-coded chat UI copy with translation lookups backed by zh-CN and en dictionaries
- cover the chat page and message list with locale-specific snapshot tests

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm smoke

------
https://chatgpt.com/codex/tasks/task_e_68ca7b356d10832b8f124e54ed4ea5b7