### PR TITLE
feat: add MCP workspace server and replay logging

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -1,10 +1,10 @@
-import { readFile } from "node:fs/promises";
 import {
   ToolInvoker,
   ToolCall,
   ToolResult,
   ToolOk,
   ToolError,
+  ToolContext,
   AgentKernel,
   Plan,
   PlanStep,
@@ -12,6 +12,7 @@ import {
   ReviewResult,
 } from "../core/agent";
 import type { ChatMessage } from "../types/chat";
+import { createMcpRegistry, type CreateMcpRegistryOptions } from "./mcp";
 import { buildChatCompletionsUrl, loadLLMConfig } from "../config/llm";
 
 export const DEFAULT_SYSTEM_PROMPT = {
@@ -42,23 +43,6 @@ async function handleHttpGet(args: any): Promise<ToolResult> {
       code: "http.error",
       message: err?.message ?? "request failed",
       retryable: true,
-    } satisfies ToolError;
-  }
-}
-
-async function handleFileRead(args: any): Promise<ToolResult> {
-  const path = args?.path;
-  if (!path) {
-    return { ok: false, code: "file.invalid_path", message: "path is required" };
-  }
-  try {
-    const content = await readFile(path, "utf8");
-    return { ok: true, data: { path, content } } satisfies ToolOk;
-  } catch (err: any) {
-    return {
-      ok: false,
-      code: "file.read_error",
-      message: err?.message ?? "failed to read file",
     } satisfies ToolError;
   }
 }
@@ -182,15 +166,20 @@ async function handleChat(args: any): Promise<ToolResult> {
   }
 }
 
-export function createDefaultToolInvoker(): ToolInvoker {
-  return async (call: ToolCall, _ctx: any) => {
+export interface DefaultToolInvokerOptions extends CreateMcpRegistryOptions {}
+
+export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}): ToolInvoker {
+  const mcpRegistry = createMcpRegistry(options);
+  return async (call: ToolCall, ctx: ToolContext) => {
+    const mcpResult = await mcpRegistry.invoke(call, ctx);
+    if (mcpResult !== null) {
+      return mcpResult;
+    }
     switch (call.name) {
       case "echo":
         return handleEcho(call.args);
       case "http.get":
         return handleHttpGet(call.args);
-      case "file.read":
-        return handleFileRead(call.args);
       case "llm.chat":
         return handleChat(call.args);
       default:

--- a/adapters/mcp.ts
+++ b/adapters/mcp.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+
+import type { ToolCall, ToolContext, ToolError, ToolResult } from "../core/agent";
+import type { EventBus, EventEnvelope } from "../runtime/events";
+import { createCoreMcpServer } from "../servers/mcp-core";
+
+export type McpMode = "record" | "replay";
+
+export interface CreateMcpRegistryOptions {
+  workspaceRoot?: string;
+  eventBus?: EventBus;
+  mode?: McpMode;
+  replayState?: Map<string, ToolResult>;
+}
+
+interface RegisteredTool {
+  serverId: string;
+  handler: (args: any, ctx: ToolContext) => Promise<ToolResult>;
+}
+
+function cloneResult<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function buildReplayKey(serverId: string, toolName: string, args: unknown): string {
+  return JSON.stringify({ server: serverId, tool: toolName, args });
+}
+
+function publishEvent(bus: EventBus | undefined, envelope: EventEnvelope): Promise<EventEnvelope | void> {
+  if (!bus) {
+    return Promise.resolve();
+  }
+  const enriched: EventEnvelope = {
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    version: 1,
+    ...envelope,
+  };
+  return bus.publish(enriched);
+}
+
+function cloneToolResult(result: ToolResult): ToolResult {
+  return cloneResult(result);
+}
+
+export interface McpRegistry {
+  hasTool(name: string): boolean;
+  invoke(call: ToolCall, ctx: ToolContext): Promise<ToolResult | null>;
+}
+
+export function createMcpRegistry(options: CreateMcpRegistryOptions = {}): McpRegistry {
+  const server = createCoreMcpServer({ root: options.workspaceRoot });
+  const tools = new Map<string, RegisteredTool>();
+  const servers = [server];
+  for (const srv of servers) {
+    for (const [name, handler] of Object.entries(srv.tools)) {
+      tools.set(name, { serverId: srv.id, handler });
+    }
+  }
+
+  const mode: McpMode = options.mode ?? "record";
+  const replayState = options.replayState ?? new Map<string, ToolResult>();
+
+  return {
+    hasTool(name: string): boolean {
+      return tools.has(name);
+    },
+
+    async invoke(call: ToolCall, ctx: ToolContext): Promise<ToolResult | null> {
+      const entry = tools.get(call.name);
+      if (!entry) {
+        return null;
+      }
+
+      const args = call.args ?? {};
+      const key = buildReplayKey(entry.serverId, call.name, args);
+
+      await publishEvent(options.eventBus, {
+        type: "mcp.call",
+        trace_id: ctx.trace_id,
+        span_id: ctx.span_id,
+        data: {
+          server: entry.serverId,
+          tool: call.name,
+          args,
+        },
+      });
+
+      if (mode === "replay") {
+        const recorded = replayState.get(key);
+        if (!recorded) {
+          const error: ToolError = {
+            ok: false,
+            code: "mcp.replay_missing",
+            message: `no recorded result for ${call.name}`,
+          };
+          await publishEvent(options.eventBus, {
+            type: "mcp.result",
+            trace_id: ctx.trace_id,
+            span_id: ctx.span_id,
+            data: {
+              server: entry.serverId,
+              tool: call.name,
+              ok: false,
+              error: error.message,
+            },
+          });
+          return error;
+        }
+        const cloned = cloneToolResult(recorded);
+        await publishEvent(options.eventBus, {
+          type: "mcp.result",
+          trace_id: ctx.trace_id,
+          span_id: ctx.span_id,
+          data: {
+            server: entry.serverId,
+            tool: call.name,
+            ok: cloned.ok,
+            bytes: cloned.ok && typeof (cloned.data as any)?.bytes === "number" ? (cloned.data as any).bytes : undefined,
+            path: cloned.ok && typeof (cloned.data as any)?.path === "string" ? (cloned.data as any).path : undefined,
+            result: cloned,
+          },
+        });
+        return cloneResult(cloned);
+      }
+
+      const result = await entry.handler(args, ctx);
+      replayState.set(key, cloneToolResult(result));
+      await publishEvent(options.eventBus, {
+        type: "mcp.result",
+        trace_id: ctx.trace_id,
+        span_id: ctx.span_id,
+        data: {
+          server: entry.serverId,
+          tool: call.name,
+          ok: result.ok,
+          bytes: result.ok && typeof (result.data as any)?.bytes === "number" ? (result.data as any).bytes : undefined,
+          path: result.ok && typeof (result.data as any)?.path === "string" ? (result.data as any).path : undefined,
+          result,
+        },
+      });
+      return result;
+    },
+  } satisfies McpRegistry;
+}

--- a/cli.ts
+++ b/cli.ts
@@ -10,7 +10,7 @@ async function runOnce(message: string) {
   const traceId = randomUUID();
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId });
-  const toolInvoker = createDefaultToolInvoker();
+  const toolInvoker = createDefaultToolInvoker({ eventBus: bus });
   const kernel = createChatKernel({ message, traceId, toolInvoker, history: [] });
 
   bus.subscribe((event: any) => {

--- a/pages/api/chat/send.ts
+++ b/pages/api/chat/send.ts
@@ -221,7 +221,7 @@ export default async function handler(
 
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId, dir: episodesDir });
-  const toolInvoker = createDefaultToolInvoker();
+  const toolInvoker = createDefaultToolInvoker({ eventBus: bus });
   const kernel = createChatKernel({ message: text, traceId, toolInvoker, history });
 
   const events: EventEnvelope[] = [];

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -92,7 +92,7 @@ export default async function handler(
 
   const bus = new EventBus();
   const logger = new EpisodeLogger({ traceId, dir: episodesDir });
-  const toolInvoker = createDefaultToolInvoker();
+  const toolInvoker = createDefaultToolInvoker({ eventBus: bus });
   const kernel = createChatKernel({ message, traceId, toolInvoker, history });
 
   const events: EventEnvelope<CoreEvent>[] = [];

--- a/servers/mcp-core.ts
+++ b/servers/mcp-core.ts
@@ -1,0 +1,154 @@
+import { dirname, join, relative, resolve } from "node:path";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+
+import type { ToolContext, ToolError, ToolOk, ToolResult } from "../core/agent";
+
+export type McpToolHandler = (args: any, ctx: ToolContext) => Promise<ToolResult>;
+
+export interface McpServerDefinition {
+  id: string;
+  tools: Record<string, McpToolHandler>;
+}
+
+export interface McpCoreServerOptions {
+  root?: string;
+}
+
+const DEFAULT_WORKSPACE_ROOT = process.env.AOS_WORKSPACE_ROOT ?? join(process.cwd(), "workspace");
+
+function normaliseRoot(root?: string): string {
+  return resolve(root ?? DEFAULT_WORKSPACE_ROOT);
+}
+
+function isSubPath(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.includes(":"));
+}
+
+function resolveWorkspacePath(root: string, target: string): string {
+  const normalisedRoot = normaliseRoot(root);
+  const trimmed = typeof target === "string" ? target.trim() : "";
+  const candidate = trimmed ? resolve(normalisedRoot, trimmed) : normalisedRoot;
+  if (!isSubPath(normalisedRoot, candidate)) {
+    throw new Error(`path ${target} is outside of workspace root`);
+  }
+  return candidate;
+}
+
+function createToolError(code: string, message: string): ToolError {
+  return { ok: false, code, message } satisfies ToolError;
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  const dir = dirname(filePath);
+  await mkdir(dir, { recursive: true });
+}
+
+export function createCoreMcpServer(options: McpCoreServerOptions = {}): McpServerDefinition {
+  const root = normaliseRoot(options.root);
+
+  const handlers: Record<string, McpToolHandler> = {
+    async "file.read"(args: any, _ctx: ToolContext): Promise<ToolResult> {
+      const pathInput = typeof args?.path === "string" ? args.path : "";
+      if (!pathInput) {
+        return createToolError("file.invalid_path", "path is required");
+      }
+      try {
+        const absolutePath = resolveWorkspacePath(root, pathInput);
+        const content = await readFile(absolutePath, "utf8");
+        const bytes = Buffer.byteLength(content, "utf8");
+        return {
+          ok: true,
+          data: {
+            path: pathInput,
+            absolute_path: absolutePath,
+            content,
+            bytes,
+          },
+        } satisfies ToolOk;
+      } catch (err: any) {
+        if (err && err.code === "ENOENT") {
+          return createToolError("file.not_found", `file not found: ${pathInput}`);
+        }
+        const message = err instanceof Error ? err.message : "failed to read file";
+        return createToolError("file.read_error", message);
+      }
+    },
+
+    async "file.write"(args: any, _ctx: ToolContext): Promise<ToolResult> {
+      const pathInput = typeof args?.path === "string" ? args.path : "";
+      const content = typeof args?.content === "string" ? args.content : undefined;
+      const encoding = typeof args?.encoding === "string" ? args.encoding : "utf8";
+      if (!pathInput) {
+        return createToolError("file.invalid_path", "path is required");
+      }
+      if (typeof content !== "string") {
+        return createToolError("file.invalid_content", "content must be a string");
+      }
+      try {
+        const absolutePath = resolveWorkspacePath(root, pathInput);
+        await ensureParentDir(absolutePath);
+        await writeFile(absolutePath, content, { encoding: encoding as BufferEncoding });
+        const bytes = Buffer.byteLength(content, encoding as BufferEncoding);
+        return {
+          ok: true,
+          data: {
+            path: pathInput,
+            absolute_path: absolutePath,
+            bytes,
+            encoding,
+          },
+        } satisfies ToolOk;
+      } catch (err: any) {
+        const message = err instanceof Error ? err.message : "failed to write file";
+        return createToolError("file.write_error", message);
+      }
+    },
+
+    async "file.list"(args: any, _ctx: ToolContext): Promise<ToolResult> {
+      const pathInput = typeof args?.path === "string" && args.path.length > 0 ? args.path : ".";
+      try {
+        const absolutePath = resolveWorkspacePath(root, pathInput);
+        const dirEntries = await readdir(absolutePath, { withFileTypes: true });
+        const entries = await Promise.all(
+          dirEntries.map(async (entry) => {
+            const entryPath = join(absolutePath, entry.name);
+            const kind = entry.isDirectory() ? "dir" : entry.isFile() ? "file" : "other";
+            const relativePath = relative(root, entryPath) || entry.name;
+            let size = 0;
+            if (entry.isFile()) {
+              const stats = await stat(entryPath);
+              size = stats.size;
+            }
+            return {
+              name: entry.name,
+              path: relativePath,
+              kind,
+              size,
+            };
+          }),
+        );
+        entries.sort((a, b) => a.path.localeCompare(b.path));
+        return {
+          ok: true,
+          data: {
+            path: pathInput,
+            absolute_path: resolveWorkspacePath(root, pathInput),
+            entries,
+          },
+        } satisfies ToolOk;
+      } catch (err: any) {
+        if (err && err.code === "ENOENT") {
+          return createToolError("file.not_found", `directory not found: ${pathInput}`);
+        }
+        const message = err instanceof Error ? err.message : "failed to list directory";
+        return createToolError("file.list_error", message);
+      }
+    },
+  } satisfies Record<string, McpToolHandler>;
+
+  return {
+    id: "mcp-core",
+    tools: handlers,
+  } satisfies McpServerDefinition;
+}

--- a/tests/mcpWorkspace.test.ts
+++ b/tests/mcpWorkspace.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { createDefaultToolInvoker } from "../adapters/core";
+import type {
+  ActionOutcome,
+  AgentKernel,
+  Plan,
+  PlanStep,
+  ReviewResult,
+  ToolInvoker,
+  ToolResult,
+} from "../core/agent";
+import { runLoop, type CoreEvent, type EmitSpanOptions } from "../core/agent";
+import { EventBus, wrapCoreEvent, type EventEnvelope } from "../runtime/events";
+import { EpisodeLogger } from "../runtime/episode";
+import { replayEpisode } from "../runtime/replay";
+
+class WorkspaceKernel implements AgentKernel {
+  private planned = false;
+
+  constructor(private readonly toolInvoker: ToolInvoker, private readonly traceId: string) {}
+
+  async perceive(): Promise<void> {
+    /* no-op */
+  }
+
+  async plan(): Promise<Plan> {
+    if (this.planned) {
+      return { steps: [] } satisfies Plan;
+    }
+    this.planned = true;
+    return {
+      steps: [
+        {
+          id: "write-note",
+          op: "file.write",
+          args: { path: "notes/hello.txt", content: "hello workspace" },
+        },
+        {
+          id: "read-note",
+          op: "file.read",
+          args: { path: "notes/hello.txt" },
+        },
+        {
+          id: "list-notes",
+          op: "file.list",
+          args: { path: "notes" },
+        },
+      ],
+    } satisfies Plan;
+  }
+
+  async act(step: PlanStep): Promise<ActionOutcome> {
+    const result = await this.toolInvoker(
+      { name: step.op, args: step.args },
+      { trace_id: this.traceId, span_id: step.id },
+    );
+    return { step, result } satisfies ActionOutcome;
+  }
+
+  async review(actions: ActionOutcome[]): Promise<ReviewResult> {
+    return { score: actions.length, passed: true, notes: ["workspace"] } satisfies ReviewResult;
+  }
+
+  async renderFinal(actions: ActionOutcome[]): Promise<any> {
+    return actions.map((action) => (action.result.ok ? action.result.data : action.result));
+  }
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+describe("mcp workspace server", () => {
+  it("records workspace operations and replays results", async () => {
+    const workspaceRoot = await createTempDir("aos-workspace-");
+    const episodesDir = await createTempDir("aos-episodes-");
+    const traceId = randomUUID();
+
+    const bus = new EventBus();
+    const logger = new EpisodeLogger({ traceId, dir: episodesDir });
+    const recordedEvents: EventEnvelope[] = [];
+    bus.subscribe(async (event) => {
+      recordedEvents.push(event);
+      await logger.append(event);
+    });
+
+    const replayState = new Map<string, ToolResult>();
+
+    try {
+      const toolInvoker = createDefaultToolInvoker({
+        workspaceRoot,
+        eventBus: bus,
+        replayState,
+      });
+
+      const kernel = new WorkspaceKernel(toolInvoker, traceId);
+      const emit = (event: CoreEvent, span?: EmitSpanOptions) =>
+        bus.publish(wrapCoreEvent(traceId, event, span));
+      const result = await runLoop(kernel, emit, { context: { traceId } });
+
+      expect(result.reason).toBe("completed");
+      expect(Array.isArray(result.final)).toBe(true);
+      expect(result.final).toHaveLength(3);
+
+      const writtenContent = await readFile(join(workspaceRoot, "notes/hello.txt"), "utf8");
+      expect(writtenContent).toBe("hello workspace");
+
+      const writeToolEvent = recordedEvents.find((event) => {
+        if (event.type !== "agent.tool") return false;
+        const data = event.data as any;
+        return data?.type === "tool" && data?.name === "file.write";
+      });
+      expect(writeToolEvent).toBeTruthy();
+    const writeResult = (writeToolEvent?.data as any)?.result as ToolResult | undefined;
+    expect(writeResult?.ok).toBe(true);
+    if (writeResult?.ok) {
+      expect(typeof (writeResult.data as any)?.bytes).toBe("number");
+      expect((writeResult.data as any).bytes > 0).toBe(true);
+    }
+
+      const mcpResultEvent = recordedEvents.find(
+        (event) => event.type === "mcp.result" && (event.data as any).tool === "file.write",
+      );
+      expect(mcpResultEvent).toBeTruthy();
+      expect((mcpResultEvent?.data as any).bytes > 0).toBe(true);
+      expect((mcpResultEvent?.data as any).path).toBe("notes/hello.txt");
+
+      const replayed = await replayEpisode(traceId, { dir: episodesDir });
+      expect(replayed.map((event) => event.type)).toEqual(
+        recordedEvents.map((event) => event.type),
+      );
+      const replayWriteResult = replayed.find(
+        (event) => event.type === "mcp.result" && (event.data as any).tool === "file.write",
+      );
+      expect(replayWriteResult?.data).toMatchObject(mcpResultEvent?.data ?? {});
+
+      const replayWorkspaceRoot = await createTempDir("aos-replay-workspace-");
+      const replayBus = new EventBus();
+      const replayLogger = new EpisodeLogger({ traceId: `${traceId}-replay`, dir: episodesDir });
+      replayBus.subscribe(async (event) => {
+        await replayLogger.append(event);
+      });
+
+      try {
+        const replayInvoker = createDefaultToolInvoker({
+          workspaceRoot: replayWorkspaceRoot,
+          eventBus: replayBus,
+          mode: "replay",
+          replayState,
+        });
+
+        const replayKernel = new WorkspaceKernel(replayInvoker, `${traceId}-replay`);
+        const replayEmit = (event: CoreEvent, span?: EmitSpanOptions) =>
+          replayBus.publish(wrapCoreEvent(`${traceId}-replay`, event, span));
+        const replayResult = await runLoop(replayKernel, replayEmit, {
+          context: { traceId: `${traceId}-replay` },
+        });
+
+        expect(replayResult.final).toEqual(result.final);
+
+        const replayFiles = await readdir(replayWorkspaceRoot);
+        expect(replayFiles.length).toBe(0);
+      } finally {
+        await rm(replayWorkspaceRoot, { recursive: true, force: true });
+      }
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(episodesDir, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement a core MCP server that exposes workspace-scoped file.read, file.write, and file.list tools
- add an MCP registry that logs call/result events, supports replayed results, and integrate it into the default tool invoker and APIs
- cover the new workflow with an integration test that records an episode and verifies replayed tool outputs

## Testing
- `pnpm test -- mcpWorkspace`


------
https://chatgpt.com/codex/tasks/task_e_68caa1db34ec832bb275691ae392588f