### PR TITLE
feat(cli): add MCP registry management

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { runLoop, type CoreEvent, type EmitSpanOptions } from "./core/agent";
 import { EventBus, wrapCoreEvent } from "./runtime/events";
 import { EpisodeLogger } from "./runtime/episode";
 import { replayEpisode } from "./runtime/replay";
 import { createChatKernel, createDefaultToolInvoker } from "./adapters/core";
+import { updateMCPRegistry, type MCPServerEntry } from "./config/mcpRegistry";
 
 async function runOnce(message: string) {
   const traceId = randomUUID();
@@ -65,37 +68,177 @@ async function replay(traceId: string) {
   console.log(`Replayed ${events.length} events.`);
 }
 
-async function main() {
-  const [command, ...args] = process.argv.slice(2);
+function printUsage() {
+  console.log("Usage (after compiling to JavaScript):");
+  console.log('  node dist/cli.js run "message"');
+  console.log("  node dist/cli.js replay <trace_id>");
+  console.log("  node dist/cli.js mcp add --transport <kind> <id> <url> [--default]");
+}
+
+function printMcpUsage() {
+  console.log("MCP subcommands:");
+  console.log("  mcp add --transport <kind> <id> <url> [--default]");
+}
+
+async function handleMcpAdd(args: string[]): Promise<number> {
+  let transport: string | undefined;
+  let setDefault = false;
+  let registryPath: string | undefined;
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === "--transport") {
+      transport = args[i + 1];
+      if (!transport) {
+        console.error("Missing value for --transport option.");
+        return 1;
+      }
+      i += 1;
+      continue;
+    }
+    if (token === "--default") {
+      setDefault = true;
+      continue;
+    }
+    if (token === "--file" || token === "--registry") {
+      registryPath = args[i + 1];
+      if (!registryPath) {
+        console.error(`Missing value for ${token} option.`);
+        return 1;
+      }
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      console.error(`Unknown option: ${token}`);
+      return 1;
+    }
+    positional.push(token);
+  }
+
+  const [id, url] = positional;
+  if (!id) {
+    console.error("Server id is required.");
+    return 1;
+  }
+  if (!transport) {
+    console.error("--transport option is required.");
+    return 1;
+  }
+
+  const entry: MCPServerEntry = { id, transport };
+  if (url) {
+    entry.url = url;
+  }
+
+  let created = false;
+  let updated = false;
+  let defaultChanged = false;
+
+  await updateMCPRegistry((registry) => {
+    const index = registry.servers.findIndex((server) => server.id === id);
+    if (index === -1) {
+      registry.servers.push({ ...entry });
+      created = true;
+    } else {
+      const existing = registry.servers[index];
+      if (existing.transport !== transport || existing.url !== url) {
+        registry.servers[index] = { ...existing, ...entry };
+        updated = true;
+      }
+    }
+
+    if (setDefault) {
+      if (registry.defaultServerId !== id) {
+        defaultChanged = true;
+      }
+      registry.defaultServerId = id;
+    }
+  }, registryPath);
+
+  if (created) {
+    console.log(
+      `Registered MCP server "${id}" (${transport})${entry.url ? ` -> ${entry.url}` : ""}.`,
+    );
+  } else if (updated) {
+    console.log(`Updated MCP server "${id}" (${transport}).`);
+  } else {
+    console.log(`MCP server "${id}" is already registered.`);
+  }
+
+  if (setDefault) {
+    if (defaultChanged) {
+      console.log(`Default MCP server set to "${id}".`);
+    } else {
+      console.log(`Default MCP server remains "${id}".`);
+    }
+  }
+
+  return 0;
+}
+
+async function handleMcpCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (!subcommand || subcommand === "help") {
+    printMcpUsage();
+    return 0;
+  }
+
+  if (subcommand === "add") {
+    return handleMcpAdd(rest);
+  }
+
+  console.error(`Unknown MCP subcommand: ${subcommand}`);
+  return 1;
+}
+
+export async function runCLI(argv: string[]): Promise<number> {
+  const [command, ...args] = argv;
 
   if (!command || command === "help") {
-    console.log("Usage (after compiling to JavaScript):");
-    console.log('  node dist/cli.js run "message"');
-    console.log("  node dist/cli.js replay <trace_id>");
-    process.exit(0);
+    printUsage();
+    return 0;
   }
 
   if (command === "run") {
     const message = args.join(" ") || "Hello from CLI";
     await runOnce(message);
-    return;
+    return 0;
   }
 
   if (command === "replay") {
     const traceId = args[0];
     if (!traceId) {
       console.error("Trace id is required for replay.");
-      process.exit(1);
+      return 1;
     }
     await replay(traceId);
-    return;
+    return 0;
+  }
+
+  if (command === "mcp") {
+    return handleMcpCommand(args);
   }
 
   console.error(`Unknown command: ${command}`);
-  process.exit(1);
+  return 1;
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isDirectExecution =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectExecution) {
+  runCLI(process.argv.slice(2))
+    .then((code) => {
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/config/mcpRegistry.ts
+++ b/config/mcpRegistry.ts
@@ -1,0 +1,114 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface MCPServerEntry {
+  id: string;
+  transport: string;
+  url?: string;
+  cmd?: string;
+  args?: string[];
+  [key: string]: unknown;
+}
+
+export interface MCPRegistry {
+  servers: MCPServerEntry[];
+  defaultServerId?: string;
+}
+
+const DEFAULT_FILENAME = "mcp.registry.json";
+
+function createEmptyRegistry(): MCPRegistry {
+  return { servers: [] };
+}
+
+function normalizeRegistry(value: any): MCPRegistry {
+  if (!value || typeof value !== "object") {
+    return createEmptyRegistry();
+  }
+
+  const servers = Array.isArray((value as any).servers)
+    ? (value as any).servers
+        .filter((server: any) => server && typeof server === "object")
+        .map((server: any) => {
+          const entry: MCPServerEntry = {
+            id: String(server.id ?? ""),
+            transport: String(server.transport ?? ""),
+          };
+
+          if (!entry.id || !entry.transport) {
+            return null;
+          }
+
+          if (typeof server.url === "string" && server.url) {
+            entry.url = server.url;
+          }
+          if (typeof server.cmd === "string" && server.cmd) {
+            entry.cmd = server.cmd;
+          }
+          if (Array.isArray(server.args)) {
+            entry.args = server.args.filter((arg: any) => typeof arg === "string");
+          }
+
+          const extraKeys = Object.keys(server).filter(
+            (key) => !["id", "transport", "url", "cmd", "args"].includes(key),
+          );
+          for (const key of extraKeys) {
+            entry[key] = server[key];
+          }
+
+          return entry;
+        })
+        .filter((entry: MCPServerEntry | null): entry is MCPServerEntry => entry !== null)
+    : [];
+
+  const registry: MCPRegistry = { servers };
+
+  if (typeof (value as any).defaultServerId === "string" && (value as any).defaultServerId) {
+    registry.defaultServerId = (value as any).defaultServerId;
+  }
+
+  return registry;
+}
+
+export function resolveMCPRegistryPath(customPath?: string): string {
+  const candidate = customPath ?? process.env.MCP_REGISTRY_PATH ?? DEFAULT_FILENAME;
+  return path.isAbsolute(candidate) ? candidate : path.resolve(process.cwd(), candidate);
+}
+
+export async function readMCPRegistry(filePath = resolveMCPRegistryPath()): Promise<MCPRegistry> {
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    if (!content.trim()) {
+      return createEmptyRegistry();
+    }
+    return normalizeRegistry(JSON.parse(content));
+  } catch (error: any) {
+    if (error?.code === "ENOENT") {
+      return createEmptyRegistry();
+    }
+    throw error;
+  }
+}
+
+export async function writeMCPRegistry(
+  registry: MCPRegistry,
+  filePath = resolveMCPRegistryPath(),
+): Promise<void> {
+  const normalized = normalizeRegistry(registry);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+}
+
+export async function updateMCPRegistry(
+  mutator: (registry: MCPRegistry) => void | MCPRegistry | Promise<void | MCPRegistry>,
+  filePath = resolveMCPRegistryPath(),
+): Promise<MCPRegistry> {
+  const current = await readMCPRegistry(filePath);
+  const draft: MCPRegistry = JSON.parse(JSON.stringify(current));
+  const result = await mutator(draft);
+  const next = normalizeRegistry(result ?? draft);
+  await writeMCPRegistry(next, filePath);
+  return next;
+}
+
+export const DEFAULT_MCP_REGISTRY_FILENAME = DEFAULT_FILENAME;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { MCPRegistry } from "../config/mcpRegistry";
+
+describe("CLI mcp add command", () => {
+  let tempDir: string;
+  let registryPath: string;
+  let runCLI: (argv: string[]) => Promise<number>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "aos-cli-"));
+    registryPath = path.join(tempDir, "mcp.registry.json");
+    process.env.MCP_REGISTRY_PATH = registryPath;
+    ({ runCLI } = await import("../cli"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    delete process.env.MCP_REGISTRY_PATH;
+  });
+
+  async function loadRegistry(): Promise<MCPRegistry> {
+    const data = await readFile(registryPath, "utf8");
+    return JSON.parse(data) as MCPRegistry;
+  }
+
+  it("creates a default registry when the file is missing", async () => {
+    const exitCode = await runCLI([
+      "mcp",
+      "add",
+      "--transport",
+      "ws",
+      "alpha",
+      "wss://alpha.example",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const registry = await loadRegistry();
+    expect(registry.servers).toEqual([
+      {
+        id: "alpha",
+        transport: "ws",
+        url: "wss://alpha.example",
+      },
+    ]);
+    expect(registry.defaultServerId).toBe(undefined);
+  });
+
+  it("does not duplicate entries when the same server is added twice", async () => {
+    await runCLI(["mcp", "add", "--transport", "ws", "alpha", "wss://alpha.example"]);
+    const exitCode = await runCLI([
+      "mcp",
+      "add",
+      "--transport",
+      "ws",
+      "alpha",
+      "wss://alpha.example",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const registry = await loadRegistry();
+    expect(registry.servers).toHaveLength(1);
+    expect(registry.servers[0]).toMatchObject({
+      id: "alpha",
+      transport: "ws",
+      url: "wss://alpha.example",
+    });
+  });
+
+  it("sets the default server when --default is provided", async () => {
+    const exitCode = await runCLI([
+      "mcp",
+      "add",
+      "--transport",
+      "ws",
+      "beta",
+      "wss://beta.example",
+      "--default",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const registry = await loadRegistry();
+    expect(registry.defaultServerId).toBe("beta");
+    expect(registry.servers[0]).toMatchObject({ id: "beta" });
+  });
+});


### PR DESCRIPTION
## Summary
- add MCP registry helper with default path handling and read/write/update utilities
- extend CLI to support `mcp add` for registering servers and setting defaults without duplicates
- cover new CLI flows with Vitest cases for creation, deduplication, and default server selection

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68caa61cc7f4832baa06e9373e7c11d7