### PR TITLE
feat: add skills management API and page

### DIFF
--- a/lib/skills.ts
+++ b/lib/skills.ts
@@ -1,0 +1,164 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export interface SkillMetadata {
+  id: string;
+  name: string;
+  description: string;
+  category?: string;
+  tags?: string[];
+  enabled: boolean;
+}
+
+export class SkillNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Skill with id "${id}" was not found`);
+    this.name = "SkillNotFoundError";
+  }
+}
+
+const DEFAULT_SKILLS: SkillMetadata[] = [
+  {
+    id: "csv.clean",
+    name: "CSV Cleaner",
+    description: "Normalise and sanitise CSV datasets for downstream tooling.",
+    category: "data",
+    tags: ["csv", "preprocess"],
+    enabled: true,
+  },
+  {
+    id: "stats.aggregate",
+    name: "Stats Aggregate",
+    description: "Compute descriptive statistics across structured tabular inputs.",
+    category: "analytics",
+    tags: ["statistics", "report"],
+    enabled: true,
+  },
+  {
+    id: "md.render",
+    name: "Markdown Renderer",
+    description: "Render Markdown knowledge cards into enriched HTML blocks.",
+    category: "rendering",
+    tags: ["markdown", "ui"],
+    enabled: false,
+  },
+];
+
+let memorySkills: SkillMetadata[] = cloneSkills(DEFAULT_SKILLS);
+
+const getSkillsStorePath = (): string =>
+  process.env.AOS_SKILLS_PATH ?? join(process.cwd(), "runtime", "skills.json");
+
+function cloneSkill(skill: SkillMetadata): SkillMetadata {
+  const cloned: SkillMetadata = {
+    ...skill,
+    ...(skill.tags ? { tags: [...skill.tags] } : {}),
+  };
+  return cloned;
+}
+
+function cloneSkills(skills: SkillMetadata[]): SkillMetadata[] {
+  return skills.map((skill) => cloneSkill(skill));
+}
+
+function normaliseSkill(raw: unknown): SkillMetadata | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const candidate = raw as Record<string, unknown>;
+  const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+  const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+  const description = typeof candidate.description === "string" ? candidate.description.trim() : "";
+  if (!id || !name || !description) {
+    return null;
+  }
+
+  const enabledValue = candidate.enabled;
+  const enabled = typeof enabledValue === "boolean" ? enabledValue : true;
+  const category =
+    typeof candidate.category === "string" && candidate.category.trim().length > 0
+      ? candidate.category.trim()
+      : undefined;
+  const tags = Array.isArray(candidate.tags)
+    ? candidate.tags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0)
+    : undefined;
+
+  return {
+    id,
+    name,
+    description,
+    enabled,
+    ...(category ? { category } : {}),
+    ...(tags && tags.length > 0 ? { tags: [...tags] } : {}),
+  };
+}
+
+async function readFromFile(): Promise<SkillMetadata[] | null> {
+  const filePath = getSkillsStorePath();
+  try {
+    const payload = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(payload);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    const normalised = parsed
+      .map((entry) => normaliseSkill(entry))
+      .filter((entry): entry is SkillMetadata => entry !== null);
+    if (normalised.length === 0) {
+      return null;
+    }
+    return normalised;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function persistSkills(skills: SkillMetadata[]): Promise<void> {
+  const filePath = getSkillsStorePath();
+  try {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, JSON.stringify(skills, null, 2), "utf8");
+  } catch (error) {
+    console.warn("Failed to persist skills store", error);
+  }
+}
+
+async function ensureMemoryStore(): Promise<SkillMetadata[]> {
+  const stored = await readFromFile();
+  if (stored) {
+    memorySkills = cloneSkills(stored);
+  }
+  return memorySkills;
+}
+
+export async function listSkills(): Promise<SkillMetadata[]> {
+  const skills = await ensureMemoryStore();
+  return cloneSkills(skills);
+}
+
+export async function setSkillEnabled(id: string, enabled: boolean): Promise<SkillMetadata> {
+  const skills = await ensureMemoryStore();
+  const match = skills.find((skill) => skill.id === id);
+  if (!match) {
+    throw new SkillNotFoundError(id);
+  }
+  match.enabled = enabled;
+  await persistSkills(skills);
+  return cloneSkill(match);
+}
+
+export async function resetSkillsStore(options?: {
+  skills?: SkillMetadata[];
+  persist?: boolean;
+}): Promise<void> {
+  const { skills = DEFAULT_SKILLS, persist = false } = options ?? {};
+  memorySkills = cloneSkills(skills);
+  const filePath = getSkillsStorePath();
+  if (!persist) {
+    await rm(filePath, { force: true });
+    return;
+  }
+  await persistSkills(memorySkills);
+}
+
+export { DEFAULT_SKILLS };

--- a/pages/api/skills/index.ts
+++ b/pages/api/skills/index.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  listSkills,
+  setSkillEnabled,
+  SkillNotFoundError,
+  type SkillMetadata,
+} from "../../../lib/skills";
+
+type SkillsListResponse = { skills: SkillMetadata[] };
+type SkillMutationResponse = { skill: SkillMetadata; skills: SkillMetadata[] };
+type ErrorResponse = { error: string; message: string };
+
+function parseBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+function parseString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+async function handleList(res: NextApiResponse<SkillsListResponse | ErrorResponse>) {
+  try {
+    const skills = await listSkills();
+    res.status(200).json({ skills });
+  } catch (error) {
+    res
+      .status(500)
+      .json({ error: "skills_fetch_failed", message: "Failed to load skills metadata" });
+  }
+}
+
+async function handleMutation(
+  req: NextApiRequest,
+  res: NextApiResponse<SkillMutationResponse | ErrorResponse>,
+) {
+  const { id, enabled } = req.body ?? {};
+
+  if (!parseString(id) || !parseBoolean(enabled)) {
+    res
+      .status(400)
+      .json({ error: "invalid_payload", message: "id and enabled fields are required" });
+    return;
+  }
+
+  try {
+    const updated = await setSkillEnabled(id, enabled);
+    const skills = await listSkills();
+    res.status(200).json({ skill: updated, skills });
+  } catch (error) {
+    if (error instanceof SkillNotFoundError) {
+      res.status(404).json({ error: "skill_not_found", message: `Skill ${id} does not exist` });
+      return;
+    }
+    res
+      .status(500)
+      .json({ error: "skills_update_failed", message: "Failed to update skill status" });
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SkillsListResponse | SkillMutationResponse | ErrorResponse>,
+) {
+  if (req.method === "GET") {
+    await handleList(res);
+    return;
+  }
+
+  if (req.method === "POST" || req.method === "PATCH") {
+    await handleMutation(req, res);
+    return;
+  }
+
+  res.setHeader("Allow", "GET,POST,PATCH");
+  res
+    .status(405)
+    .json({ error: "method_not_allowed", message: "Only GET, POST and PATCH are supported" });
+}

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -1,0 +1,205 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { NextPage } from "next";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  badgeClass,
+  headerSurfaceClass,
+  headingClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  pageContainerClass,
+  panelSurfaceClass,
+  primaryButtonClass,
+  shellClass,
+  subtleTextClass,
+} from "../lib/theme";
+import type { SkillMetadata } from "../lib/skills";
+
+type SkillsState = {
+  isLoading: boolean;
+  error: string | null;
+  items: SkillMetadata[];
+};
+
+type SkillsResponse = { skills?: SkillMetadata[]; skill?: SkillMetadata; message?: string };
+
+type ToggleRequest = { id: string; enabled: boolean };
+
+const SkillsPage: NextPage = () => {
+  const [state, setState] = useState<SkillsState>({ isLoading: true, error: null, items: [] });
+  const [mutatingId, setMutatingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadSkills = async () => {
+      try {
+        const response = await fetch("/api/skills");
+        const payload: SkillsResponse | null = await response.json().catch(() => null);
+        if (!response.ok || !payload || !Array.isArray(payload.skills)) {
+          throw new Error(payload?.message ?? "Failed to load skills");
+        }
+        if (!isMounted) return;
+        setState({ isLoading: false, error: null, items: payload.skills });
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred while loading skills";
+        if (!isMounted) return;
+        setState({ isLoading: false, error: message, items: [] });
+      }
+    };
+
+    loadSkills();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleToggle = useCallback(async (payload: ToggleRequest) => {
+    setMutatingId(payload.id);
+    try {
+      const response = await fetch("/api/skills", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data: SkillsResponse | null = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        throw new Error(data?.message ?? "Failed to update skill status");
+      }
+      setState((previous) => {
+        if (Array.isArray(data.skills)) {
+          return { isLoading: false, error: null, items: data.skills };
+        }
+        if (data.skill) {
+          return {
+            isLoading: false,
+            error: null,
+            items: previous.items.map((skill) =>
+              skill.id === data.skill?.id ? data.skill! : skill,
+            ),
+          };
+        }
+        return previous;
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred while updating the skill";
+      setState((previous) => ({ ...previous, error: message }));
+    } finally {
+      setMutatingId(null);
+    }
+  }, []);
+
+  const renderSkills = () => {
+    if (state.isLoading) {
+      return <p className={subtleTextClass}>Loading skills...</p>;
+    }
+
+    if (state.items.length === 0) {
+      return <p className={subtleTextClass}>No skills are currently registered.</p>;
+    }
+
+    return (
+      <ul className="flex flex-col gap-4">
+        {state.items.map((skill) => {
+          const isMutating = mutatingId === skill.id;
+          const actionLabel = skill.enabled ? "Disable" : "Enable";
+          const buttonClass = skill.enabled ? outlineButtonClass : primaryButtonClass;
+          const statusLabel = skill.enabled ? "Enabled" : "Disabled";
+
+          return (
+            <li
+              key={skill.id}
+              className={`${insetSurfaceClass} flex flex-col gap-3 p-5`}
+              data-testid="skill-card"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-col gap-1">
+                  <h2 className={`${headingClass} text-base`}>{skill.name}</h2>
+                  <span className={subtleTextClass}>{skill.description}</span>
+                </div>
+                <div className="flex flex-col items-end gap-2 text-right">
+                  <span className={labelClass}>Status</span>
+                  <span className={badgeClass} data-testid="skill-status">
+                    {statusLabel}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  {skill.category ? <span className={badgeClass}>#{skill.category}</span> : null}
+                  {skill.tags?.map((tag) => (
+                    <span key={tag} className={badgeClass}>
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  disabled={isMutating}
+                  className={buttonClass}
+                  onClick={() => handleToggle({ id: skill.id, enabled: !skill.enabled })}
+                >
+                  {isMutating ? "Updating..." : actionLabel}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <div className={shellClass}>
+      <Head>
+        <title>Skills | AOS</title>
+      </Head>
+      <header className={`${headerSurfaceClass} sticky top-0 z-10`}>
+        <div className={`${pageContainerClass} flex items-center justify-between py-6`}>
+          <div className="flex flex-col gap-1">
+            <span className={labelClass}>Operations</span>
+            <h1 className={`${headingClass} text-2xl`}>Skills</h1>
+          </div>
+          <nav className="flex items-center gap-3">
+            <Link href="/" className={outlineButtonClass}>
+              Home
+            </Link>
+            <Link href="/run" className={primaryButtonClass}>
+              Launch Run
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className={`${pageContainerClass} flex flex-col gap-6`}>
+        <section className={`${panelSurfaceClass} flex flex-col gap-6 p-8`}>
+          <div className="flex flex-col gap-2">
+            <p className={subtleTextClass}>
+              Review the currently registered skills, toggle their availability, and jump into a run
+              to verify changes instantly.
+            </p>
+          </div>
+          {state.error ? (
+            <div
+              className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+              role="alert"
+            >
+              {state.error}
+            </div>
+          ) : null}
+          {renderSkills()}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default SkillsPage;

--- a/tests/llmConfig.test.ts
+++ b/tests/llmConfig.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  DEFAULT_CHINESE_MODEL,
-  LLMConfigError,
-  loadLLMConfig,
-} from "../config/llm";
+import { DEFAULT_CHINESE_MODEL, LLMConfigError, loadLLMConfig } from "../config/llm";
 
 describe("loadLLMConfig", () => {
   it("falls back to the default chinese model when OPENAI_MODEL is missing", () => {
     const env = {
+      NODE_ENV: "test",
       OPENAI_API_KEY: "key-123",
     } as NodeJS.ProcessEnv;
 
@@ -17,7 +14,7 @@ describe("loadLLMConfig", () => {
   });
 
   it("throws a chinese error message when api key is missing", () => {
-    const env = {} as NodeJS.ProcessEnv;
+    const env = { NODE_ENV: "test" } as NodeJS.ProcessEnv;
     try {
       loadLLMConfig({ env });
       throw new Error("expected loadLLMConfig to throw");
@@ -29,6 +26,7 @@ describe("loadLLMConfig", () => {
 
   it("uses the provided model when available", () => {
     const env = {
+      NODE_ENV: "test",
       OPENAI_API_KEY: "key-abc",
       OPENAI_MODEL: "custom-zh-model",
     } as NodeJS.ProcessEnv;

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it } from "vitest";
+
+import handler from "../pages/api/skills/index";
+import { DEFAULT_SKILLS, listSkills, resetSkillsStore } from "../lib/skills";
+
+interface MockResponseState {
+  statusCode: number;
+  body?: any;
+}
+
+function createMockResponse(): { res: NextApiResponse; state: MockResponseState } {
+  const state: MockResponseState = { statusCode: 0 };
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      state.body = payload;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  } as unknown as NextApiResponse;
+  return { res, state };
+}
+
+async function withTempSkillsStore(run: () => Promise<void>): Promise<void> {
+  const originalEnv = { ...process.env };
+  const dir = await mkdtemp(join(tmpdir(), "skills-api-"));
+  process.env.AOS_SKILLS_PATH = join(dir, "skills.json");
+  await resetSkillsStore({ persist: true });
+  try {
+    await run();
+  } finally {
+    await resetSkillsStore();
+    process.env = { ...originalEnv };
+  }
+}
+
+describe("/api/skills", () => {
+  it("returns the registered skills", async () => {
+    await withTempSkillsStore(async () => {
+      const req = { method: "GET" } as NextApiRequest;
+      const { res, state } = createMockResponse();
+
+      await handler(req, res);
+
+      expect(state.statusCode).toBe(200);
+      expect(Array.isArray(state.body?.skills)).toBe(true);
+      expect(state.body.skills).toHaveLength(DEFAULT_SKILLS.length);
+    });
+  });
+
+  it("updates the skill status", async () => {
+    await withTempSkillsStore(async () => {
+      const initialSkills = await listSkills();
+      const skill = initialSkills[0];
+      const req = {
+        method: "POST",
+        body: { id: skill.id, enabled: !skill.enabled },
+      } as NextApiRequest;
+      const { res, state } = createMockResponse();
+
+      await handler(req, res);
+
+      expect(state.statusCode).toBe(200);
+      expect(state.body?.skill?.id).toBe(skill.id);
+      expect(state.body?.skill?.enabled).toBe(!skill.enabled);
+      expect(state.body?.skills?.find((item: any) => item.id === skill.id)?.enabled).toBe(
+        !skill.enabled,
+      );
+    });
+  });
+
+  it("returns 404 when the skill is missing", async () => {
+    await withTempSkillsStore(async () => {
+      const req = {
+        method: "POST",
+        body: { id: "missing-skill", enabled: true },
+      } as NextApiRequest;
+      const { res, state } = createMockResponse();
+
+      await handler(req, res);
+
+      expect(state.statusCode).toBe(404);
+      expect(state.body?.error).toBe("skill_not_found");
+    });
+  });
+
+  it("rejects invalid payloads", async () => {
+    await withTempSkillsStore(async () => {
+      const req = {
+        method: "POST",
+        body: { id: "", enabled: "true" },
+      } as NextApiRequest;
+      const { res, state } = createMockResponse();
+
+      await handler(req, res);
+
+      expect(state.statusCode).toBe(400);
+      expect(state.body?.error).toBe("invalid_payload");
+    });
+  });
+});

--- a/tests/ui/skills-page.pw.ts
+++ b/tests/ui/skills-page.pw.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("user can toggle a skill from the skills page", async ({ page }) => {
+  await page.goto("/skills");
+
+  await expect(page.getByRole("heading", { name: "Skills" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Launch Run" })).toBeVisible();
+
+  const firstSkillCard = page.getByTestId("skill-card").first();
+  await expect(firstSkillCard).toBeVisible();
+
+  const statusChip = firstSkillCard.getByTestId("skill-status");
+  const initialStatus = (await statusChip.textContent())?.trim() ?? "";
+  expect(initialStatus === "Enabled" || initialStatus === "Disabled").toBe(true);
+
+  const toggleButton = firstSkillCard.getByRole("button", { name: /Enable|Disable|Updating/ });
+  await toggleButton.click();
+
+  const expectedAfterToggle = initialStatus === "Enabled" ? "Disabled" : "Enabled";
+  await expect(statusChip).toHaveText(expectedAfterToggle);
+
+  await toggleButton.click();
+  await expect(statusChip).toHaveText(initialStatus);
+});


### PR DESCRIPTION
## Summary
- add lib/skills store with default metadata, persistence helpers, and reset utility
- expose GET/POST /api/skills for listing and enabling/disabling skills
- create /skills page with themed UI, toggling controls, and navigation links
- cover API behavior with unit tests and add a Playwright interaction test
- allow llmConfig tests to satisfy ProcessEnv typing by adding NODE_ENV

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:ui *(fails: chat page Playwright spec cannot find the expected heading, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68caa61d1690832bb760388c41bccce9