### PR TITLE
feat: add MCP registry CLI management

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,10 +1,28 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
+import { resolve as resolvePath } from "node:path";
+import { addOrUpdateMCPServer } from "./config/mcpRegistry";
 import { runLoop, type CoreEvent, type EmitSpanOptions } from "./core/agent";
 import { EventBus, wrapCoreEvent } from "./runtime/events";
 import { EpisodeLogger } from "./runtime/episode";
 import { replayEpisode } from "./runtime/replay";
 import { createChatKernel, createDefaultToolInvoker } from "./adapters/core";
+
+interface Writer {
+  write(chunk: string): unknown;
+}
+
+interface CliStreams {
+  stdout: Writer;
+  stderr: Writer;
+}
+
+interface RunCliOptions {
+  stdout?: Writer;
+  stderr?: Writer;
+  cwd?: string;
+}
 
 async function runOnce(message: string) {
   const traceId = randomUUID();
@@ -65,37 +83,154 @@ async function replay(traceId: string) {
   console.log(`Replayed ${events.length} events.`);
 }
 
-async function main() {
-  const [command, ...args] = process.argv.slice(2);
+export async function runCli(argv: string[], options: RunCliOptions = {}): Promise<number> {
+  const streams = resolveCliStreams(options);
+  const cwd = options.cwd ?? process.cwd();
+  const [command, ...args] = argv;
 
   if (!command || command === "help") {
-    console.log("Usage (after compiling to JavaScript):");
-    console.log('  node dist/cli.js run "message"');
-    console.log("  node dist/cli.js replay <trace_id>");
-    process.exit(0);
+    streams.stdout.write("Usage (after compiling to JavaScript):\n");
+    streams.stdout.write('  node dist/cli.js run "message"\n');
+    streams.stdout.write("  node dist/cli.js replay <trace_id>\n");
+    streams.stdout.write("  node dist/cli.js mcp add --transport <type> <id> <url> [--default]\n");
+    return 0;
   }
 
   if (command === "run") {
     const message = args.join(" ") || "Hello from CLI";
     await runOnce(message);
-    return;
+    return 0;
   }
 
   if (command === "replay") {
     const traceId = args[0];
     if (!traceId) {
-      console.error("Trace id is required for replay.");
-      process.exit(1);
+      streams.stderr.write("Trace id is required for replay.\n");
+      return 1;
     }
     await replay(traceId);
-    return;
+    return 0;
   }
 
-  console.error(`Unknown command: ${command}`);
-  process.exit(1);
+  if (command === "mcp") {
+    return handleMcpCommand(args, { streams, cwd });
+  }
+
+  streams.stderr.write(`Unknown command: ${command}\n`);
+  return 1;
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+function resolveCliStreams(options: RunCliOptions): CliStreams {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  return { stdout, stderr };
+}
+
+async function handleMcpCommand(args: string[], context: { streams: CliStreams; cwd: string }): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (!subcommand || subcommand === "help") {
+    context.streams.stdout.write("Usage: mcp add --transport <type> <id> <url> [--default]\n");
+    return 0;
+  }
+
+  if (subcommand !== "add") {
+    context.streams.stderr.write(`Unknown MCP command: ${subcommand}\n`);
+    return 1;
+  }
+
+  const parsed = parseMcpAddArgs(rest);
+  if (parsed.error) {
+    context.streams.stderr.write(`${parsed.error}\n`);
+    return 1;
+  }
+
+  const result = await addOrUpdateMCPServer({
+    id: parsed.id,
+    transport: parsed.transport,
+    url: parsed.url,
+    setAsDefault: parsed.setAsDefault,
+    registryPath: resolvePath(context.cwd, "mcp.registry.json"),
+  });
+
+  if (result.action === "created") {
+    context.streams.stdout.write(`已添加 MCP 端点 "${parsed.id}" (transport: ${parsed.transport})。\n`);
+  } else if (result.action === "updated") {
+    context.streams.stdout.write(`已更新 MCP 端点 "${parsed.id}" 的配置。\n`);
+  } else {
+    context.streams.stdout.write(`MCP 端点 "${parsed.id}" 配置未变。\n`);
+  }
+
+  if (parsed.setAsDefault) {
+    if (result.defaultChanged) {
+      context.streams.stdout.write(`已将 "${parsed.id}" 设置为默认端点。\n`);
+    } else {
+      context.streams.stdout.write(`"${parsed.id}" 已经是默认端点。\n`);
+    }
+  }
+
+  return 0;
+}
+
+interface ParsedMcpAddArgs {
+  id: string;
+  url: string;
+  transport: string;
+  setAsDefault: boolean;
+  error?: undefined;
+}
+
+interface ParsedMcpAddArgsError {
+  error: string;
+}
+
+function parseMcpAddArgs(args: string[]): ParsedMcpAddArgs | ParsedMcpAddArgsError {
+  let transport: string | undefined;
+  let setAsDefault = false;
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--transport") {
+      const value = args[i + 1];
+      if (!value) {
+        return { error: "参数 --transport 需要一个值" };
+      }
+      transport = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--default") {
+      setAsDefault = true;
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  if (!transport) {
+    return { error: "请通过 --transport 指定端点传输类型。" };
+  }
+
+  const [id, url] = positional;
+  if (!id) {
+    return { error: "请提供端点 ID。" };
+  }
+  if (!url) {
+    return { error: "请提供端点 URL。" };
+  }
+
+  return { id, url, transport, setAsDefault };
+}
+
+if (process.argv[1]) {
+  const entryUrl = pathToFileURL(process.argv[1]).href;
+  if (import.meta.url === entryUrl) {
+    runCli(process.argv.slice(2))
+      .then((code) => {
+        process.exitCode = code;
+      })
+      .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+      });
+  }
+}

--- a/config/mcpRegistry.ts
+++ b/config/mcpRegistry.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export interface MCPServerConfig {
+  id: string;
+  transport: string;
+  url?: string;
+  default?: boolean;
+  [key: string]: unknown;
+}
+
+export interface MCPRegistry {
+  servers: MCPServerConfig[];
+}
+
+export interface LoadRegistryOptions {
+  registryPath?: string;
+}
+
+export interface AddServerOptions {
+  id: string;
+  transport: string;
+  url?: string;
+  setAsDefault?: boolean;
+  registryPath?: string;
+}
+
+export interface AddServerResult {
+  action: "created" | "updated" | "unchanged";
+  defaultChanged: boolean;
+  registry: MCPRegistry;
+}
+
+const DEFAULT_REGISTRY: MCPRegistry = { servers: [] };
+
+export async function readMCPRegistry(
+  options: LoadRegistryOptions = {},
+): Promise<MCPRegistry> {
+  const registryPath = resolveRegistryPath(options.registryPath);
+  try {
+    const contents = await fs.readFile(registryPath, "utf8");
+    const parsed = JSON.parse(contents) as MCPRegistry;
+    if (!parsed.servers || !Array.isArray(parsed.servers)) {
+      throw new Error("Invalid registry: missing servers array");
+    }
+    return {
+      servers: parsed.servers.map((server) => ({ ...server })),
+    };
+  } catch (error: any) {
+    if (error?.code === "ENOENT") {
+      await initialiseRegistryFile(registryPath);
+      return { ...DEFAULT_REGISTRY, servers: [] };
+    }
+    throw error;
+  }
+}
+
+export async function addOrUpdateMCPServer(
+  options: AddServerOptions,
+): Promise<AddServerResult> {
+  const registryPath = resolveRegistryPath(options.registryPath);
+  const registry = await readMCPRegistry({ registryPath });
+
+  const existingIndex = registry.servers.findIndex((server) => server.id === options.id);
+  let action: AddServerResult["action"] = "unchanged";
+  let defaultChanged = false;
+
+  if (existingIndex === -1) {
+    const newServer: MCPServerConfig = buildServer(options);
+    registry.servers.push(newServer);
+    action = "created";
+  } else {
+    const existing = registry.servers[existingIndex];
+    const updated = applyServerUpdates(existing, options);
+    if (updated) {
+      action = "updated";
+    }
+  }
+
+  if (options.setAsDefault) {
+    defaultChanged = updateDefaultServer(registry, options.id);
+  }
+
+  if (action !== "unchanged" || defaultChanged) {
+    await writeRegistry(registryPath, registry);
+  }
+
+  return { action, defaultChanged, registry };
+}
+
+async function initialiseRegistryFile(registryPath: string) {
+  await fs.mkdir(dirname(registryPath), { recursive: true });
+  await writeRegistry(registryPath, DEFAULT_REGISTRY);
+}
+
+function resolveRegistryPath(registryPath?: string): string {
+  if (registryPath) {
+    return resolve(registryPath);
+  }
+  return resolve(process.cwd(), "mcp.registry.json");
+}
+
+function buildServer(options: AddServerOptions): MCPServerConfig {
+  const server: MCPServerConfig = {
+    id: options.id,
+    transport: options.transport,
+  };
+  if (options.url !== undefined) {
+    server.url = options.url;
+  }
+  return server;
+}
+
+function applyServerUpdates(existing: MCPServerConfig, options: AddServerOptions): boolean {
+  let changed = false;
+  if (existing.transport !== options.transport) {
+    existing.transport = options.transport;
+    changed = true;
+  }
+  if (options.url !== undefined && existing.url !== options.url) {
+    existing.url = options.url;
+    changed = true;
+  }
+  return changed;
+}
+
+function updateDefaultServer(registry: MCPRegistry, defaultId: string): boolean {
+  let changed = false;
+  for (const server of registry.servers) {
+    const shouldBeDefault = server.id === defaultId;
+    if ((server.default ?? false) !== shouldBeDefault) {
+      server.default = shouldBeDefault;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+async function writeRegistry(registryPath: string, registry: MCPRegistry) {
+  const serialised = `${JSON.stringify(registry, null, 2)}\n`;
+  await fs.writeFile(registryPath, serialised, "utf8");
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../cli";
+
+interface MemoryWriter {
+  write(chunk: string): unknown;
+  toString(): string;
+}
+
+function createMemoryWriter(): MemoryWriter {
+  let buffer = "";
+  return {
+    write(chunk: string) {
+      buffer += String(chunk);
+      return true;
+    },
+    toString() {
+      return buffer;
+    },
+  };
+}
+
+describe("CLI mcp add", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "aos-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("creates a new registry file on first add", async () => {
+    const stdout = createMemoryWriter();
+    const stderr = createMemoryWriter();
+
+    const code = await runCli(
+      ["mcp", "add", "--transport", "ws", "mcp-search", "wss://example.com"],
+      { cwd, stdout, stderr },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().includes('已添加 MCP 端点 "mcp-search"')).toBe(true);
+
+    const registryRaw = await readFile(join(cwd, "mcp.registry.json"), "utf8");
+    const registry = JSON.parse(registryRaw) as { servers: any[] };
+    expect(registry.servers).toHaveLength(1);
+    expect(registry.servers[0]).toMatchObject({
+      id: "mcp-search",
+      transport: "ws",
+      url: "wss://example.com",
+    });
+  });
+
+  it("does not duplicate servers when the same id is added twice", async () => {
+    await runCli(["mcp", "add", "--transport", "ws", "mcp-search", "wss://example.com"], {
+      cwd,
+      stdout: createMemoryWriter(),
+      stderr: createMemoryWriter(),
+    });
+
+    const stdout = createMemoryWriter();
+    const stderr = createMemoryWriter();
+    const code = await runCli(
+      ["mcp", "add", "--transport", "ws", "mcp-search", "wss://example.com"],
+      { cwd, stdout, stderr },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().includes('MCP 端点 "mcp-search" 配置未变')).toBe(true);
+
+    const registryRaw = await readFile(join(cwd, "mcp.registry.json"), "utf8");
+    const registry = JSON.parse(registryRaw) as { servers: any[] };
+    expect(registry.servers).toHaveLength(1);
+  });
+
+  it("marks the server as default when --default is provided", async () => {
+    await runCli(["mcp", "add", "--transport", "ws", "mcp-search", "wss://example.com"], {
+      cwd,
+      stdout: createMemoryWriter(),
+      stderr: createMemoryWriter(),
+    });
+
+    const stdout = createMemoryWriter();
+    const stderr = createMemoryWriter();
+    const code = await runCli(
+      [
+        "mcp",
+        "add",
+        "--transport",
+        "ws",
+        "mcp-primary",
+        "wss://primary.example.com",
+        "--default",
+      ],
+      { cwd, stdout, stderr },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().includes('已将 "mcp-primary" 设置为默认端点')).toBe(true);
+
+    const registryRaw = await readFile(join(cwd, "mcp.registry.json"), "utf8");
+    const registry = JSON.parse(registryRaw) as { servers: any[] };
+    const searchServer = registry.servers.find((server) => server.id === "mcp-search");
+    const defaultServer = registry.servers.find((server) => server.id === "mcp-primary");
+    expect(Boolean(searchServer?.default)).toBe(false);
+    expect(Boolean(defaultServer?.default)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `config/mcpRegistry.ts`，提供 MCP 注册表的读取与更新逻辑
- 扩展 CLI 支持 `mcp add` 子命令，可设置默认端点并输出中文提示
- 补充 CLI 单测覆盖首次创建、重复添加与默认端点场景

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68caad8fd2b8832b9301e89835c31b29