### PR TITLE
Add MCP core server with workspace file tools

### DIFF
--- a/adapters/mcp.ts
+++ b/adapters/mcp.ts
@@ -1,0 +1,309 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type { ToolError, ToolOk, ToolResult } from "../core/agent";
+import type { EventBus, EventEnvelope } from "../runtime/events";
+import { McpCoreServer, type McpServer, type McpCoreServerOptions } from "../servers/mcp-core";
+
+export type McpMode = "live" | "replay";
+
+export interface McpAdapterOptions {
+  traceId: string;
+  bus: EventBus;
+  mode?: McpMode;
+  recordedEvents?: EventEnvelope[];
+}
+
+export interface McpCallOptions {
+  spanId?: string;
+  parentSpanId?: string;
+  topic?: string;
+}
+
+interface McpCallEventData {
+  server: string;
+  tool: string;
+  args_hash: string;
+  args_preview?: string;
+}
+
+interface McpResultEventData {
+  server: string;
+  tool: string;
+  args_hash: string;
+  ok: boolean;
+  result?: unknown;
+  error?: {
+    code: string;
+    message: string;
+    retryable?: boolean;
+  };
+  latency_ms?: number;
+  cost?: number;
+}
+
+interface RecordedPair {
+  call: EventEnvelope<McpCallEventData>;
+  result: EventEnvelope<McpResultEventData>;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return '"[unserializable]"';
+  }
+}
+
+function hashArgs(args: unknown): string {
+  return createHash("sha256").update(safeStringify(args)).digest("hex");
+}
+
+function buildArgsPreview(args: unknown): string | undefined {
+  if (args == null) return undefined;
+  const serialized = safeStringify(args);
+  if (serialized.length <= 512) {
+    return serialized;
+  }
+  return `${serialized.slice(0, 509)}...`;
+}
+
+function cloneEnvelope<T>(event: EventEnvelope<T>): EventEnvelope<T> {
+  return JSON.parse(JSON.stringify(event)) as EventEnvelope<T>;
+}
+
+function extractToolError(result: ToolResult): ToolError | null {
+  if (result.ok) return null;
+  return result;
+}
+
+function mergeLatency(result: ToolResult, latencyMs: number): ToolResult {
+  if (!result.ok) {
+    return { ...result } satisfies ToolError;
+  }
+  const existing = result as ToolOk;
+  if (typeof existing.latency_ms === "number") {
+    return existing;
+  }
+  return { ...existing, latency_ms: latencyMs } satisfies ToolOk;
+}
+
+export class McpAdapter {
+  private readonly servers = new Map<string, McpServer>();
+  private readonly recorded = new Map<string, RecordedPair[]>();
+  private readonly mode: McpMode;
+
+  constructor(private readonly options: McpAdapterOptions) {
+    this.mode = options.mode ?? "live";
+    if (this.mode === "replay" && Array.isArray(options.recordedEvents)) {
+      this.ingestRecordedEvents(options.recordedEvents);
+    }
+  }
+
+  registerServer(server: McpServer): void {
+    this.servers.set(server.id, server);
+  }
+
+  async call(
+    serverId: string,
+    tool: string,
+    args: unknown,
+    options: McpCallOptions = {},
+  ): Promise<ToolResult> {
+    const argsHash = hashArgs(args);
+    const spanId = options.spanId ?? randomUUID();
+
+    if (this.mode === "replay") {
+      return this.replayCall(serverId, tool, argsHash, spanId, options);
+    }
+
+    const argsPreview = buildArgsPreview(args);
+    const callEnvelope: EventEnvelope<McpCallEventData> = {
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: "mcp.call",
+      version: 1,
+      trace_id: this.options.traceId,
+      span_id: spanId,
+      parent_span_id: options.parentSpanId,
+      topic: options.topic,
+      data: {
+        server: serverId,
+        tool,
+        args_hash: argsHash,
+        ...(argsPreview ? { args_preview: argsPreview } : {}),
+      },
+    };
+
+    await this.options.bus.publish(callEnvelope);
+
+    const server = this.servers.get(serverId);
+    if (!server) {
+      const error: ToolError = {
+        ok: false,
+        code: "mcp.server_not_found",
+        message: `server ${serverId} is not registered`,
+      };
+      await this.publishResultEnvelope(spanId, serverId, tool, argsHash, error, options);
+      return error;
+    }
+
+    const started = Date.now();
+    let invocationResult: ToolResult;
+    try {
+      invocationResult = await server.invoke(tool, args);
+    } catch (err: any) {
+      const message = err instanceof Error ? err.message : "unexpected mcp invocation error";
+      invocationResult = { ok: false, code: "mcp.invoke_error", message } satisfies ToolError;
+    }
+    const latency = Date.now() - started;
+    const merged = mergeLatency(invocationResult, latency);
+
+    await this.publishResultEnvelope(spanId, serverId, tool, argsHash, merged, options);
+    return merged;
+  }
+
+  private async replayCall(
+    serverId: string,
+    tool: string,
+    argsHash: string,
+    spanId: string,
+    options: McpCallOptions,
+  ): Promise<ToolResult> {
+    const key = this.buildKey(serverId, tool, argsHash);
+    const queue = this.recorded.get(key);
+    if (!queue || queue.length === 0) {
+      return {
+        ok: false,
+        code: "mcp.replay_missing_result",
+        message: "no recorded result available for the given call",
+      } satisfies ToolError;
+    }
+
+    const pair = queue.shift()!;
+    const callEnvelope = cloneEnvelope(pair.call);
+    callEnvelope.span_id = callEnvelope.span_id ?? spanId;
+    await this.options.bus.publish(callEnvelope);
+
+    const resultEnvelope = cloneEnvelope(pair.result);
+    resultEnvelope.span_id = resultEnvelope.span_id ?? spanId;
+    await this.options.bus.publish(resultEnvelope);
+
+    if (pair.result.data.ok) {
+      const okData = pair.result.data;
+      const toolOk: ToolOk = {
+        ok: true,
+        data: okData.result,
+        latency_ms: okData.latency_ms,
+        cost: okData.cost,
+      } satisfies ToolOk;
+      return toolOk;
+    }
+
+    const errorData = pair.result.data;
+    return {
+      ok: false,
+      code: errorData.error?.code ?? "mcp.replay_error",
+      message: errorData.error?.message ?? "recorded call failed",
+      ...(errorData.error?.retryable != null ? { retryable: errorData.error.retryable } : {}),
+    } satisfies ToolError;
+  }
+
+  private async publishResultEnvelope(
+    spanId: string,
+    serverId: string,
+    tool: string,
+    argsHash: string,
+    result: ToolResult,
+    options: McpCallOptions,
+  ): Promise<void> {
+    const error = extractToolError(result);
+    const resultEnvelope: EventEnvelope<McpResultEventData> = {
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: "mcp.result",
+      version: 1,
+      trace_id: this.options.traceId,
+      span_id: spanId,
+      parent_span_id: options.parentSpanId,
+      topic: options.topic,
+      data: {
+        server: serverId,
+        tool,
+        args_hash: argsHash,
+        ok: result.ok,
+        ...(result.ok
+          ? {
+              result: result.data,
+              latency_ms: (result as ToolOk).latency_ms,
+              cost: (result as ToolOk).cost,
+            }
+          : {
+              error: {
+                code: error?.code ?? "mcp.error",
+                message: error?.message ?? "unknown error",
+                ...(error?.retryable != null ? { retryable: error.retryable } : {}),
+              },
+            }),
+      },
+    };
+
+    await this.options.bus.publish(resultEnvelope);
+  }
+
+  private ingestRecordedEvents(events: EventEnvelope[]): void {
+    const callBySpan = new Map<string, EventEnvelope<McpCallEventData>>();
+    for (const event of events) {
+      if (event.type === "mcp.call") {
+        if (event.span_id) {
+          callBySpan.set(event.span_id, event as EventEnvelope<McpCallEventData>);
+        }
+      }
+    }
+
+    for (const event of events) {
+      if (event.type !== "mcp.result") continue;
+      const resultEvent = event as EventEnvelope<McpResultEventData>;
+      const data = resultEvent.data;
+      const key = this.buildKey(data.server, data.tool, data.args_hash);
+      const spanId = resultEvent.span_id;
+      const callEvent =
+        (spanId ? callBySpan.get(spanId) : undefined) ?? this.createSyntheticCall(resultEvent);
+      const queue = this.recorded.get(key) ?? [];
+      queue.push({ call: callEvent, result: resultEvent });
+      this.recorded.set(key, queue);
+    }
+  }
+
+  private createSyntheticCall(
+    resultEvent: EventEnvelope<McpResultEventData>,
+  ): EventEnvelope<McpCallEventData> {
+    return {
+      id: randomUUID(),
+      ts: resultEvent.ts,
+      type: "mcp.call",
+      version: resultEvent.version,
+      trace_id: resultEvent.trace_id,
+      span_id: resultEvent.span_id,
+      parent_span_id: resultEvent.parent_span_id,
+      topic: resultEvent.topic,
+      data: {
+        server: resultEvent.data.server,
+        tool: resultEvent.data.tool,
+        args_hash: resultEvent.data.args_hash,
+      },
+    };
+  }
+
+  private buildKey(server: string, tool: string, argsHash: string): string {
+    return `${server}::${tool}::${argsHash}`;
+  }
+}
+
+export function createMcpAdapter(
+  options: McpAdapterOptions & { core?: McpCoreServerOptions },
+): McpAdapter {
+  const adapter = new McpAdapter(options);
+  const coreServer = new McpCoreServer(options.core);
+  adapter.registerServer(coreServer);
+  return adapter;
+}

--- a/servers/mcp-core.ts
+++ b/servers/mcp-core.ts
@@ -1,0 +1,247 @@
+import { dirname, join, relative, resolve } from "node:path";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+
+import type { ToolError, ToolOk, ToolResult } from "../core/agent";
+
+export interface McpCoreServerOptions {
+  workspaceRoot?: string;
+}
+
+export interface McpServer {
+  readonly id: string;
+  invoke(tool: string, args: unknown): Promise<ToolResult>;
+}
+
+interface DirectoryEntryInfo {
+  name: string;
+  kind: "file" | "directory" | "other";
+  path: string;
+  size?: number;
+}
+
+interface FileListResult {
+  path: string;
+  entries: DirectoryEntryInfo[];
+}
+
+interface FileReadResult {
+  path: string;
+  content: string;
+}
+
+interface FileWriteResult {
+  path: string;
+  bytes: number;
+}
+
+export class McpCoreServer implements McpServer {
+  readonly id = "mcp-core";
+
+  private readonly workspaceRoot: string;
+
+  constructor(options: McpCoreServerOptions = {}) {
+    const root = options.workspaceRoot ? resolve(options.workspaceRoot) : process.cwd();
+    this.workspaceRoot = root;
+  }
+
+  async invoke(tool: string, args: unknown): Promise<ToolResult> {
+    switch (tool) {
+      case "file.read":
+        return this.handleFileRead(args);
+      case "file.write":
+        return this.handleFileWrite(args);
+      case "file.list":
+        return this.handleFileList(args);
+      default:
+        return {
+          ok: false,
+          code: "mcp.tool_not_found",
+          message: `tool ${tool} is not available on server ${this.id}`,
+        } satisfies ToolError;
+    }
+  }
+
+  private async handleFileRead(args: unknown): Promise<ToolResult<FileReadResult>> {
+    const pathArg = this.extractPathArgument(args);
+    if (!pathArg) {
+      return {
+        ok: false,
+        code: "file.invalid_path",
+        message: "path is required",
+      } satisfies ToolError;
+    }
+
+    const resolved = this.resolveWithinWorkspace(pathArg);
+    if (!resolved.ok) {
+      return resolved.error;
+    }
+
+    try {
+      const content = await readFile(resolved.fullPath, "utf8");
+      return {
+        ok: true,
+        data: { path: resolved.relativePath, content },
+      } satisfies ToolOk<FileReadResult>;
+    } catch (err: any) {
+      if (err && err.code === "ENOENT") {
+        return {
+          ok: false,
+          code: "file.not_found",
+          message: "file does not exist",
+        } satisfies ToolError;
+      }
+      const message = err instanceof Error ? err.message : "unknown file read error";
+      return { ok: false, code: "file.read_error", message } satisfies ToolError;
+    }
+  }
+
+  private async handleFileWrite(args: unknown): Promise<ToolResult<FileWriteResult>> {
+    const pathArg = this.extractPathArgument(args);
+    if (!pathArg) {
+      return {
+        ok: false,
+        code: "file.invalid_path",
+        message: "path is required",
+      } satisfies ToolError;
+    }
+
+    const content = this.extractContentArgument(args);
+    if (content == null) {
+      return {
+        ok: false,
+        code: "file.invalid_content",
+        message: "content must be a string",
+      } satisfies ToolError;
+    }
+
+    const resolved = this.resolveWithinWorkspace(pathArg);
+    if (!resolved.ok) {
+      return resolved.error;
+    }
+
+    try {
+      await mkdir(dirname(resolved.fullPath), { recursive: true });
+      await writeFile(resolved.fullPath, content, "utf8");
+      const bytes = Buffer.byteLength(content, "utf8");
+      return {
+        ok: true,
+        data: { path: resolved.relativePath, bytes },
+      } satisfies ToolOk<FileWriteResult>;
+    } catch (err: any) {
+      const message = err instanceof Error ? err.message : "unknown file write error";
+      return { ok: false, code: "file.write_error", message } satisfies ToolError;
+    }
+  }
+
+  private async handleFileList(args: unknown): Promise<ToolResult<FileListResult>> {
+    const pathArg = this.extractOptionalPathArgument(args);
+    const resolved = this.resolveWithinWorkspace(pathArg);
+    if (!resolved.ok) {
+      return resolved.error;
+    }
+
+    try {
+      const entries = await readdir(resolved.fullPath, { withFileTypes: true });
+      const detailed: DirectoryEntryInfo[] = [];
+      for (const entry of entries) {
+        const entryPath = join(resolved.fullPath, entry.name);
+        const entryRelative = this.toRelativePath(entryPath);
+        if (entry.isDirectory()) {
+          detailed.push({ name: entry.name, kind: "directory", path: entryRelative });
+        } else if (entry.isFile()) {
+          const stats = await stat(entryPath);
+          detailed.push({
+            name: entry.name,
+            kind: "file",
+            path: entryRelative,
+            size: stats.size,
+          });
+        } else {
+          detailed.push({ name: entry.name, kind: "other", path: entryRelative });
+        }
+      }
+      detailed.sort((a, b) => a.name.localeCompare(b.name));
+      return {
+        ok: true,
+        data: {
+          path: resolved.relativePath,
+          entries: detailed,
+        },
+      } satisfies ToolOk<FileListResult>;
+    } catch (err: any) {
+      if (err && err.code === "ENOENT") {
+        return {
+          ok: false,
+          code: "file.not_found",
+          message: "directory does not exist",
+        } satisfies ToolError;
+      }
+      const message = err instanceof Error ? err.message : "unknown file list error";
+      return { ok: false, code: "file.list_error", message } satisfies ToolError;
+    }
+  }
+
+  private extractPathArgument(args: unknown): string | undefined {
+    if (args && typeof (args as any).path === "string") {
+      const value = (args as any).path.trim();
+      return value.length > 0 ? value : undefined;
+    }
+    if (typeof args === "string") {
+      const value = args.trim();
+      return value.length > 0 ? value : undefined;
+    }
+    return undefined;
+  }
+
+  private extractOptionalPathArgument(args: unknown): string {
+    const value = this.extractPathArgument(args);
+    return value ?? ".";
+  }
+
+  private extractContentArgument(args: unknown): string | undefined {
+    if (args && typeof (args as any).content === "string") {
+      return (args as any).content;
+    }
+    return undefined;
+  }
+
+  private toRelativePath(target: string): string {
+    const relativePath = relative(this.workspaceRoot, target);
+    return this.normaliseRelativePath(relativePath);
+  }
+
+  private resolveWithinWorkspace(
+    requested: string,
+  ): { ok: true; fullPath: string; relativePath: string } | { ok: false; error: ToolError } {
+    const fullPath = resolve(this.workspaceRoot, requested);
+    const relativePath = relative(this.workspaceRoot, fullPath);
+    const isOutside =
+      relativePath === ""
+        ? false
+        : relativePath.split(/\\|\//).some((segment) => segment === ".." || segment === "");
+
+    if (isOutside) {
+      return {
+        ok: false,
+        error: {
+          ok: false,
+          code: "file.out_of_workspace",
+          message: "path is outside of the workspace",
+        } satisfies ToolError,
+      } as const;
+    }
+
+    return {
+      ok: true,
+      fullPath,
+      relativePath: this.normaliseRelativePath(relativePath),
+    } as const;
+  }
+
+  private normaliseRelativePath(value: string): string {
+    if (value === "" || value === ".") {
+      return ".";
+    }
+    return value.replace(/\\+/g, "/");
+  }
+}

--- a/tests/llmConfig.test.ts
+++ b/tests/llmConfig.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  DEFAULT_CHINESE_MODEL,
-  LLMConfigError,
-  loadLLMConfig,
-} from "../config/llm";
+import { DEFAULT_CHINESE_MODEL, LLMConfigError, loadLLMConfig } from "../config/llm";
 
 describe("loadLLMConfig", () => {
   it("falls back to the default chinese model when OPENAI_MODEL is missing", () => {
     const env = {
+      NODE_ENV: "test",
       OPENAI_API_KEY: "key-123",
     } as NodeJS.ProcessEnv;
 
@@ -17,7 +14,7 @@ describe("loadLLMConfig", () => {
   });
 
   it("throws a chinese error message when api key is missing", () => {
-    const env = {} as NodeJS.ProcessEnv;
+    const env = { NODE_ENV: "test" } as NodeJS.ProcessEnv;
     try {
       loadLLMConfig({ env });
       throw new Error("expected loadLLMConfig to throw");
@@ -29,6 +26,7 @@ describe("loadLLMConfig", () => {
 
   it("uses the provided model when available", () => {
     const env = {
+      NODE_ENV: "test",
       OPENAI_API_KEY: "key-abc",
       OPENAI_MODEL: "custom-zh-model",
     } as NodeJS.ProcessEnv;

--- a/tests/mcpWorkspace.test.ts
+++ b/tests/mcpWorkspace.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { createMcpAdapter } from "../adapters/mcp";
+import type { ToolResult } from "../core/agent";
+import { EventBus, type EventEnvelope } from "../runtime/events";
+
+function assertOk(result: ToolResult): asserts result is Extract<ToolResult, { ok: true }> {
+  if (!result.ok) {
+    throw new Error(`expected ok result, received error ${result.code}: ${result.message}`);
+  }
+}
+
+describe("mcp workspace integration", () => {
+  it("records events, applies file side effects, and replays deterministically", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "mcp-workspace-"));
+    const traceId = "trace-mcp-workspace";
+    const events: EventEnvelope[] = [];
+    const bus = new EventBus();
+    bus.subscribe(async (event) => {
+      events.push(event);
+    });
+
+    const adapter = createMcpAdapter({ traceId, bus, core: { workspaceRoot: workspace } });
+
+    const writeArgs = { path: "notes/hello.txt", content: "hello mcp" } as const;
+    const writeResult = await adapter.call("mcp-core", "file.write", writeArgs);
+    assertOk(writeResult);
+    expect(writeResult.data.path).toBe("notes/hello.txt");
+    expect(writeResult.data.bytes).toBe(Buffer.byteLength(writeArgs.content, "utf8"));
+
+    const readResult = await adapter.call("mcp-core", "file.read", { path: writeArgs.path });
+    assertOk(readResult);
+    expect(readResult.data.path).toBe("notes/hello.txt");
+    expect(readResult.data.content).toBe(writeArgs.content);
+
+    const listResult = await adapter.call("mcp-core", "file.list", { path: "notes" });
+    assertOk(listResult);
+    expect(listResult.data.path).toBe("notes");
+    const entries = (listResult.data as { entries: Array<{ name: string }> }).entries;
+    const entryNames = entries.map((entry) => entry.name);
+    expect(entryNames).toContainEqual("hello.txt");
+
+    const fileContent = await readFile(join(workspace, "notes", "hello.txt"), "utf8");
+    expect(fileContent).toBe(writeArgs.content);
+
+    const callEvents = events.filter((event) => event.type === "mcp.call");
+    const resultEvents = events.filter((event) => event.type === "mcp.result");
+    expect(callEvents).toHaveLength(3);
+    expect(resultEvents).toHaveLength(3);
+
+    const spanMatches = new Map<string, { call: EventEnvelope; result?: EventEnvelope }>();
+    for (const event of callEvents) {
+      if (event.span_id) {
+        spanMatches.set(event.span_id, { call: event });
+      }
+    }
+    for (const event of resultEvents) {
+      if (!event.span_id) continue;
+      const pair = spanMatches.get(event.span_id);
+      if (!pair) {
+        throw new Error(`missing call event for span ${event.span_id}`);
+      }
+      if (pair) {
+        pair.result = event;
+        const callData = pair.call.data as { args_hash: string };
+        const resultData = event.data as { args_hash: string; ok: boolean };
+        expect(resultData.args_hash).toBe(callData.args_hash);
+        expect(typeof resultData.ok).toBe("boolean");
+      }
+    }
+
+    await rm(join(workspace, "notes"), { recursive: true, force: true });
+
+    const replayBus = new EventBus();
+    const replayEvents: EventEnvelope[] = [];
+    replayBus.subscribe(async (event) => {
+      replayEvents.push(event);
+    });
+
+    const replayAdapter = createMcpAdapter({
+      traceId,
+      bus: replayBus,
+      mode: "replay",
+      recordedEvents: events,
+      core: { workspaceRoot: workspace },
+    });
+
+    const replayWrite = await replayAdapter.call("mcp-core", "file.write", writeArgs);
+    expect(replayWrite.ok).toBe(true);
+    if (replayWrite.ok) {
+      expect(replayWrite.data).toEqual(writeResult.data);
+    }
+
+    const replayRead = await replayAdapter.call("mcp-core", "file.read", { path: writeArgs.path });
+    expect(replayRead.ok).toBe(true);
+    if (replayRead.ok) {
+      expect(replayRead.data).toEqual(readResult.data);
+    }
+
+    const replayList = await replayAdapter.call("mcp-core", "file.list", { path: "notes" });
+    expect(replayList.ok).toBe(true);
+    if (replayList.ok) {
+      expect(replayList.data).toEqual(listResult.data);
+    }
+
+    expect(replayEvents.filter((event) => event.type === "mcp.call")).toHaveLength(3);
+    expect(replayEvents.filter((event) => event.type === "mcp.result")).toHaveLength(3);
+
+    try {
+      await stat(join(workspace, "notes", "hello.txt"));
+      throw new Error("expected stat to fail for missing file");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an in-process MCP core server that safely handles file.read/file.write/file.list within the workspace
- introduce an MCP adapter that logs mcp.call/mcp.result events, supports replay, and registers the local core server
- add an integration test covering live file operations, event capture, deterministic replay, and adjust LLM config tests to set NODE_ENV

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68caad8c703c832b806d5bea296232d3