### PR TITLE
feat: integrate MCP 客户端并路由工具调用

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -13,6 +13,29 @@ import {
 } from "../core/agent";
 import type { ChatMessage } from "../types/chat";
 import { buildChatCompletionsUrl, loadLLMConfig } from "../config/llm";
+import { createMCPClient, parseQualifiedToolName, MCPClient } from "./mcp";
+
+let mcpClientPromise: Promise<MCPClient | null> | null = null;
+
+async function getMCPClient(): Promise<MCPClient | null> {
+  if (mcpClientPromise) {
+    const cached = await mcpClientPromise;
+    if (cached) {
+      return cached;
+    }
+    mcpClientPromise = null;
+  }
+  const pending = createMCPClient().catch((error) => {
+    console.warn("failed to initialise MCP client", error);
+    return null;
+  });
+  mcpClientPromise = pending;
+  const client = await pending;
+  if (!client) {
+    mcpClientPromise = null;
+  }
+  return client;
+}
 
 export const DEFAULT_SYSTEM_PROMPT = {
   role: "system",
@@ -182,8 +205,8 @@ async function handleChat(args: any): Promise<ToolResult> {
   }
 }
 
-export function createDefaultToolInvoker(): ToolInvoker {
-  return async (call: ToolCall, _ctx: any) => {
+function createLocalToolInvoker(): ToolInvoker {
+  return async (call: ToolCall) => {
     switch (call.name) {
       case "echo":
         return handleEcho(call.args);
@@ -200,6 +223,24 @@ export function createDefaultToolInvoker(): ToolInvoker {
           message: `tool ${call.name} is not available`,
         } satisfies ToolError;
     }
+  };
+}
+
+export function createDefaultToolInvoker(): ToolInvoker {
+  const localInvoker = createLocalToolInvoker();
+  return async (call: ToolCall, ctx: any) => {
+    const client = await getMCPClient();
+    if (client) {
+      const parts = parseQualifiedToolName(call.name, client.defaultServer?.id);
+      if (parts) {
+        const result = await client.invoke(parts.serverId, parts.toolName, call.args, ctx);
+        if (!result.ok && (result.code === "tool.not_found" || result.code.startsWith("mcp."))) {
+          return localInvoker(call, ctx);
+        }
+        return result;
+      }
+    }
+    return localInvoker(call, ctx);
   };
 }
 

--- a/adapters/mcp.ts
+++ b/adapters/mcp.ts
@@ -1,0 +1,529 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { spawn, ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { ToolContext, ToolError, ToolResult } from "../core/agent";
+
+const REGISTRY_ENV_KEY = "MCP_REGISTRY_PATH";
+
+export type MCPTransportKind = "stdio" | "ws" | "http";
+
+export interface MCPRegistryEntry {
+  id: string;
+  transport: MCPTransportKind;
+  cmd?: string;
+  args?: string[];
+  url?: string;
+  headers?: Record<string, string>;
+  default?: boolean;
+}
+
+interface MCPTransport {
+  connect(): Promise<void>;
+  request(method: string, params: any): Promise<any>;
+  close(): Promise<void>;
+}
+
+class MCPTransportError extends Error {
+  constructor(message: string, public readonly detail?: any) {
+    super(message);
+    this.name = "MCPTransportError";
+  }
+}
+
+class MCPServerError extends Error {
+  constructor(message: string, public readonly data: any) {
+    super(message);
+    this.name = "MCPServerError";
+  }
+}
+
+type PendingRequest = {
+  resolve: (value: any) => void;
+  reject: (reason?: any) => void;
+};
+
+class StdIoTransport implements MCPTransport {
+  private child?: ChildProcessWithoutNullStreams;
+  private buffer = "";
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private connecting?: Promise<void>;
+
+  constructor(private readonly entry: MCPRegistryEntry) {}
+
+  private ensureCommand(): { cmd: string; args: string[] } {
+    const cmd = this.entry.cmd;
+    if (!cmd) {
+      throw new MCPTransportError(`stdio transport for ${this.entry.id} missing cmd`);
+    }
+    return { cmd, args: this.entry.args ?? [] };
+  }
+
+  async connect(): Promise<void> {
+    if (this.child) return;
+    if (!this.connecting) {
+      const { cmd, args } = this.ensureCommand();
+      this.connecting = new Promise<void>((resolve, reject) => {
+        try {
+          const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+          child.once("error", (err) => {
+            this.failAll(
+              new MCPTransportError(`stdio transport error: ${err instanceof Error ? err.message : String(err)}`),
+            );
+            this.child = undefined;
+            reject(err);
+          });
+          child.once("exit", (code, signal) => {
+            const reason = typeof code === "number" ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
+            this.failAll(new MCPTransportError(`stdio transport exited with ${reason}`));
+            this.child = undefined;
+          });
+
+          child.stdout.setEncoding("utf8");
+          child.stdout.on("data", (chunk: string) => {
+            this.buffer += chunk;
+            this.processBuffer();
+          });
+
+          this.child = child;
+          resolve();
+        } catch (error) {
+          this.child = undefined;
+          reject(error);
+        }
+      });
+    }
+
+    try {
+      await this.connecting;
+    } catch (error) {
+      this.connecting = undefined;
+      throw error;
+    }
+  }
+
+  private processBuffer() {
+    let newlineIndex = this.buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = this.buffer.slice(0, newlineIndex).trim();
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line) {
+        try {
+          const message = JSON.parse(line);
+          const id = message?.id;
+          if (typeof id === "number" && this.pending.has(id)) {
+            const pending = this.pending.get(id);
+            this.pending.delete(id);
+            if (pending) {
+              if (message.error) {
+                pending.reject(new MCPServerError(message.error.message ?? "mcp error", message.error));
+              } else {
+                pending.resolve(message.result);
+              }
+            }
+          }
+        } catch (error) {
+          // ignore malformed payloads
+        }
+      }
+      newlineIndex = this.buffer.indexOf("\n");
+    }
+  }
+
+  private failAll(error: Error) {
+    for (const [, pending] of this.pending) {
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  async request(method: string, params: any): Promise<any> {
+    await this.connect();
+    if (!this.child || !this.child.stdin.writable) {
+      throw new MCPTransportError(`stdio transport for ${this.entry.id} is not writable`);
+    }
+
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    const promise = new Promise<any>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+
+    this.child.stdin.write(`${payload}\n`, (err) => {
+      if (err) {
+        const pending = this.pending.get(id);
+        if (pending) {
+          this.pending.delete(id);
+          pending.reject(new MCPTransportError(`failed to write to stdio: ${err.message}`));
+        }
+      }
+    });
+
+    return promise;
+  }
+
+  async close(): Promise<void> {
+    if (this.child) {
+      this.child.removeAllListeners();
+      this.child.stdout.removeAllListeners();
+      this.child.stdin.end();
+      this.child.kill();
+      this.child = undefined;
+    }
+    this.buffer = "";
+    this.pending.clear();
+  }
+}
+
+class WsTransport extends EventEmitter implements MCPTransport {
+  private ws?: WebSocket;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private connecting?: Promise<void>;
+
+  constructor(private readonly entry: MCPRegistryEntry) {
+    super();
+  }
+
+  private ensureUrl(): string {
+    if (!this.entry.url) {
+      throw new MCPTransportError(`ws transport for ${this.entry.id} missing url`);
+    }
+    return this.entry.url;
+  }
+
+  async connect(): Promise<void> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
+    if (!this.connecting) {
+      const url = this.ensureUrl();
+      this.connecting = new Promise<void>((resolve, reject) => {
+        try {
+          const ws = new WebSocket(url, { headers: this.entry.headers });
+          ws.addEventListener("open", () => {
+            this.ws = ws;
+            resolve();
+          });
+          ws.addEventListener("message", (event) => {
+            try {
+              const data = typeof event.data === "string" ? event.data : event.data?.toString?.() ?? "";
+              const message = JSON.parse(data);
+              const id = message?.id;
+              if (typeof id === "number" && this.pending.has(id)) {
+                const pending = this.pending.get(id);
+                this.pending.delete(id);
+                if (pending) {
+                  if (message.error) {
+                    pending.reject(new MCPServerError(message.error.message ?? "mcp error", message.error));
+                  } else {
+                    pending.resolve(message.result);
+                  }
+                }
+              }
+            } catch {
+              // ignore
+            }
+          });
+          ws.addEventListener("error", (err) => {
+            reject(err);
+            for (const [, pending] of this.pending) {
+              pending.reject(new MCPTransportError("websocket error", err));
+            }
+            this.pending.clear();
+            this.ws = undefined;
+          });
+          ws.addEventListener("close", () => {
+            for (const [, pending] of this.pending) {
+              pending.reject(new MCPTransportError("websocket closed"));
+            }
+            this.pending.clear();
+            this.ws = undefined;
+          });
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }
+
+    try {
+      await this.connecting;
+    } catch (error) {
+      this.connecting = undefined;
+      throw error;
+    }
+  }
+
+  async request(method: string, params: any): Promise<any> {
+    await this.connect();
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new MCPTransportError(`websocket transport for ${this.entry.id} is not open`);
+    }
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    const promise = new Promise<any>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.ws.send(payload);
+    return promise;
+  }
+
+  async close(): Promise<void> {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = undefined;
+    }
+    this.pending.clear();
+  }
+}
+
+class HttpTransport implements MCPTransport {
+  constructor(private readonly entry: MCPRegistryEntry) {}
+
+  private ensureUrl(): string {
+    if (!this.entry.url) {
+      throw new MCPTransportError(`http transport for ${this.entry.id} missing url`);
+    }
+    return this.entry.url;
+  }
+
+  async connect(): Promise<void> {
+    // stateless
+  }
+
+  async request(method: string, params: any): Promise<any> {
+    const url = this.ensureUrl();
+    const payload = { jsonrpc: "2.0", id: Date.now(), method, params };
+    let response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(this.entry.headers ?? {}),
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      throw new MCPTransportError(
+        `http request failed for ${this.entry.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+    }
+
+    if (!response.ok) {
+      throw new MCPTransportError(`http request failed with status ${response.status}`, {
+        status: response.status,
+      });
+    }
+
+    let data: any;
+    try {
+      data = await response.json();
+    } catch (error) {
+      throw new MCPTransportError(`invalid json response from ${this.entry.id}`, error);
+    }
+
+    if (data?.error) {
+      throw new MCPServerError(data.error.message ?? "mcp error", data.error);
+    }
+
+    return data?.result;
+  }
+
+  async close(): Promise<void> {
+    // stateless
+  }
+}
+
+function createTransport(entry: MCPRegistryEntry): MCPTransport {
+  switch (entry.transport) {
+    case "stdio":
+      return new StdIoTransport(entry);
+    case "ws":
+      return new WsTransport(entry);
+    case "http":
+      return new HttpTransport(entry);
+    default:
+      throw new MCPTransportError(`unsupported transport ${(entry as any).transport}`);
+  }
+}
+
+function parseRegistry(value: unknown): MCPRegistryEntry[] {
+  if (!value) return [];
+  const entries: unknown = Array.isArray(value) ? value : (value as any)?.servers;
+  if (!Array.isArray(entries)) return [];
+
+  const results: MCPRegistryEntry[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as any).id;
+    const transport = (entry as any).transport;
+    if (typeof id !== "string" || typeof transport !== "string") continue;
+    if (transport !== "stdio" && transport !== "ws" && transport !== "http") continue;
+    results.push({
+      id,
+      transport,
+      cmd: typeof (entry as any).cmd === "string" ? (entry as any).cmd : undefined,
+      args: Array.isArray((entry as any).args)
+        ? (entry as any).args.filter((item: any) => typeof item === "string")
+        : undefined,
+      url: typeof (entry as any).url === "string" ? (entry as any).url : undefined,
+      headers:
+        (entry as any).headers && typeof (entry as any).headers === "object"
+          ? Object.fromEntries(
+              Object.entries((entry as any).headers).filter(
+                ([key, value]) => typeof key === "string" && typeof value === "string",
+              ),
+            )
+          : undefined,
+      default: Boolean((entry as any).default),
+    });
+  }
+  return results;
+}
+
+export async function loadMCPRegistry(registryPath?: string): Promise<MCPRegistryEntry[]> {
+  const resolvedPath = registryPath ?? process.env[REGISTRY_ENV_KEY] ?? resolve(process.cwd(), "mcp.registry.json");
+  let raw: string;
+  try {
+    raw = await readFile(resolvedPath, "utf8");
+  } catch (error: any) {
+    if (error && error.code === "ENOENT") {
+      return [];
+    }
+    throw new MCPTransportError(
+      `failed to read MCP registry at ${resolvedPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return parseRegistry(parsed);
+  } catch (error) {
+    throw new MCPTransportError(
+      `failed to parse MCP registry at ${resolvedPath}: ${error instanceof Error ? error.message : String(error)}`,
+      error,
+    );
+  }
+}
+
+export interface MCPClient {
+  readonly servers: MCPRegistryEntry[];
+  readonly defaultServer?: MCPRegistryEntry;
+  invoke(serverId: string, toolName: string, args: any, ctx?: ToolContext): Promise<ToolResult>;
+  listTools(serverId: string): Promise<any>;
+  close(): Promise<void>;
+}
+
+class DefaultMCPClient implements MCPClient {
+  private transports = new Map<string, MCPTransport>();
+
+  constructor(public readonly servers: MCPRegistryEntry[], public readonly defaultServer?: MCPRegistryEntry) {}
+
+  private getTransport(serverId: string): MCPTransport {
+    const existing = this.transports.get(serverId);
+    if (existing) return existing;
+    const server = this.servers.find((item) => item.id === serverId);
+    if (!server) {
+      throw new MCPTransportError(`server ${serverId} not found in registry`);
+    }
+    const transport = createTransport(server);
+    this.transports.set(serverId, transport);
+    return transport;
+  }
+
+  async invoke(serverId: string, toolName: string, args: any, ctx?: ToolContext): Promise<ToolResult> {
+    let transport: MCPTransport;
+    try {
+      transport = this.getTransport(serverId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown transport error";
+      return { ok: false, code: "mcp.transport_missing", message, retryable: true } satisfies ToolError;
+    }
+
+    try {
+      const result = await transport.request("tools/call", {
+        name: toolName,
+        arguments: args,
+        context: ctx,
+      });
+      if (result && typeof result === "object" && "ok" in result) {
+        return result as ToolResult;
+      }
+      return {
+        ok: false,
+        code: "mcp.invalid_response",
+        message: `invalid MCP response for ${serverId}.${toolName}`,
+      } satisfies ToolError;
+    } catch (error) {
+      if (error instanceof MCPServerError) {
+        const code =
+          typeof error.data?.code === "string"
+            ? error.data.code
+            : typeof error.data?.code === "number"
+              ? `mcp.server_error.${error.data.code}`
+              : "mcp.server_error";
+        const message =
+          typeof error.data?.message === "string"
+            ? error.data.message
+            : error.message ?? "MCP server error";
+        return { ok: false, code, message } satisfies ToolError;
+      }
+      const message = error instanceof Error ? error.message : "MCP transport error";
+      return { ok: false, code: "mcp.transport_error", message, retryable: true } satisfies ToolError;
+    }
+  }
+
+  async listTools(serverId: string): Promise<any> {
+    const transport = this.getTransport(serverId);
+    try {
+      const result = await transport.request("tools/list", {});
+      if (result && typeof result === "object" && Array.isArray((result as any).tools)) {
+        return (result as any).tools;
+      }
+      return [];
+    } catch (error) {
+      if (error instanceof MCPServerError) {
+        throw new MCPTransportError(error.message, error.data);
+      }
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    const closes: Promise<void>[] = [];
+    for (const transport of this.transports.values()) {
+      closes.push(transport.close());
+    }
+    this.transports.clear();
+    await Promise.allSettled(closes);
+  }
+}
+
+export async function createMCPClient(options: {
+  registryPath?: string;
+} = {}): Promise<MCPClient | null> {
+  const entries = await loadMCPRegistry(options.registryPath);
+  if (entries.length === 0) {
+    return null;
+  }
+  const defaultServer = entries.find((entry) => entry.default) ?? entries[0];
+  return new DefaultMCPClient(entries, defaultServer);
+}
+
+export type ToolNameParts = {
+  serverId: string;
+  toolName: string;
+};
+
+export function parseQualifiedToolName(name: string, defaultServer?: string): ToolNameParts | null {
+  if (typeof name !== "string" || !name) return null;
+  const dotIndex = name.indexOf(".");
+  if (dotIndex > 0) {
+    return { serverId: name.slice(0, dotIndex), toolName: name.slice(dotIndex + 1) };
+  }
+  if (defaultServer) {
+    return { serverId: defaultServer, toolName: name };
+  }
+  return null;
+}

--- a/tests/mcpAdapter.test.ts
+++ b/tests/mcpAdapter.test.ts
@@ -1,0 +1,157 @@
+import { Buffer } from "node:buffer";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+async function createRegistry(entries: any[]): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "mcp-registry-"));
+  const filePath = join(dir, "mcp.registry.json");
+  await writeFile(filePath, JSON.stringify(entries), "utf8");
+  return {
+    path: filePath,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("MCP adapter", () => {
+  it("returns null when registry file is missing", async () => {
+    const { createMCPClient } = await import("../adapters/mcp");
+    const missingPath = join(tmpdir(), `missing-registry-${Date.now()}.json`);
+    const client = await createMCPClient({ registryPath: missingPath });
+    expect(client).toBe(null);
+  });
+
+  it("returns transport error when connection fails", async () => {
+    const registry = await createRegistry([
+      {
+        id: "offline",
+        transport: "http",
+        url: "http://127.0.0.1:9",
+        default: true,
+      },
+    ]);
+    try {
+      const { createMCPClient } = await import("../adapters/mcp");
+      const client = await createMCPClient({ registryPath: registry.path });
+      expect(client).not.toBe(null);
+      const result = await client!.invoke("offline", "ping", { value: 1 }, { trace_id: "test" });
+      expect(result.ok).toBe(false);
+      expect(result.code.startsWith("mcp.")).toBe(true);
+    } finally {
+      await registry.cleanup();
+    }
+  });
+
+  it("invokes tools via HTTP registry entry and integrates with default tool invoker", async () => {
+    const registry = await createRegistry([
+      { id: "mock", transport: "http", url: "http://mock.mcp.test/rpc", default: true },
+    ]);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: any, init?: any) => {
+      const targetUrl = typeof input === "string" ? input : input?.url ?? "";
+      if (targetUrl === "http://mock.mcp.test/rpc") {
+        const bodyValue =
+          typeof init?.body === "string"
+            ? init.body
+            : init?.body instanceof Uint8Array
+              ? Buffer.from(init.body).toString("utf8")
+              : init?.body?.toString?.() ?? "";
+        const payload = bodyValue ? JSON.parse(bodyValue) : {};
+        const id = payload.id ?? null;
+        const method = payload.method;
+        if (method === "tools/list") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { tools: [{ name: "ping", description: "Ping tool" }] },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (method === "tools/call") {
+          if (payload.params?.name === "missing") {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id,
+                error: { code: "tool.not_found", message: "unknown tool" },
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          const value = payload.params?.arguments?.value ?? null;
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              result: { ok: true, data: { echoed: value } },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id, error: { code: "mcp.unsupported", message: "bad" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (typeof originalFetch === "function") {
+        return originalFetch(input, init);
+      }
+      throw new Error("unexpected fetch invocation");
+    };
+
+    try {
+      process.env.MCP_REGISTRY_PATH = registry.path;
+      const { createMCPClient } = await import("../adapters/mcp");
+      const client = await createMCPClient();
+      expect(client).not.toBe(null);
+
+      const tools = await client!.listTools("mock");
+      expect(Array.isArray(tools)).toBe(true);
+      expect(tools[0]?.name).toBe("ping");
+
+      const result = await client!.invoke("mock", "ping", { value: 42 }, { trace_id: "trace" });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toEqual({ echoed: 42 });
+      }
+
+      const missing = await client!.invoke("mock", "missing", {}, { trace_id: "trace" });
+      expect(missing.ok).toBe(false);
+      if (!missing.ok) {
+        expect(missing.code).toBe("tool.not_found");
+      }
+
+      await client!.close();
+
+      process.env.MCP_REGISTRY_PATH = registry.path;
+      const { createDefaultToolInvoker } = await import("../adapters/core");
+      const invoker = createDefaultToolInvoker();
+
+      const remoteDefault = await invoker({ name: "ping", args: { value: 7 } }, { trace_id: "abc" });
+      expect(remoteDefault.ok).toBe(true);
+      if (remoteDefault.ok) {
+        expect(remoteDefault.data).toEqual({ echoed: 7 });
+      }
+
+      const remotePrefixed = await invoker({ name: "mock.ping", args: { value: 9 } }, { trace_id: "def" });
+      expect(remotePrefixed.ok).toBe(true);
+      if (remotePrefixed.ok) {
+        expect(remotePrefixed.data).toEqual({ echoed: 9 });
+      }
+
+      const fallback = await invoker({ name: "mock.missing", args: {} }, { trace_id: "ghi" });
+      expect(fallback.ok).toBe(false);
+      if (!fallback.ok) {
+        expect(fallback.code).toBe("tool.not_found");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.MCP_REGISTRY_PATH;
+      await registry.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `adapters/mcp.ts` 读取注册表并建立 stdio/ws/http 传输的 MCP 客户端，统一提供 `invoke` 和 `listTools`
- 调整默认工具调用器优先分派 MCP 工具请求，并在工具缺失或传输错误时回退到本地实现
- 增补单元测试覆盖注册表缺失、连接失败及成功调用路径，验证事件与错误返回

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68caad8a45c0832b92ae4ff8dc5b7620