### PR TITLE
feat(runtime): add run stream sse endpoint

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toLogFlowMessage } from "../lib/logflowMessages";
 import type {
   BranchNode,
   BranchResponse,
@@ -25,19 +26,30 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   const [branch, setBranch] = useState<BranchResponse | null>(null);
   const latestSelectionRef = useRef<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const seenIdsRef = useRef<Set<string>>(new Set());
   const branchCards = useMemo(() => {
     if (!branch?.tree) return [];
     return flattenBranchNodes(branch.tree);
   }, [branch]);
 
   useEffect(() => {
+    const closeStream = () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    };
+
     if (!traceId) {
+      closeStream();
       setMessages([]);
       setSelectedMessage(null);
       setBranch(null);
       setMainlineState(initialRequestState);
       setBranchState(initialRequestState);
       latestSelectionRef.current = null;
+      seenIdsRef.current.clear();
       return;
     }
 
@@ -49,6 +61,8 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
     latestSelectionRef.current = null;
 
     const controller = new AbortController();
+    closeStream();
+    seenIdsRef.current = new Set();
 
     fetch(`/api/logflow/mainline?trace_id=${encodeURIComponent(traceId)}`, {
       signal: controller.signal,
@@ -63,6 +77,63 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
       .then((data) => {
         if (cancelled) return;
         setMessages(data.messages);
+        seenIdsRef.current = new Set(data.messages.map((msg) => msg.id));
+        if (typeof window !== "undefined") {
+          const source = new EventSource(`/api/runs/${traceId}/stream`);
+          eventSourceRef.current = source;
+
+          const handleEnvelope = (event: MessageEvent<string>) => {
+            try {
+              const envelope = JSON.parse(event.data);
+              if (!envelope || typeof envelope.id !== "string") {
+                return;
+              }
+              if (seenIdsRef.current.has(envelope.id)) {
+                return;
+              }
+              seenIdsRef.current.add(envelope.id);
+              const message = toLogFlowMessage(envelope);
+              setMessages((prev) => {
+                const next = [...prev, message];
+                next.sort((a, b) => a.ln - b.ln);
+                return next;
+              });
+            } catch (error) {
+              console.error("Failed to parse SSE event", error);
+            }
+          };
+
+          const eventNames = [
+            "run.started",
+            "run.progress",
+            "plan.updated",
+            "tool.succeeded",
+            "tool.failed",
+            "run.log",
+            "run.ask",
+            "run.score",
+            "run.finished",
+            "run.failed",
+          ];
+
+          eventNames.forEach((eventName) => {
+            source.addEventListener(eventName, handleEnvelope as EventListener);
+          });
+
+          const handleStreamEnd = () => {
+            if (eventSourceRef.current === source) {
+              source.close();
+              eventSourceRef.current = null;
+            }
+          };
+
+          source.addEventListener("stream.end", handleStreamEnd);
+          source.onerror = () => {
+            if (source.readyState === EventSource.CLOSED) {
+              handleStreamEnd();
+            }
+          };
+        }
       })
       .catch((err: any) => {
         if (cancelled) return;
@@ -77,6 +148,10 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
     return () => {
       cancelled = true;
       controller.abort();
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
     };
   }, [traceId]);
 

--- a/lib/logflow.ts
+++ b/lib/logflow.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import type { EventEnvelope } from "../runtime/events";
 import { readEpisodeIndex } from "../runtime/episode";
+import { toLogFlowMessage } from "./logflowMessages";
 import type { BranchNode, EpisodeIndexEntry, LogFlowMessage } from "../types/logflow";
 
 function resolveEpisodeDir(dir?: string): string {
@@ -38,46 +39,6 @@ export async function readEpisodeIndexEntries(
 ): Promise<EpisodeIndexEntry[]> {
   const baseDir = resolveEpisodeDir(dir);
   return readEpisodeIndex(traceId, baseDir);
-}
-
-function summarizeEvent(event: EventEnvelope): string {
-  const data = event.data as any;
-  switch (event.type) {
-    case "agent.plan": {
-      const steps = Array.isArray(data?.steps) ? data.steps.length : 0;
-      const revision = data?.revision ?? "?";
-      return `Plan revision ${revision} with ${steps} step${steps === 1 ? "" : "s"}`;
-    }
-    case "agent.tool":
-      return `Tool ${data?.name ?? "(unknown)"}`;
-    case "agent.final":
-      return "Final output ready";
-    case "agent.ask":
-      return data?.question ? `Ask: ${data.question}` : "Ask";
-    case "agent.score":
-      return `Score ${data?.value ?? "?"} (${data?.passed ? "pass" : "fail"})`;
-    case "agent.progress":
-      return `Progress ${Math.round((data?.pct ?? 0) * 100)}% (${data?.step ?? "step"})`;
-    case "agent.log":
-      return typeof data?.message === "string" ? data.message : "Log";
-    default:
-      return event.type;
-  }
-}
-
-export function toLogFlowMessage(event: EventEnvelope): LogFlowMessage {
-  return {
-    id: event.id,
-    ln: event.ln ?? 0,
-    span_id: event.span_id,
-    parent_span_id: event.parent_span_id,
-    type: event.type,
-    ts: event.ts,
-    level: event.level,
-    message: summarizeEvent(event),
-    data: event.data,
-    byte_offset: event.byte_offset,
-  } satisfies LogFlowMessage;
 }
 
 interface MutableBranchNode {

--- a/lib/logflowMessages.ts
+++ b/lib/logflowMessages.ts
@@ -1,0 +1,48 @@
+import type { EventEnvelope } from "../runtime/events";
+import type { LogFlowMessage } from "../types/logflow";
+
+function summarise(event: EventEnvelope): string {
+  const data = event.data as any;
+  switch (event.type) {
+    case "plan.updated": {
+      const steps = Array.isArray(data?.steps) ? data.steps.length : 0;
+      const revision = data?.revision ?? "?";
+      return `Plan revision ${revision} with ${steps} step${steps === 1 ? "" : "s"}`;
+    }
+    case "tool.succeeded":
+      return `Tool ${data?.name ?? "(unknown)"} succeeded`;
+    case "tool.failed":
+      return `Tool ${data?.name ?? "(unknown)"} failed`;
+    case "run.started":
+      return "Run started";
+    case "run.progress":
+      return `Progress ${Math.round((data?.pct ?? 0) * 100)}% (${data?.step ?? "step"})`;
+    case "run.finished":
+      return `Run finished (${data?.reason ?? "completed"})`;
+    case "run.failed":
+      return `Run failed${data?.message ? `: ${data.message}` : ""}`;
+    case "run.ask":
+      return data?.question ? `Ask: ${data.question}` : "Ask";
+    case "run.score":
+      return `Score ${data?.value ?? "?"} (${data?.passed ? "pass" : "fail"})`;
+    case "run.log":
+      return typeof data?.message === "string" ? data.message : "Log";
+    default:
+      return event.type;
+  }
+}
+
+export function toLogFlowMessage(event: EventEnvelope): LogFlowMessage {
+  return {
+    id: event.id,
+    ln: event.ln ?? 0,
+    span_id: event.span_id,
+    parent_span_id: event.parent_span_id,
+    type: event.type,
+    ts: event.ts,
+    level: event.level,
+    message: summarise(event),
+    data: event.data,
+    byte_offset: event.byte_offset,
+  } satisfies LogFlowMessage;
+}

--- a/pages/api/chat/send.ts
+++ b/pages/api/chat/send.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 import { createChatKernel, createDefaultToolInvoker } from "../../../adapters/core";
 import { runLoop, type CoreEvent, type EmitSpanOptions } from "../../../core/agent";
 import { EpisodeLogger } from "../../../runtime/episode";
-import { EventBus, type EventEnvelope, wrapCoreEvent } from "../../../runtime/events";
+import {
+  EventBus,
+  type EventEnvelope,
+  wrapCoreEvent,
+  createRunEvent,
+} from "../../../runtime/events";
+import { markRunCompleted, markRunFailed, registerRun } from "../../../runtime/runRegistry";
 
 type RunReason = "completed" | "no-plan" | "ask" | "max-iterations";
 
@@ -234,6 +240,8 @@ export default async function handler(
     }
   });
 
+  registerRun(traceId, { bus, logger });
+
   const chatMessageEnvelope: EventEnvelope = {
     id: randomUUID(),
     ts: new Date().toISOString(),
@@ -250,6 +258,14 @@ export default async function handler(
   };
 
   try {
+    await bus.publish(
+      createRunEvent(traceId, "run.started", {
+        trace_id: traceId,
+        input: text,
+        history_length: history.length,
+      }),
+    );
+
     await bus.publish(chatMessageEnvelope);
 
     const emit = async (event: CoreEvent, span?: EmitSpanOptions): Promise<void> => {
@@ -325,6 +341,8 @@ export default async function handler(
       data: assistantPayload,
     });
 
+    markRunCompleted(traceId);
+
     res.status(200).json({
       trace_id: traceId,
       msg_id: msgId,
@@ -343,6 +361,10 @@ export default async function handler(
   } catch (err) {
     console.error("chat send request failed", err);
     const message = err instanceof Error ? err.message : "unknown error";
+    await bus.publish(
+      createRunEvent(traceId, "run.failed", { message, trace_id: traceId }),
+    );
+    markRunFailed(traceId);
     res
       .status(500)
       .json({ error: "internal_error", message: `服务器内部错误：${message}` });

--- a/pages/api/logflow/branch.ts
+++ b/pages/api/logflow/branch.ts
@@ -1,10 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import {
-  buildBranchTree,
-  readEpisodeEvents,
-  readEpisodeIndexEntries,
-  toLogFlowMessage,
-} from "../../../lib/logflow";
+import { buildBranchTree, readEpisodeEvents, readEpisodeIndexEntries } from "../../../lib/logflow";
+import { toLogFlowMessage } from "../../../lib/logflowMessages";
 import type {
   BranchOrigin,
   BranchResponse,

--- a/pages/api/logflow/mainline.ts
+++ b/pages/api/logflow/mainline.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { readEpisodeEvents, readEpisodeIndexEntries, toLogFlowMessage } from "../../../lib/logflow";
+import { readEpisodeEvents, readEpisodeIndexEntries } from "../../../lib/logflow";
+import { toLogFlowMessage } from "../../../lib/logflowMessages";
 import type { MainlineResponse } from "../../../types/logflow";
 
 const METHOD = "GET";

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -10,7 +10,13 @@ import {
   type RunLoopResult,
 } from "../../core/agent";
 import { EpisodeLogger } from "../../runtime/episode";
-import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../runtime/events";
+import {
+  EventBus,
+  wrapCoreEvent,
+  createRunEvent,
+  type EventEnvelope,
+} from "../../runtime/events";
+import { markRunCompleted, markRunFailed, registerRun } from "../../runtime/runRegistry";
 
 interface RunResponse {
   trace_id: string;
@@ -105,7 +111,17 @@ export default async function handler(
     }
   });
 
+  registerRun(traceId, { bus, logger });
+
   try {
+    await bus.publish(
+      createRunEvent(traceId, "run.started", {
+        trace_id: traceId,
+        input: message,
+        history_length: history.length,
+      }),
+    );
+
     const emit = async (event: CoreEvent, span?: EmitSpanOptions): Promise<void> => {
       await bus.publish(wrapCoreEvent(traceId, event, span));
     };
@@ -120,7 +136,7 @@ export default async function handler(
       const envelope: EventEnvelope = {
         id: randomUUID(),
         ts: new Date().toISOString(),
-        type: "agent.chat.msg",
+        type: "chat.msg",
         version: 1,
         trace_id: traceId,
         data: {
@@ -162,6 +178,8 @@ export default async function handler(
       });
     }
 
+    markRunCompleted(traceId);
+
     res.status(200).json({
       trace_id: traceId,
       result: result.final,
@@ -177,6 +195,10 @@ export default async function handler(
   } catch (err) {
     console.error("request failed", err);
     const message = err instanceof Error ? err.message : "unknown error";
+    await bus.publish(
+      createRunEvent(traceId, "run.failed", { message, trace_id: traceId }),
+    );
+    markRunFailed(traceId);
     res.status(500).json({ error: "internal_error", message });
   }
 }

--- a/pages/api/runs/[runId]/stream.ts
+++ b/pages/api/runs/[runId]/stream.ts
@@ -1,0 +1,128 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { join } from "node:path";
+import type { ServerResponse } from "http";
+
+import { readEpisodeEvents } from "../../../../lib/logflow";
+import type { EventEnvelope } from "../../../../runtime/events";
+import { getRun } from "../../../../runtime/runRegistry";
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+function parseRunId(value: string | string[] | undefined): string | null {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === "string") {
+    return value[0]?.trim() ?? null;
+  }
+  return null;
+}
+
+function writeEvent(res: ServerResponse, event: EventEnvelope): void {
+  const payload = JSON.stringify(event);
+  res.write(`event: ${event.type}\n`);
+  res.write(`id: ${event.id}\n`);
+  res.write(`data: ${payload}\n\n`);
+}
+
+function writeStreamEvent(res: ServerResponse, eventName: string, data: unknown): void {
+  const payload = JSON.stringify(data ?? {});
+  res.write(`event: ${eventName}\n`);
+  res.write(`data: ${payload}\n\n`);
+}
+
+function resolveEpisodesDir(): string {
+  if (process.env.AOS_EPISODES_DIR) {
+    return process.env.AOS_EPISODES_DIR;
+  }
+  return join(process.cwd(), "episodes");
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).json({ error: "method_not_allowed", message: "only GET is allowed" });
+    return;
+  }
+
+  const runId = parseRunId(req.query.runId);
+  if (!runId || !/^[A-Za-z0-9-_.]+$/.test(runId)) {
+    res.status(400).json({ error: "invalid_run_id", message: "runId must be a non-empty string" });
+    return;
+  }
+
+  const episodesDir = resolveEpisodesDir();
+  let history: EventEnvelope[] = [];
+  try {
+    history = await readEpisodeEvents(runId, episodesDir);
+  } catch (err: any) {
+    if (err?.code !== "ENOENT") {
+      console.error("failed to read episode history", err);
+      res.status(500).json({ error: "history_read_failed", message: err?.message ?? "unexpected error" });
+      return;
+    }
+  }
+
+  const runEntry = getRun(runId);
+  if (!runEntry && history.length === 0) {
+    res.status(404).json({ error: "run_not_found", message: `run ${runId} not found` });
+    return;
+  }
+
+  res.status(200);
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+
+  const socket = res.socket;
+  socket?.setKeepAlive?.(true);
+  socket?.setNoDelay?.(true);
+
+  (res as ServerResponse).flushHeaders?.();
+
+  let closed = false;
+  const serverRes = res as unknown as ServerResponse;
+
+  for (const event of history) {
+    writeEvent(serverRes, event);
+  }
+
+  if (!runEntry) {
+    const lastType = history.at(-1)?.type ?? "history.complete";
+    writeStreamEvent(serverRes, "stream.end", { reason: lastType });
+    res.end();
+    return;
+  }
+
+  const heartbeat = setInterval(() => {
+    if (closed) {
+      return;
+    }
+    serverRes.write(`: heartbeat ${Date.now()}\n\n`);
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeat.unref?.();
+
+  const unsubscribe = runEntry.bus.subscribe((event) => {
+    if (closed || event.trace_id !== runId) {
+      return;
+    }
+    writeEvent(serverRes, event);
+    if (event.type === "run.finished" || event.type === "run.failed") {
+      writeStreamEvent(serverRes, "stream.end", { reason: event.type });
+      serverRes.end();
+    }
+  });
+
+  const close = () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    clearInterval(heartbeat);
+    unsubscribe();
+  };
+
+  req.on("close", close);
+  req.on("aborted", close);
+  serverRes.on("close", close);
+}

--- a/runtime/events.ts
+++ b/runtime/events.ts
@@ -54,6 +54,35 @@ export interface WrapEventOptions extends EventMetadata {
   version?: number;
 }
 
+function mapCoreEventType(event: CoreEvent): string {
+  switch (event.type) {
+    case "plan":
+      return "plan.updated";
+    case "tool":
+      return event.result && event.result.ok === false ? "tool.failed" : "tool.succeeded";
+    case "progress":
+      return "run.progress";
+    case "final":
+      return "run.finished";
+    case "log":
+      return "run.log";
+    case "ask":
+      return "run.ask";
+    case "score":
+      return "run.score";
+    default:
+      return event.type;
+  }
+}
+
+function enrichEventData(event: CoreEvent): CoreEvent {
+  if (event.type === "tool") {
+    const status = event.result && event.result.ok === false ? "failed" : "succeeded";
+    return { ...event, status };
+  }
+  return event;
+}
+
 export function wrapCoreEvent(
   traceId: string,
   event: CoreEvent,
@@ -65,13 +94,33 @@ export function wrapCoreEvent(
   return {
     id: randomUUID(),
     ts: new Date().toISOString(),
-    type: `agent.${event.type}`,
+    type: mapCoreEventType(event),
     version: options.version ?? 1,
     trace_id: traceId,
     span_id: options.spanId,
     parent_span_id: options.parentSpanId,
     topic: options.topic,
     level,
-    data: event,
+    data: enrichEventData(event),
+  };
+}
+
+export function createRunEvent(
+  traceId: string,
+  type: string,
+  data: Record<string, unknown> = {},
+  options: WrapEventOptions = {},
+): EventEnvelope<Record<string, unknown>> {
+  return {
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    type,
+    version: options.version ?? 1,
+    trace_id: traceId,
+    span_id: options.spanId,
+    parent_span_id: options.parentSpanId,
+    topic: options.topic,
+    level: options.level,
+    data,
   };
 }

--- a/runtime/runRegistry.ts
+++ b/runtime/runRegistry.ts
@@ -1,0 +1,90 @@
+import type { EpisodeLogger } from "./episode";
+import type { EventBus } from "./events";
+
+export type RunStatus = "running" | "completed" | "failed";
+
+export interface RunEntry {
+  runId: string;
+  bus: EventBus;
+  logger: EpisodeLogger;
+  status: RunStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const CLEANUP_DELAY_MS = 5 * 60_000;
+
+interface InternalRunEntry extends RunEntry {
+  cleanupTimer?: NodeJS.Timeout;
+}
+
+const runs = new Map<string, InternalRunEntry>();
+
+export function registerRun(runId: string, options: {
+  bus: EventBus;
+  logger: EpisodeLogger;
+}): RunEntry {
+  const existing = runs.get(runId);
+  if (existing?.cleanupTimer) {
+    clearTimeout(existing.cleanupTimer);
+  }
+
+  const entry: InternalRunEntry = {
+    runId,
+    bus: options.bus,
+    logger: options.logger,
+    status: "running",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  runs.set(runId, entry);
+  return entry;
+}
+
+export function getRun(runId: string): RunEntry | undefined {
+  return runs.get(runId);
+}
+
+function scheduleCleanup(runId: string, entry: InternalRunEntry): void {
+  if (entry.cleanupTimer) {
+    clearTimeout(entry.cleanupTimer);
+  }
+  entry.cleanupTimer = setTimeout(() => {
+    const current = runs.get(runId);
+    if (current === entry) {
+      runs.delete(runId);
+    }
+  }, CLEANUP_DELAY_MS);
+  entry.cleanupTimer.unref?.();
+}
+
+function updateStatus(runId: string, status: RunStatus): void {
+  const entry = runs.get(runId);
+  if (!entry) {
+    return;
+  }
+  entry.status = status;
+  entry.updatedAt = Date.now();
+  if (status !== "running") {
+    scheduleCleanup(runId, entry);
+  }
+}
+
+export function markRunCompleted(runId: string): void {
+  updateStatus(runId, "completed");
+}
+
+export function markRunFailed(runId: string): void {
+  updateStatus(runId, "failed");
+}
+
+export function removeRun(runId: string): void {
+  const entry = runs.get(runId);
+  if (!entry) {
+    return;
+  }
+  if (entry.cleanupTimer) {
+    clearTimeout(entry.cleanupTimer);
+  }
+  runs.delete(runId);
+}

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -17,10 +17,10 @@ const mockEpisodeId = `smoke-test-${Date.now()}`;
 const mockEpisode = {
   id: mockEpisodeId,
   ts: new Date().toISOString(),
-  type: "agent.final",
+  type: "run.finished",
   version: 1,
   trace_id: mockEpisodeId,
-  data: { type: "final", outputs: { text: "Smoke test completed successfully" } },
+  data: { outputs: { text: "Smoke test completed successfully" }, reason: "completed" },
 };
 
 await writeFile(join("episodes", `${mockEpisodeId}.jsonl`), JSON.stringify(mockEpisode) + "\n");

--- a/tests/apiRun.test.ts
+++ b/tests/apiRun.test.ts
@@ -215,7 +215,7 @@ describe("POST /api/run", () => {
 
       const lineNumbers = updatedEvents.map((event) => event.ln);
       expect(lineNumbers).toEqual([...lineNumbers].sort((a, b) => (a ?? 0) - (b ?? 0)));
-      const finalEvents = updatedEvents.filter((event) => event.type === "agent.final");
+      const finalEvents = updatedEvents.filter((event) => event.type === "run.finished");
       expect(finalEvents.length >= 1).toBe(true);
       const lastFinal = finalEvents.at(-1);
       expect((lastFinal?.data as any)?.reason).toBe("completed");

--- a/tests/chatSendApi.test.ts
+++ b/tests/chatSendApi.test.ts
@@ -123,7 +123,7 @@ describe("POST /api/chat/send", () => {
     expect(assistantMessage?.trace_id).toBe(responseTraceId);
     expect(assistantMessage?.reply_to).toBe(responseMsgId);
     expect(Array.isArray(record.body?.events)).toBe(true);
-    expect(record.body?.events?.[0]?.type).toBe("chat.msg");
+    expect(record.body?.events?.[0]?.type).toBe("run.started");
 
     const events = await parseEpisode(responseTraceId);
     expect(events.length > 0).toBe(true);

--- a/tests/episodeLogger.test.ts
+++ b/tests/episodeLogger.test.ts
@@ -20,8 +20,10 @@ describe("EpisodeLogger", () => {
       data,
     });
 
-    const first = await logger.append(makeEvent("agent.plan", { revision: 1 }));
-    const second = await logger.append(makeEvent("agent.final", { final: { answer: "done" } }));
+    const first = await logger.append(makeEvent("plan.updated", { revision: 1 }));
+    const second = await logger.append(
+      makeEvent("run.finished", { outputs: { answer: "done" }, reason: "completed" }),
+    );
 
     expect(first.ln).toBe(1);
     expect(first.byte_offset).toBe(0);

--- a/tests/logflow.test.ts
+++ b/tests/logflow.test.ts
@@ -4,7 +4,7 @@ import type { BranchNode, LogFlowMessage } from "../types/logflow";
 
 describe("buildBranchTree", () => {
   const baseMessage = {
-    type: "agent.tool",
+    type: "tool.succeeded",
     ts: "2024-01-01T00:00:00.000Z",
     message: "",
     data: {},
@@ -82,7 +82,7 @@ describe("buildBranchTree", () => {
         id: "evt-1",
         ln: 1,
         span_id: "trace-root",
-        type: "agent.progress",
+        type: "run.progress",
         ts: now,
         message: "root progress",
         data: { step: "perceive" },
@@ -92,7 +92,7 @@ describe("buildBranchTree", () => {
         ln: 2,
         span_id: "plan-1",
         parent_span_id: "trace-root",
-        type: "agent.plan",
+        type: "plan.updated",
         ts: now,
         message: "plan",
         data: { revision: 1 },
@@ -102,7 +102,7 @@ describe("buildBranchTree", () => {
         ln: 3,
         span_id: "step-a",
         parent_span_id: "plan-1",
-        type: "agent.progress",
+        type: "run.progress",
         ts: now,
         message: "progress",
         data: { step: "act" },
@@ -112,7 +112,7 @@ describe("buildBranchTree", () => {
         ln: 4,
         span_id: "step-a",
         parent_span_id: "plan-1",
-        type: "agent.tool",
+        type: "tool.succeeded",
         ts: now,
         message: "tool",
         data: { name: "tool.echo" },
@@ -122,7 +122,7 @@ describe("buildBranchTree", () => {
         ln: 5,
         span_id: "step-b",
         parent_span_id: "plan-1",
-        type: "agent.tool",
+        type: "tool.succeeded",
         ts: now,
         message: "tool",
         data: { name: "tool.calc" },
@@ -136,6 +136,6 @@ describe("buildBranchTree", () => {
     expect(tree?.children.map((child) => child.span_id)).toEqual(["step-a", "step-b"]);
     const stepANode = tree?.children.find((child) => child.span_id === "step-a");
     expect(stepANode?.events).toHaveLength(2);
-    expect(stepANode?.events.map((evt) => evt.type)).toEqual(["agent.progress", "agent.tool"]);
+    expect(stepANode?.events.map((evt) => evt.type)).toEqual(["run.progress", "tool.succeeded"]);
   });
 });

--- a/tests/mcpWorkspace.test.ts
+++ b/tests/mcpWorkspace.test.ts
@@ -111,7 +111,7 @@ describe("mcp workspace registry", () => {
       expect(writtenContent).toBe("hello workspace");
 
       const writeToolEvent = recordedEvents.find((event) => {
-        if (event.type !== "agent.tool") return false;
+        if (event.type !== "tool.succeeded") return false;
         const data = event.data as any;
         return data?.type === "tool" && data?.name === "file.write";
       });

--- a/tests/replay.test.ts
+++ b/tests/replay.test.ts
@@ -26,9 +26,9 @@ describe("replayEpisode", () => {
     const traceId = "trace-replay";
     const logger = new EpisodeLogger({ traceId, dir });
 
-    const first = await logger.append(createEvent(traceId, "agent.progress", { step: "act" }));
+    const first = await logger.append(createEvent(traceId, "run.progress", { step: "act" }));
     const second = await logger.append(
-      createEvent(traceId, "agent.final", { outputs: { answer: 42 } }),
+      createEvent(traceId, "run.finished", { outputs: { answer: 42 }, reason: "completed" }),
     );
 
     const seen: string[] = [];
@@ -42,7 +42,7 @@ describe("replayEpisode", () => {
     expect(events).toHaveLength(2);
     expect(events[0].ln).toBe(first.ln);
     expect(events[1].ln).toBe(second.ln);
-    expect(seen).toEqual(["agent.progress", "agent.final"]);
+    expect(seen).toEqual(["run.progress", "run.finished"]);
   });
 
   it("throws when the episode file is missing", async () => {

--- a/tests/runApi.test.ts
+++ b/tests/runApi.test.ts
@@ -93,7 +93,7 @@ describe("POST /api/run", () => {
         .split("\n")
         .filter(Boolean)
         .map((line) => JSON.parse(line) as Record<string, any>)
-        .filter((event) => event.type === "agent.chat.msg");
+        .filter((event) => event.type === "chat.msg");
 
       expect(chatEvents).toHaveLength(history.length + 2);
       const roles = chatEvents.map((event) => event.data.role);

--- a/tests/runStream.test.ts
+++ b/tests/runStream.test.ts
@@ -1,0 +1,204 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it } from "vitest";
+
+import handler from "../pages/api/runs/[runId]/stream";
+import { createRunEvent, wrapCoreEvent, EventBus, type EventEnvelope } from "../runtime/events";
+import { EpisodeLogger } from "../runtime/episode";
+import { registerRun, markRunCompleted, removeRun } from "../runtime/runRegistry";
+
+interface SseState {
+  statusCode: number;
+  headers: Map<string, string>;
+  chunks: string[];
+  ended: boolean;
+  json?: unknown;
+}
+
+function createSseMocks(runId: string): {
+  req: NextApiRequest & { emit: EventEmitter["emit"] };
+  res: NextApiResponse;
+  state: SseState;
+  reqEmitter: EventEmitter;
+  resEmitter: EventEmitter;
+} {
+  const reqEmitter = new EventEmitter();
+  const resEmitter = new EventEmitter();
+  const state: SseState = { statusCode: 0, headers: new Map(), chunks: [], ended: false };
+
+  const req = {
+    method: "GET",
+    query: { runId },
+    on: reqEmitter.on.bind(reqEmitter),
+  } as unknown as NextApiRequest & { emit: EventEmitter["emit"] };
+  req.emit = reqEmitter.emit.bind(reqEmitter);
+
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    setHeader(name: string, value: string | number | readonly string[]) {
+      const normalized = Array.isArray(value) ? value.join(",") : String(value);
+      state.headers.set(name.toLowerCase(), normalized);
+      return this;
+    },
+    write(chunk: any) {
+      state.chunks.push(typeof chunk === "string" ? chunk : chunk?.toString?.() ?? "");
+      return true;
+    },
+    end(chunk?: any) {
+      if (chunk) {
+        this.write(chunk);
+      }
+      state.ended = true;
+      resEmitter.emit("close");
+      return this;
+    },
+    flushHeaders() {
+      /* noop */
+    },
+    json(payload: any) {
+      state.json = payload;
+      state.ended = true;
+      return this;
+    },
+    on: resEmitter.on.bind(resEmitter),
+    socket: {
+      setKeepAlive() {
+        /* noop */
+      },
+      setNoDelay() {
+        /* noop */
+      },
+      on: resEmitter.on.bind(resEmitter),
+    },
+  } as unknown as NextApiResponse;
+
+  return { req, res, state, reqEmitter, resEmitter };
+}
+
+function parseSse(chunks: string[]): Array<{ event: string; id?: string; data: any }> {
+  const joined = chunks.join("");
+  return joined
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const lines = block.split("\n").filter((line) => line.trim().length > 0 && !line.startsWith(":"));
+      const eventLine = lines.find((line) => line.startsWith("event:"));
+      const idLine = lines.find((line) => line.startsWith("id:"));
+      const dataLines = lines.filter((line) => line.startsWith("data:"));
+      const dataRaw = dataLines.map((line) => line.slice(5).trim()).join("\n");
+      return {
+        event: eventLine ? eventLine.slice(6).trim() : "",
+        id: idLine ? idLine.slice(3).trim() : undefined,
+        data: dataRaw ? JSON.parse(dataRaw) : null,
+      };
+    });
+}
+
+describe("GET /api/runs/[runId]/stream", () => {
+  it("streams historical and live events for an active run", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "run-stream-"));
+    const prevDir = process.env.AOS_EPISODES_DIR;
+    process.env.AOS_EPISODES_DIR = tmp;
+
+    const runId = randomUUID();
+    const bus = new EventBus();
+    const logger = new EpisodeLogger({ traceId: runId, dir: tmp });
+    bus.subscribe(async (event: EventEnvelope) => {
+      await logger.append(event);
+    });
+
+    registerRun(runId, { bus, logger });
+
+    try {
+      await bus.publish(createRunEvent(runId, "run.started", { trace_id: runId }));
+
+      const { req, res, state } = createSseMocks(runId);
+      await handler(req, res);
+
+      await bus.publish(
+        wrapCoreEvent(
+          runId,
+          { type: "progress", step: "act", pct: 0.5 },
+          { spanId: "plan-1", parentSpanId: runId },
+        ),
+      );
+      await bus.publish(
+        wrapCoreEvent(
+          runId,
+          { type: "final", outputs: { text: "done" }, reason: "completed" },
+          { spanId: runId },
+        ),
+      );
+      markRunCompleted(runId);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const events = parseSse(state.chunks);
+      expect(state.statusCode).toBe(200);
+      expect(state.headers.get("content-type")).toContain("text/event-stream");
+      expect(events.some((evt) => evt.event === "run.started")).toBe(true);
+      expect(events.some((evt) => evt.event === "run.progress")).toBe(true);
+      const finished = events.find((evt) => evt.event === "run.finished");
+      expect(finished?.data?.type).toBe("run.finished");
+      expect(finished?.data?.data?.type).toBe("final");
+      expect(finished?.data?.data?.reason).toBe("completed");
+      const endEvent = events.find((evt) => evt.event === "stream.end");
+      expect(endEvent?.data?.reason).toBe("run.finished");
+      expect(state.ended).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+      removeRun(runId);
+      if (prevDir === undefined) {
+        delete process.env.AOS_EPISODES_DIR;
+      } else {
+        process.env.AOS_EPISODES_DIR = prevDir;
+      }
+    }
+  });
+
+  it("replays stored events when run is completed", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "run-history-"));
+    const prevDir = process.env.AOS_EPISODES_DIR;
+    process.env.AOS_EPISODES_DIR = tmp;
+
+    const runId = randomUUID();
+    const logger = new EpisodeLogger({ traceId: runId, dir: tmp });
+
+    try {
+      await logger.append(createRunEvent(runId, "run.started", { trace_id: runId }));
+      await logger.append(
+        wrapCoreEvent(
+          runId,
+          { type: "final", outputs: { answer: 42 }, reason: "completed" },
+          { spanId: runId },
+        ),
+      );
+
+      const { req, res, state } = createSseMocks(runId);
+      await handler(req, res);
+
+      const events = parseSse(state.chunks);
+      expect(state.statusCode).toBe(200);
+      expect(state.ended).toBe(true);
+      expect(events.map((evt) => evt.event)).toContain("run.started");
+      expect(events.map((evt) => evt.event)).toContain("run.finished");
+      const endEvent = events.find((evt) => evt.event === "stream.end");
+      expect(endEvent?.data?.reason).toBe("run.finished");
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+      if (prevDir === undefined) {
+        delete process.env.AOS_EPISODES_DIR;
+      } else {
+        process.env.AOS_EPISODES_DIR = prevDir;
+      }
+    }
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -150,31 +150,47 @@
         }
       }
 
+      function handleEnvelopeEvent(evt) {
+        try {
+          const payload = JSON.parse(evt.data);
+          appendLogLine(JSON.stringify(payload));
+          status.textContent = `Streaming ${payload.type}`;
+        } catch (error) {
+          console.error("Failed to parse event", error);
+        }
+      }
+
       function subscribeToEvents(traceId) {
         closeStream();
-        const source = new EventSource(`/api/run/${traceId}/events`);
+        const source = new EventSource(`/api/runs/${traceId}/stream`);
         eventSource = source;
 
         source.addEventListener("open", () => {
           status.textContent = "Running...";
         });
 
-        source.addEventListener("event", (evt) => {
-          try {
-            const payload = JSON.parse(evt.data);
-            appendLogLine(JSON.stringify(payload));
-            status.textContent = "Streaming events...";
-          } catch (error) {
-            console.error("Failed to parse event", error);
-          }
+        const streamEvents = [
+          "run.started",
+          "run.progress",
+          "plan.updated",
+          "tool.succeeded",
+          "tool.failed",
+          "run.log",
+          "run.ask",
+          "run.score",
+        ];
+
+        streamEvents.forEach((eventName) => {
+          source.addEventListener(eventName, handleEnvelopeEvent);
         });
 
-        source.addEventListener("complete", async (evt) => {
+        source.addEventListener("run.finished", async (evt) => {
+          handleEnvelopeEvent(evt);
           try {
             const payload = JSON.parse(evt.data);
-            const reason = payload.reason ? ` (${payload.reason})` : "";
+            const reason = payload.data?.reason ? ` (${payload.data.reason})` : "";
             status.textContent = `Completed${reason}`;
-            finalOutput.textContent = JSON.stringify(payload.final ?? null, null, 2);
+            finalOutput.textContent = JSON.stringify(payload.data?.outputs ?? null, null, 2);
           } catch (error) {
             status.textContent = "Completed";
             console.error("Failed to parse completion payload", error);
@@ -184,17 +200,28 @@
           closeStream();
         });
 
-        source.addEventListener("run-error", (evt) => {
+        source.addEventListener("run.failed", async (evt) => {
+          handleEnvelopeEvent(evt);
           try {
             const payload = JSON.parse(evt.data);
-            status.textContent = `Failed: ${payload.message || "Unknown error"}`;
-            finalOutput.textContent = payload.message || "Run failed.";
+            const message = payload.data?.message || payload.message || "Run failed.";
+            status.textContent = `Failed: ${message}`;
+            finalOutput.textContent = message;
           } catch (error) {
             status.textContent = "Failed";
             finalOutput.textContent = "Run failed.";
-            console.error("Failed to parse error payload", error);
+            console.error("Failed to parse failure payload", error);
           }
           runButton.disabled = false;
+          await hydrateEpisode(traceId);
+          closeStream();
+        });
+
+        source.addEventListener("stream.end", () => {
+          if (runButton.disabled) {
+            status.textContent = "Stream closed";
+            runButton.disabled = false;
+          }
           closeStream();
         });
 


### PR DESCRIPTION
### Summary
- add a server-sent events endpoint for `/api/runs/[runId]/stream` that replays history, streams live run.* / tool.* envelopes, and sends heartbeat & shutdown events
- introduce a shared run registry plus event renaming helpers so chat/run handlers publish `run.started`, `plan.updated`, `tool.*`, etc. into the episode log and SSE bus
- update the UI LogFlow panel + static demo to consume the SSE stream and adjust tests (including new coverage) for the revised event schema

### Plan
- scope: runtime event bus, run/chat API handlers, SSE endpoint, logflow UI/tests; out of scope: persistence format beyond event type renames; risk: SSE leaks resources; rollback: revert commit

### Diff Overview
- runtime/events.ts, runtime/runRegistry.ts, pages/api/*: emit new run/tool events and share buses/loggers via registry
- pages/api/runs/[runId]/stream.ts: implement SSE handler with history replay, heartbeat, and lifecycle shutdown
- components/LogFlowPanel.tsx, ui/index.html, lib/logflow*.ts: subscribe to SSE envelopes and render updated log messages
- tests/*.ts, scripts/smoke.mjs: align expectations with new event names and add SSE streaming coverage

### Test Evidence
- `pnpm test runStream`

### Impact & Migration
- API: introduce GET `/api/runs/:runId/stream` SSE endpoint, rename emitted event types to `run.*`/`tool.*`; no env/config changes required

### Checklist
- [x] Lint  - [ ] Types  - [x] Tests  - [ ] Docs  - [ ] Security scan

------
https://chatgpt.com/codex/tasks/task_e_68cb9a6f3efc832b8a351858b0f88dc2