### PR TITLE
feat(chat): refactor chat stream ui

### DIFF
--- a/components/LogFlowPanel.tsx
+++ b/components/LogFlowPanel.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type {
-  BranchNode,
-  BranchResponse,
-  LogFlowMessage,
-  MainlineResponse,
-} from "../types/logflow";
+
+import {
+  badgeClass,
+  headingClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  subtleTextClass,
+} from "../lib/theme";
+import type { BranchNode, BranchResponse, LogFlowMessage } from "../types/logflow";
 
 interface LogFlowPanelProps {
   traceId?: string;
@@ -13,6 +17,18 @@ interface LogFlowPanelProps {
 interface RequestState {
   loading: boolean;
   error: string | null;
+}
+
+interface RunEventsResponse {
+  events?: LogFlowMessage[];
+  items?: LogFlowMessage[];
+  next_cursor?: string | null;
+  next?: string | null;
+  stats?: {
+    tokens?: number;
+    cost?: number;
+    latency_ms?: number;
+  };
 }
 
 const initialRequestState: RequestState = { loading: false, error: null };
@@ -25,60 +41,90 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   const [branch, setBranch] = useState<BranchResponse | null>(null);
   const latestSelectionRef = useRef<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [stats, setStats] = useState<{
+    tokens?: number;
+    cost?: number;
+    latency_ms?: number;
+  } | null>(null);
+
   const branchCards = useMemo(() => {
     if (!branch?.tree) return [];
     return flattenBranchNodes(branch.tree);
   }, [branch]);
 
-  useEffect(() => {
-    if (!traceId) {
-      setMessages([]);
-      setSelectedMessage(null);
-      setBranch(null);
-      setMainlineState(initialRequestState);
-      setBranchState(initialRequestState);
-      latestSelectionRef.current = null;
-      return;
-    }
-
-    let cancelled = false;
-    setMainlineState({ loading: true, error: null });
+  const resetState = useCallback(() => {
+    setMessages([]);
     setSelectedMessage(null);
     setBranch(null);
+    setMainlineState(initialRequestState);
     setBranchState(initialRequestState);
     latestSelectionRef.current = null;
+    setCursor(null);
+    setStats(null);
+  }, []);
 
-    const controller = new AbortController();
+  const fetchPage = useCallback(
+    async (runId: string, nextCursor: string | null, append: boolean) => {
+      const params = new URLSearchParams();
+      if (nextCursor) {
+        params.set("cursor", nextCursor);
+      }
+      params.set("limit", "200");
+      const response = await fetch(
+        `/api/runs/${encodeURIComponent(runId)}/events?${params.toString()}`,
+      );
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        throw new Error(detail?.message ?? `Failed to load events (${response.status})`);
+      }
+      const payload = (await response.json()) as RunEventsResponse;
+      const items = payload.events ?? payload.items ?? [];
+      setStats(payload.stats ?? null);
+      setMessages((prev) => (append ? [...prev, ...items] : items));
+      setCursor(payload.next_cursor ?? payload.next ?? null);
+      if (!append && items.length > 0) {
+        setSelectedMessage(items[0]);
+        latestSelectionRef.current = items[0]?.id ?? null;
+      }
+    },
+    [],
+  );
 
-    fetch(`/api/logflow/mainline?trace_id=${encodeURIComponent(traceId)}`, {
-      signal: controller.signal,
-    })
-      .then(async (resp) => {
-        if (!resp.ok) {
-          const detail = await resp.json().catch(() => ({}));
-          throw new Error(detail?.message ?? `Failed to load mainline (${resp.status})`);
-        }
-        return (await resp.json()) as MainlineResponse;
-      })
-      .then((data) => {
-        if (cancelled) return;
-        setMessages(data.messages);
-      })
+  useEffect(() => {
+    if (!traceId) {
+      resetState();
+      return;
+    }
+    let cancelled = false;
+    setMainlineState({ loading: true, error: null });
+    fetchPage(traceId, null, false)
       .catch((err: any) => {
         if (cancelled) return;
-        setMessages([]);
-        setMainlineState({ loading: false, error: err?.message ?? "Failed to load mainline" });
+        resetState();
+        setMainlineState({ loading: false, error: err?.message ?? "Failed to load events" });
       })
       .finally(() => {
         if (cancelled) return;
         setMainlineState((prev) => ({ ...prev, loading: false }));
       });
-
     return () => {
       cancelled = true;
-      controller.abort();
     };
-  }, [traceId]);
+  }, [traceId, fetchPage, resetState]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!traceId || !cursor) return;
+    setLoadingMore(true);
+    fetchPage(traceId, cursor, true)
+      .catch((err: any) => {
+        setMainlineState((prev) => ({ ...prev, error: err?.message ?? "Failed to load events" }));
+      })
+      .finally(() => {
+        setLoadingMore(false);
+      });
+  }, [cursor, fetchPage, traceId]);
 
   const handleSelect = useCallback(
     (message: LogFlowMessage) => {
@@ -163,63 +209,82 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
   }, [selectedPayload]);
 
   return (
-    <section style={{ border: "1px solid #1f2937", borderRadius: 12, padding: "1rem" }}>
-      <header style={{ marginBottom: "0.75rem" }}>
-        <h2 style={{ margin: 0, fontSize: "1.1rem" }}>LogFlow</h2>
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h2 className={headingClass}>LogFlow</h2>
         {traceId ? (
-          <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
-            trace_id: <code>{traceId}</code>
+          <p className={`${subtleTextClass} text-xs`}>
+            trace_id: <code className="text-slate-200">{traceId}</code>
           </p>
         ) : (
-          <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
+          <p className={`${subtleTextClass} text-xs`}>
             Submit a run to see timeline and branch details.
           </p>
         )}
+        {stats ? (
+          <dl className="flex flex-wrap gap-4 text-xs uppercase tracking-[0.18em] text-slate-300">
+            <div className="flex items-center gap-2">
+              <dt className={`${badgeClass} bg-transparent px-2 py-0`}>tokens</dt>
+              <dd>{typeof stats.tokens === "number" ? stats.tokens.toLocaleString() : "–"}</dd>
+            </div>
+            <div className="flex items-center gap-2">
+              <dt className={`${badgeClass} bg-transparent px-2 py-0`}>cost</dt>
+              <dd>{typeof stats.cost === "number" ? stats.cost.toFixed(4) : "–"}</dd>
+            </div>
+            <div className="flex items-center gap-2">
+              <dt className={`${badgeClass} bg-transparent px-2 py-0`}>latency</dt>
+              <dd>
+                {typeof stats.latency_ms === "number" ? `${stats.latency_ms.toFixed(0)} ms` : "–"}
+              </dd>
+            </div>
+          </dl>
+        ) : null}
       </header>
 
-      <div style={{ display: "flex", gap: "1rem", alignItems: "stretch", flexWrap: "wrap" }}>
-        <div style={{ flex: 1 }}>
-          <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Mainline Messages</h3>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <section className="space-y-4" aria-labelledby="logflow-mainline">
+          <div className="flex items-center justify-between gap-2">
+            <h3 id="logflow-mainline" className={headingClass}>
+              Mainline Events
+            </h3>
+            {cursor ? (
+              <button
+                type="button"
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+                className={outlineButtonClass}
+                data-testid="logflow-load-more"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            ) : null}
+          </div>
           {mainlineState.loading ? (
-            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>Loading mainline…</p>
+            <p className={`${subtleTextClass} text-sm`}>Loading events…</p>
           ) : mainlineState.error ? (
-            <p style={{ fontSize: "0.9rem", color: "#f87171" }}>{mainlineState.error}</p>
+            <p className="text-sm text-orange-300">{mainlineState.error}</p>
           ) : messages.length === 0 ? (
-            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>No events recorded yet.</p>
+            <p className={`${subtleTextClass} text-sm`}>No events recorded yet.</p>
           ) : (
-            <ul
-              style={{
-                listStyle: "none",
-                padding: 0,
-                margin: 0,
-                maxHeight: 320,
-                overflowY: "auto",
-              }}
-            >
+            <ul className="space-y-3" data-testid="logflow-events">
               {messages.map((message) => {
                 const isSelected = selectedMessage?.id === message.id;
                 return (
-                  <li key={message.id} style={{ marginBottom: "0.5rem" }}>
+                  <li key={message.id}>
                     <button
                       type="button"
                       onClick={() => handleSelect(message)}
-                      style={{
-                        width: "100%",
-                        textAlign: "left",
-                        borderRadius: 8,
-                        border: "1px solid",
-                        borderColor: isSelected ? "#38bdf8" : "#1f2937",
-                        background: isSelected ? "rgba(56, 189, 248, 0.12)" : "#0f172a",
-                        padding: "0.5rem 0.75rem",
-                        color: "inherit",
-                        cursor: "pointer",
-                      }}
+                      className={`${insetSurfaceClass} w-full border ${
+                        isSelected ? "border-sky-400/70" : "border-slate-800/70"
+                      } text-left transition hover:border-sky-300/80`}
                     >
-                      <div style={{ fontWeight: 600, fontSize: "0.95rem" }}>{message.message}</div>
-                      <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
-                        ln {message.ln}
-                        {message.span_id ? ` · span ${message.span_id}` : ""}
-                        {message.type ? ` · ${message.type}` : ""}
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="font-semibold text-slate-100">{message.message}</span>
+                        <span className={`${subtleTextClass} text-xs`}>
+                          ln {message.ln}
+                          {message.span_id ? ` · span ${message.span_id}` : ""}
+                          {message.type ? ` · ${message.type}` : ""}
+                        </span>
                       </div>
                     </button>
                   </li>
@@ -227,12 +292,14 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
               })}
             </ul>
           )}
-        </div>
+        </section>
 
-        <div style={{ flex: 1, minWidth: 320, display: "grid", gap: "1rem" }}>
-          <h3 style={{ margin: "0 0 0.5rem", fontSize: "1rem" }}>Branch Detail</h3>
+        <section className="space-y-4" aria-labelledby="logflow-branch">
+          <h3 id="logflow-branch" className={headingClass}>
+            Branch Detail
+          </h3>
           {selectedMessage ? (
-            <div style={{ marginBottom: "0.75rem", fontSize: "0.85rem", color: "#94a3b8" }}>
+            <div className={`${subtleTextClass} space-y-1 text-xs`}>
               <div>
                 Selected message ln {selectedMessage.ln}
                 {selectedMessage.span_id ? ` (span ${selectedMessage.span_id})` : ""}
@@ -240,83 +307,56 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
               <div>Type: {selectedMessage.type}</div>
             </div>
           ) : (
-            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+            <p className={`${subtleTextClass} text-sm`}>
               Select a message to inspect its branch timeline.
             </p>
           )}
 
           {branchState.loading ? (
-            <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>Loading branch…</p>
+            <p className={`${subtleTextClass} text-sm`}>Loading branch…</p>
           ) : branchState.error ? (
-            <p style={{ fontSize: "0.9rem", color: "#f87171" }}>{branchState.error}</p>
+            <p className="text-sm text-orange-300">{branchState.error}</p>
           ) : branch ? (
-            <div style={{ display: "grid", gap: "0.75rem" }}>
-              <div>
-                <div style={{ fontSize: "0.85rem", color: "#94a3b8", marginBottom: "0.5rem" }}>
-                  Origin: {branch.origin.span_id ? `span ${branch.origin.span_id}` : "message"}
-                  {branch.origin.ln !== undefined ? ` · ln ${branch.origin.ln}` : ""}
-                </div>
-                {branchCards.length > 0 ? (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexWrap: "wrap",
-                      gap: "0.75rem",
-                    }}
-                  >
-                    {branchCards.map(({ node, depth }) => (
-                      <div
-                        key={`${node.span_id}-${depth}`}
-                        style={{
-                          flex: "1 1 180px",
-                          minWidth: 160,
-                          border: "1px solid #1f2937",
-                          borderRadius: 10,
-                          background: "#0f172a",
-                          padding: "0.75rem",
-                          boxShadow: depth
-                            ? "inset 0 0 0 1px rgba(56, 189, 248, 0.15)"
-                            : "inset 0 0 0 1px rgba(148, 163, 184, 0.2)",
-                        }}
-                      >
-                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
-                          {depth === 0 ? "Root span" : `Depth ${depth}`}
-                        </div>
-                        <div style={{ fontWeight: 600 }}>{node.span_id}</div>
-                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
-                          Parent: {node.parent_span_id ?? "—"}
-                        </div>
-                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
-                          Lines {node.first_ln} – {node.last_ln}
-                        </div>
-                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
-                          Events {node.events.length}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p style={{ fontSize: "0.85rem", color: "#94a3b8" }}>
-                    No span hierarchy available for this selection.
-                  </p>
-                )}
+            <div className="space-y-4">
+              <div className={`${subtleTextClass} text-xs`}>
+                Origin: {branch.origin.span_id ? `span ${branch.origin.span_id}` : "message"}
+                {branch.origin.ln !== undefined ? ` · ln ${branch.origin.ln}` : ""}
               </div>
-              {branch.messages.length > 0 && (
-                <div>
-                  <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Events</h4>
-                  <ul
-                    style={{
-                      listStyle: "none",
-                      padding: 0,
-                      margin: 0,
-                      maxHeight: 200,
-                      overflowY: "auto",
-                    }}
-                  >
+              {branchCards.length > 0 ? (
+                <div className="flex flex-wrap gap-3" data-testid="branch-cards">
+                  {branchCards.map(({ node, depth }) => (
+                    <article
+                      key={`${node.span_id}-${depth}`}
+                      className={`${insetSurfaceClass} min-w-[12rem] flex-1 space-y-2 border-slate-800/70 p-3`}
+                    >
+                      <div className={`${labelClass} text-slate-300`}>
+                        {depth === 0 ? "Root span" : `Depth ${depth}`}
+                      </div>
+                      <div className="text-sm font-semibold text-slate-100">{node.span_id}</div>
+                      <p className={`${subtleTextClass} text-xs`}>
+                        Parent: {node.parent_span_id ?? "—"}
+                      </p>
+                      <p className={`${subtleTextClass} text-xs`}>
+                        Lines {node.first_ln} – {node.last_ln}
+                      </p>
+                      <p className={`${subtleTextClass} text-xs`}>Events {node.events.length}</p>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <p className={`${subtleTextClass} text-sm`}>
+                  No span hierarchy available for this selection.
+                </p>
+              )}
+
+              {branch.messages.length > 0 ? (
+                <div className="space-y-2">
+                  <h4 className={headingClass}>Events</h4>
+                  <ul className="space-y-2" data-testid="branch-events">
                     {branch.messages.map((msg: LogFlowMessage) => (
-                      <li key={msg.id} style={{ marginBottom: "0.4rem" }}>
-                        <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>{msg.message}</div>
-                        <div style={{ fontSize: "0.75rem", color: "#94a3b8" }}>
+                      <li key={msg.id} className={`${insetSurfaceClass} border-slate-800/70 p-3`}>
+                        <div className="font-semibold text-slate-100">{msg.message}</div>
+                        <div className={`${subtleTextClass} text-xs`}>
                           ln {msg.ln}
                           {msg.span_id ? ` · span ${msg.span_id}` : ""}
                           {msg.type ? ` · ${msg.type}` : ""}
@@ -325,78 +365,57 @@ export function LogFlowPanel({ traceId }: LogFlowPanelProps) {
                     ))}
                   </ul>
                 </div>
-              )}
+              ) : null}
+
               {selectedBranchNode ? (
-                <div>
-                  <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Task Tree</h4>
-                  <div style={{ maxHeight: 220, overflowY: "auto" }}>
+                <div className="space-y-2">
+                  <h4 className={headingClass}>Task Tree</h4>
+                  <div
+                    className={`${insetSurfaceClass} max-h-56 space-y-2 overflow-y-auto border-slate-800/70 p-3`}
+                  >
                     {renderBranchNode(selectedBranchNode)}
                   </div>
                 </div>
               ) : (
-                <p style={{ fontSize: "0.9rem", color: "#94a3b8" }}>
+                <p className={`${subtleTextClass} text-sm`}>
                   No task tree available for this selection.
                 </p>
               )}
             </div>
           ) : null}
 
-          {selectedPayload && (
-            <div>
-              <div
-                style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
-              >
-                <h4 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Event Payload</h4>
-                <button
-                  type="button"
-                  onClick={handleCopyPayload}
-                  style={{
-                    padding: "0.25rem 0.75rem",
-                    borderRadius: 999,
-                    border: "1px solid #38bdf8",
-                    background: "transparent",
-                    color: "#38bdf8",
-                    fontSize: "0.8rem",
-                    cursor: "pointer",
-                  }}
-                >
+          {selectedPayload ? (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h4 className={headingClass}>Event Payload</h4>
+                <button type="button" onClick={handleCopyPayload} className={outlineButtonClass}>
                   {copied ? "Copied" : "Copy JSON"}
                 </button>
               </div>
               <pre
-                style={{
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                  background: "#0f172a",
-                  borderRadius: 8,
-                  padding: "0.75rem",
-                  border: "1px solid #1f2937",
-                  maxHeight: 220,
-                  overflowY: "auto",
-                  fontSize: "0.8rem",
-                }}
+                className={`${insetSurfaceClass} max-h-60 overflow-y-auto border-slate-800/70 p-3 text-xs leading-relaxed`}
               >
                 {selectedPayload}
               </pre>
             </div>
-          )}
-        </div>
+          ) : null}
+        </section>
       </div>
-    </section>
+    </div>
   );
 }
 
 function renderBranchNode(node: BranchNode, depth = 0): JSX.Element {
   return (
-    <div key={node.span_id} style={{ marginLeft: depth ? depth * 12 : 0 }}>
-      <div style={{ fontWeight: 600, fontSize: "0.9rem" }}>
+    <div key={node.span_id} className="space-y-1" style={{ marginLeft: depth ? depth * 12 : 0 }}>
+      <div className="text-sm font-semibold text-slate-100">
         span {node.span_id} · ln {node.first_ln} – {node.last_ln}
       </div>
-      <ul style={{ listStyle: "none", padding: 0, margin: "0.25rem 0 0.5rem" }}>
+      <ul className="space-y-1 text-xs text-slate-300">
         {node.events.map((evt: LogFlowMessage) => (
-          <li key={evt.id} style={{ marginBottom: "0.25rem" }}>
-            <div style={{ fontSize: "0.85rem" }}>{evt.message}</div>
-            <div style={{ fontSize: "0.7rem", color: "#94a3b8" }}>
+          <li key={evt.id}>
+            <div>{evt.message}</div>
+            <div className="text-[0.7rem] uppercase tracking-[0.14em] text-slate-400">
               ln {evt.ln}
               {evt.type ? ` · ${evt.type}` : ""}
             </div>

--- a/components/PlanTimeline.tsx
+++ b/components/PlanTimeline.tsx
@@ -1,0 +1,166 @@
+import type { FC } from "react";
+
+import {
+  badgeClass,
+  headingClass,
+  inputSurfaceClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  subtleTextClass,
+} from "../lib/theme";
+
+export interface PlanTimelineStep {
+  id: string;
+  title: string;
+  summary?: string;
+}
+
+export interface PlanTimelineEvent {
+  id: string;
+  ts: string;
+  revision?: number;
+  reason?: string;
+  steps: PlanTimelineStep[];
+}
+
+export interface PlanTimelineLabels {
+  heading: string;
+  filterPlaceholder: string;
+  collapse: string;
+  expand: string;
+  empty: string;
+  updatedAt: (value: string) => string;
+  revision: (value: number | undefined) => string;
+  reason: (value: string | undefined) => string;
+  stepCount: (count: number) => string;
+}
+
+interface PlanTimelineProps {
+  events: PlanTimelineEvent[];
+  filter: string;
+  collapsed: boolean;
+  onFilterChange: (value: string) => void;
+  onToggleCollapse: () => void;
+  labels: PlanTimelineLabels;
+}
+
+const formatTimestamp = (value: string): string => {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString();
+  } catch {
+    return value;
+  }
+};
+
+const PlanTimeline: FC<PlanTimelineProps> = ({
+  events,
+  filter,
+  collapsed,
+  onFilterChange,
+  onToggleCollapse,
+  labels,
+}) => {
+  const normalisedFilter = filter.trim().toLowerCase();
+  const filteredEvents = normalisedFilter
+    ? events
+        .map((event) => {
+          const matchedSteps = event.steps.filter((step) => {
+            const tokens = [step.id, step.title, step.summary]
+              .filter(Boolean)
+              .join(" ")
+              .toLowerCase();
+            return tokens.includes(normalisedFilter);
+          });
+          const matchesMeta = [event.reason, formatTimestamp(event.ts)]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase()
+            .includes(normalisedFilter);
+          return matchedSteps.length > 0 || matchesMeta
+            ? { ...event, steps: matchedSteps.length > 0 ? matchedSteps : event.steps }
+            : null;
+        })
+        .filter((value): value is PlanTimelineEvent => Boolean(value))
+    : events;
+
+  return (
+    <section data-testid="plan-timeline" className="space-y-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className={headingClass}>{labels.heading}</h3>
+          <p className={`${subtleTextClass} text-xs`}>
+            {labels.stepCount(events.reduce((count, evt) => count + evt.steps.length, 0))}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className={`${outlineButtonClass} w-full sm:w-auto`}
+          data-testid="plan-collapse-toggle"
+        >
+          {collapsed ? labels.expand : labels.collapse}
+        </button>
+      </header>
+
+      {!collapsed ? (
+        <div className="space-y-4">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className={`${labelClass} text-slate-400`}>{labels.filterPlaceholder}</span>
+            <input
+              value={filter}
+              onChange={(event) => onFilterChange(event.target.value)}
+              placeholder={labels.filterPlaceholder}
+              className={`${inputSurfaceClass} w-full`}
+              data-testid="plan-filter-input"
+            />
+          </label>
+
+          {filteredEvents.length === 0 ? (
+            <p className={`${subtleTextClass} text-sm`}>{labels.empty}</p>
+          ) : (
+            <ol className="space-y-4" data-testid="plan-events">
+              {filteredEvents.map((event) => (
+                <li
+                  key={event.id}
+                  className={`${insetSurfaceClass} space-y-3 border-slate-800/60 p-4`}
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em]">
+                    <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>
+                      {labels.revision(event.revision)}
+                    </span>
+                    <span className={`${badgeClass} text-slate-300`}>
+                      {labels.updatedAt(event.ts)}
+                    </span>
+                    {event.reason ? (
+                      <span className={`${badgeClass} text-amber-200/90`}>
+                        {labels.reason(event.reason)}
+                      </span>
+                    ) : null}
+                  </div>
+                  <ul className="space-y-2 text-sm">
+                    {event.steps.map((step) => (
+                      <li key={`${event.id}-${step.id}`} className="space-y-1">
+                        <div className="font-semibold text-slate-100">{step.title}</div>
+                        {step.summary ? (
+                          <p className={`${subtleTextClass} text-xs`}>{step.summary}</p>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default PlanTimeline;

--- a/components/SkillPanel.tsx
+++ b/components/SkillPanel.tsx
@@ -1,0 +1,191 @@
+import type { FC } from "react";
+
+import {
+  badgeClass,
+  headingClass,
+  inputSurfaceClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  subtleTextClass,
+} from "../lib/theme";
+
+export type SkillEvent =
+  | {
+      id: string;
+      type: "tool";
+      ts: string;
+      name: string;
+      status: "started" | "succeeded" | "failed";
+      spanId?: string;
+      argsSummary?: string;
+      resultSummary?: string;
+      cost?: number | null;
+      latencyMs?: number | null;
+      tokens?: number | null;
+    }
+  | {
+      id: string;
+      type: "note";
+      ts: string;
+      level?: string;
+      text: string;
+    };
+
+export interface SkillPanelLabels {
+  heading: string;
+  filterPlaceholder: string;
+  collapse: string;
+  expand: string;
+  empty: string;
+  status: {
+    started: string;
+    succeeded: string;
+    failed: string;
+  };
+  metricLabels: {
+    latency: string;
+    cost: string;
+    tokens: string;
+  };
+  metrics: {
+    cost: (value: number | null | undefined) => string;
+    latency: (value: number | null | undefined) => string;
+    tokens: (value: number | null | undefined) => string;
+  };
+  noteLabel: (level?: string) => string;
+}
+
+interface SkillPanelProps {
+  events: SkillEvent[];
+  filter: string;
+  collapsed: boolean;
+  onFilterChange: (value: string) => void;
+  onToggleCollapse: () => void;
+  labels: SkillPanelLabels;
+}
+
+const describeEvent = (event: SkillEvent): string => {
+  if (event.type === "note") {
+    return `${event.level ?? "note"} ${event.text}`.toLowerCase();
+  }
+  return [event.name, event.status, event.argsSummary, event.resultSummary, event.spanId]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+};
+
+const SkillPanel: FC<SkillPanelProps> = ({
+  events,
+  filter,
+  collapsed,
+  onFilterChange,
+  onToggleCollapse,
+  labels,
+}) => {
+  const normalisedFilter = filter.trim().toLowerCase();
+  const filteredEvents = normalisedFilter
+    ? events.filter((event) => describeEvent(event).includes(normalisedFilter))
+    : events;
+
+  return (
+    <section data-testid="skill-panel" className="space-y-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className={headingClass}>{labels.heading}</h3>
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className={`${outlineButtonClass} w-full sm:w-auto`}
+          data-testid="skill-collapse-toggle"
+        >
+          {collapsed ? labels.expand : labels.collapse}
+        </button>
+      </header>
+
+      {!collapsed ? (
+        <div className="space-y-4">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className={`${labelClass} text-slate-400`}>{labels.filterPlaceholder}</span>
+            <input
+              value={filter}
+              onChange={(event) => onFilterChange(event.target.value)}
+              placeholder={labels.filterPlaceholder}
+              className={`${inputSurfaceClass} w-full`}
+              data-testid="skill-filter-input"
+            />
+          </label>
+
+          {filteredEvents.length === 0 ? (
+            <p className={`${subtleTextClass} text-sm`}>{labels.empty}</p>
+          ) : (
+            <ul className="space-y-3" data-testid="skill-events">
+              {filteredEvents.map((event) =>
+                event.type === "tool" ? (
+                  <li
+                    key={event.id}
+                    className={`${insetSurfaceClass} space-y-2 border-slate-800/60 p-4`}
+                    data-kind="tool"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em]">
+                      <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>
+                        {event.name}
+                      </span>
+                      <span className={`${badgeClass} text-slate-300`}>
+                        {labels.status[event.status] ?? event.status}
+                      </span>
+                      {event.spanId ? (
+                        <span className={`${badgeClass} text-slate-300`}>span {event.spanId}</span>
+                      ) : null}
+                    </div>
+                    {event.argsSummary ? (
+                      <p className={`${subtleTextClass} text-xs`}>{event.argsSummary}</p>
+                    ) : null}
+                    {event.resultSummary ? (
+                      <p className={`${subtleTextClass} text-xs`}>{event.resultSummary}</p>
+                    ) : null}
+                    <dl className="grid gap-2 text-[0.7rem] uppercase tracking-[0.18em] text-slate-300">
+                      <div className="flex items-center gap-2">
+                        <dt className={`${badgeClass} bg-transparent px-2 py-0`}>
+                          {labels.metricLabels.latency}
+                        </dt>
+                        <dd>{labels.metrics.latency(event.latencyMs)}</dd>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <dt className={`${badgeClass} bg-transparent px-2 py-0`}>
+                          {labels.metricLabels.cost}
+                        </dt>
+                        <dd>{labels.metrics.cost(event.cost)}</dd>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <dt className={`${badgeClass} bg-transparent px-2 py-0`}>
+                          {labels.metricLabels.tokens}
+                        </dt>
+                        <dd>{labels.metrics.tokens(event.tokens)}</dd>
+                      </div>
+                    </dl>
+                  </li>
+                ) : (
+                  <li
+                    key={event.id}
+                    className={`${insetSurfaceClass} space-y-2 border-amber-500/30 bg-amber-500/5 p-4`}
+                    data-kind="note"
+                  >
+                    <div className={`${badgeClass} text-amber-200/90`}>
+                      {labels.noteLabel(event.level)}
+                    </div>
+                    <p className="text-sm text-amber-100">{event.text}</p>
+                    <p className={`${subtleTextClass} text-xs`}>
+                      {new Date(event.ts).toLocaleString()}
+                    </p>
+                  </li>
+                ),
+              )}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default SkillPanel;

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -11,6 +11,9 @@ export const panelSurfaceClass =
 export const insetSurfaceClass =
   "rounded-2xl border border-slate-800/70 bg-slate-950/60 shadow-inner shadow-slate-950/40";
 
+export const inputSurfaceClass =
+  "rounded-2xl border border-slate-800/70 bg-slate-950/70 px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400";
+
 export const pillGroupClass =
   "flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 p-1.5 text-sm";
 
@@ -28,6 +31,12 @@ export const primaryButtonClass =
 
 export const outlineButtonClass =
   "inline-flex items-center justify-center rounded-full border border-sky-400/70 px-5 py-2 text-sm font-semibold text-sky-200 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 enabled:hover:border-sky-300 enabled:hover:text-sky-100 disabled:cursor-not-allowed disabled:opacity-50";
+
+export const modalBackdropClass =
+  "fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm transition-opacity";
+
+export const modalSurfaceClass =
+  "z-50 w-full max-w-lg rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6 shadow-[0_30px_90px_rgba(8,15,35,0.65)]";
 
 export type ChatRoleTone = "user" | "assistant" | "system";
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -19,16 +19,23 @@
     "inputLabel": "Chat input",
     "placeholder": "Ask the agent for a summary or instruction...",
     "metrics": {
+      "heading": "Run metrics",
       "traceId": "Trace ID",
+      "progress": "Progress",
       "latency": "Latency",
-      "cost": "Cost"
+      "cost": "Cost",
+      "tokens": "Tokens",
+      "streamingNotice": "Status updates as new events stream in from the agent runtime."
     },
     "submit": {
       "run": "Run",
-      "running": "Running…"
+      "running": "Running…",
+      "confirming": "Awaiting approval"
     },
     "statusIndicator": {
       "running": "Running agent",
+      "awaitingConfirmation": "Awaiting confirmation",
+      "error": "Run error",
       "ready": "Ready",
       "idle": "Idle"
     },
@@ -55,6 +62,51 @@
         "sent": "Sent"
       }
     }
+  },
+  "panels": {
+    "plan": {
+      "heading": "Plan timeline",
+      "filter": "Filter plan steps",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "empty": "No plan updates yet.",
+      "updatedAt": "Updated {value}",
+      "revision": "Revision {value}",
+      "revisionUnknown": "Revision –",
+      "reason": "Reason: {reason}",
+      "reasonUnknown": "Reason: n/a",
+      "stepCount": "Total steps: {count}"
+    },
+    "skills": {
+      "heading": "Tools & notes",
+      "filter": "Filter tool runs",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "empty": "No tool activity yet.",
+      "status": {
+        "started": "started",
+        "succeeded": "succeeded",
+        "failed": "failed"
+      },
+      "metric": {
+        "na": "–"
+      },
+      "note": "Note",
+      "noteLabel": "Note ({level})",
+      "scoreNote": "Score {value} (passed: {passed})",
+      "score": "Score update"
+    }
+  },
+  "confirmation": {
+    "title": "Approve sensitive action",
+    "subtitle": "The agent is requesting approval before continuing.",
+    "defaultPrompt": "Approve the pending operation?",
+    "systemNotice": "Confirmation required: {message}",
+    "approve": "Allow",
+    "reject": "Deny",
+    "approved": "User approved: {message}",
+    "denied": "User denied: {message}",
+    "deniedStatus": "Run cancelled by user"
   },
   "roles": {
     "user": "user",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -19,16 +19,23 @@
     "inputLabel": "聊天输入",
     "placeholder": "请向代理提问或发送指令…",
     "metrics": {
-      "traceId": "Trace ID",
+      "heading": "运行指标",
+      "traceId": "追踪 ID",
+      "progress": "进度",
       "latency": "延迟",
-      "cost": "成本"
+      "cost": "成本",
+      "tokens": "令牌数",
+      "streamingNotice": "状态会随运行事件流式更新。"
     },
     "submit": {
       "run": "运行",
-      "running": "运行中…"
+      "running": "运行中…",
+      "confirming": "等待确认"
     },
     "statusIndicator": {
       "running": "代理运行中",
+      "awaitingConfirmation": "等待确认",
+      "error": "运行出错",
       "ready": "就绪",
       "idle": "空闲"
     },
@@ -55,6 +62,51 @@
         "sent": "已发送"
       }
     }
+  },
+  "panels": {
+    "plan": {
+      "heading": "计划时间线",
+      "filter": "筛选计划步骤",
+      "collapse": "折叠",
+      "expand": "展开",
+      "empty": "尚无计划更新。",
+      "updatedAt": "更新时间 {value}",
+      "revision": "修订版 {value}",
+      "revisionUnknown": "修订版未知",
+      "reason": "原因：{reason}",
+      "reasonUnknown": "原因：无",
+      "stepCount": "步骤总数：{count}"
+    },
+    "skills": {
+      "heading": "工具与备注",
+      "filter": "筛选工具调用",
+      "collapse": "折叠",
+      "expand": "展开",
+      "empty": "暂无工具调用。",
+      "status": {
+        "started": "已开始",
+        "succeeded": "已完成",
+        "failed": "失败"
+      },
+      "metric": {
+        "na": "–"
+      },
+      "note": "备注",
+      "noteLabel": "备注（{level}）",
+      "scoreNote": "得分 {value}（通过：{passed}）",
+      "score": "评分更新"
+    }
+  },
+  "confirmation": {
+    "title": "确认敏感操作",
+    "subtitle": "代理在继续之前需要您的授权。",
+    "defaultPrompt": "是否批准当前操作？",
+    "systemNotice": "需要确认：{message}",
+    "approve": "允许",
+    "reject": "拒绝",
+    "approved": "用户已允许：{message}",
+    "denied": "用户已拒绝：{message}",
+    "deniedStatus": "运行被用户取消"
   },
   "roles": {
     "user": "用户",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,23 @@
-import { FormEventHandler, useCallback, useMemo, useState } from "react";
+import { FormEventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NextPage } from "next";
+
 import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 import LogFlowPanel from "../components/LogFlowPanel";
+import PlanTimeline, {
+  type PlanTimelineEvent,
+  type PlanTimelineStep,
+} from "../components/PlanTimeline";
+import SkillPanel, { type SkillEvent } from "../components/SkillPanel";
 import { useI18n } from "../lib/i18n/index";
 import {
   badgeClass,
   headerSurfaceClass,
   headingClass,
   insetSurfaceClass,
+  inputSurfaceClass,
   labelClass,
+  modalBackdropClass,
+  modalSurfaceClass,
   outlineButtonClass,
   pageContainerClass,
   panelSurfaceClass,
@@ -19,26 +28,38 @@ import {
 } from "../lib/theme";
 
 interface ChatSendResponse {
-  trace_id?: string;
-  msg_id?: string;
-  message?: {
-    msg_id?: string;
-    role?: string;
-    content?: string;
-    text?: string;
-    ts?: string;
-    trace_id?: string;
-    error?: string;
-  };
-  result?: { text?: string; msg_id?: string; ts?: string; error?: string };
-  output?: { text?: string; msg_id?: string; ts?: string; error?: string };
-  final?: { text?: string; msg_id?: string; ts?: string; error?: string };
-  metrics?: { latency_ms?: number; cost?: number };
+  trace_id: string;
+  result?: unknown;
+  reason?: string;
+  events?: Array<{
+    ts: string;
+    type: string;
+    span_id?: string;
+    parent_span_id?: string;
+    data?: any;
+  }>;
   error?: { message?: string } | null;
-  message_error?: string;
-  reason?: "completed" | "no-plan" | "ask" | "max-iterations";
-  review?: { notes?: string[]; score?: number; passed?: boolean } | null;
 }
+
+interface StreamEventEnvelope {
+  id: string;
+  ts: string;
+  type: string;
+  trace_id?: string;
+  span_id?: string;
+  parent_span_id?: string;
+  data?: any;
+}
+
+interface ConfirmationRequestState {
+  id: string;
+  ts: string;
+  message: string;
+  context?: any;
+  level?: string;
+}
+
+type RunStatus = "idle" | "running" | "awaiting-confirmation" | "completed" | "error";
 
 const generateLocalId = (): string => {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -56,20 +77,487 @@ const serialiseHistoryForRequest = (messages: ChatHistoryMessage[]) =>
     ts: message.ts,
   }));
 
+const parseStreamPayload = (raw: string): StreamEventEnvelope | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StreamEventEnvelope;
+    if (parsed && typeof parsed === "object" && typeof parsed.type === "string") {
+      return {
+        id: parsed.id ?? generateLocalId(),
+        ts: parsed.ts ?? new Date().toISOString(),
+        type: parsed.type,
+        trace_id: parsed.trace_id,
+        span_id: parsed.span_id,
+        parent_span_id: parsed.parent_span_id,
+        data: parsed.data,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+const normaliseEventType = (type?: string): string => {
+  if (!type) return "";
+  if (type.startsWith("agent.")) {
+    return type.slice(6);
+  }
+  return type;
+};
+
+const summarisePlanStep = (step: any): PlanTimelineStep => {
+  const title =
+    typeof step?.title === "string"
+      ? step.title
+      : typeof step?.op === "string"
+        ? step.op
+        : typeof step?.id === "string"
+          ? step.id
+          : "step";
+  const summarySource =
+    typeof step?.description === "string"
+      ? step.description
+      : typeof step?.args?.summary === "string"
+        ? step.args.summary
+        : typeof step?.args?.prompt === "string"
+          ? step.args.prompt
+          : undefined;
+  const summary = summarySource
+    ? summarySource.length > 280
+      ? `${summarySource.slice(0, 277)}...`
+      : summarySource
+    : undefined;
+  return {
+    id: typeof step?.id === "string" ? step.id : generateLocalId(),
+    title,
+    summary,
+  };
+};
+
+const summariseArgs = (args: any): string | undefined => {
+  if (!args) return undefined;
+  if (typeof args === "string") {
+    return args.length > 160 ? `${args.slice(0, 157)}...` : args;
+  }
+  if (typeof args === "object") {
+    if (typeof args.prompt === "string") {
+      const prompt = args.prompt.trim();
+      return prompt.length > 160 ? `${prompt.slice(0, 157)}...` : prompt;
+    }
+    if (typeof args.query === "string") {
+      const query = args.query.trim();
+      return query.length > 160 ? `${query.slice(0, 157)}...` : query;
+    }
+    try {
+      const json = JSON.stringify(args);
+      return json.length > 160 ? `${json.slice(0, 157)}...` : json;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+const summariseResult = (result: any): string | undefined => {
+  if (result == null) return undefined;
+  if (typeof result === "string") {
+    const trimmed = result.trim();
+    return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
+  }
+  if (typeof result === "object") {
+    if (typeof result.text === "string") {
+      const text = result.text.trim();
+      return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+    }
+    if (typeof result.content === "string") {
+      const text = result.content.trim();
+      return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+    }
+    if (typeof result.message === "string") {
+      const text = result.message.trim();
+      return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+    }
+    try {
+      const json = JSON.stringify(result);
+      return json.length > 160 ? `${json.slice(0, 157)}...` : json;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+const extractNumeric = (value: any): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+};
+
+const extractTokens = (payload: any): number | null => {
+  if (!payload || typeof payload !== "object") return null;
+  const direct = extractNumeric((payload as any).tokens);
+  if (direct !== null) return direct;
+  const nestedTotal = extractNumeric((payload as any).tokens?.total);
+  if (nestedTotal !== null) return nestedTotal;
+  const usageTotal = extractNumeric((payload as any).usage?.total_tokens);
+  if (usageTotal !== null) return usageTotal;
+  const usageTotalAlt = extractNumeric((payload as any).usage?.total);
+  if (usageTotalAlt !== null) return usageTotalAlt;
+  return null;
+};
+
 const HomePage: NextPage = () => {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [input, setInput] = useState("");
-  const [isRunning, setIsRunning] = useState(false);
+  const [runStatus, setRunStatus] = useState<RunStatus>("idle");
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
-  const [latestResponse, setLatestResponse] = useState<any>(null);
   const [chatHistory, setChatHistory] = useState<ChatHistoryMessage[]>([]);
   const [runError, setRunError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
-  const [latencyMs, setLatencyMs] = useState<number | null>(null);
-  const [cost, setCost] = useState<number | null>(null);
   const [finalOutput, setFinalOutput] = useState<any>(null);
+  const [lastEvent, setLastEvent] = useState<StreamEventEnvelope | null>(null);
+  const [planEvents, setPlanEvents] = useState<PlanTimelineEvent[]>([]);
+  const [planFilter, setPlanFilter] = useState("");
+  const [planCollapsed, setPlanCollapsed] = useState(false);
+  const [skillEvents, setSkillEvents] = useState<SkillEvent[]>([]);
+  const [skillFilter, setSkillFilter] = useState("");
+  const [skillCollapsed, setSkillCollapsed] = useState(false);
+  const [confirmationRequest, setConfirmationRequest] = useState<ConfirmationRequestState | null>(
+    null,
+  );
+  const [progressPct, setProgressPct] = useState<number | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const retryTimerRef = useRef<number | null>(null);
+  const retryAttemptRef = useRef(0);
+  const currentTraceRef = useRef<string | undefined>(undefined);
 
   const draftInput = useMemo(() => input.trim(), [input]);
+
+  const resetForRun = useCallback(() => {
+    setPlanEvents([]);
+    setSkillEvents([]);
+    setFinalOutput(null);
+    setLastEvent(null);
+    setPlanFilter("");
+    setSkillFilter("");
+    setPlanCollapsed(false);
+    setSkillCollapsed(false);
+    setConfirmationRequest(null);
+    setProgressPct(null);
+    setRunError(null);
+  }, []);
+
+  const closeStream = useCallback(() => {
+    if (retryTimerRef.current != null && typeof window !== "undefined") {
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    retryAttemptRef.current = 0;
+  }, []);
+
+  useEffect(() => () => closeStream(), [closeStream]);
+
+  const handleStreamEvent = useCallback(
+    (event: StreamEventEnvelope) => {
+      if (!event || typeof event.type !== "string") {
+        return;
+      }
+      setLastEvent(event);
+      if (event.trace_id && event.trace_id !== traceId) {
+        setTraceId(event.trace_id);
+      }
+      const kind = normaliseEventType(event.type);
+
+      if (kind === "chat.msg" || kind === "chat.message") {
+        const payload = event.data ?? {};
+        const role = typeof payload.role === "string" ? payload.role : "assistant";
+        const content =
+          typeof payload.text === "string"
+            ? payload.text
+            : typeof payload.content === "string"
+              ? payload.content
+              : "";
+        const msgId = typeof payload.msg_id === "string" ? payload.msg_id : event.id;
+        const timestamp = event.ts ?? new Date().toISOString();
+        setChatHistory((history) => {
+          const next = [...history];
+          if (role === "user") {
+            for (let index = next.length - 1; index >= 0; index -= 1) {
+              const message = next[index];
+              if (message.role === "user" && !message.msgId) {
+                next[index] = {
+                  ...message,
+                  msgId,
+                  status: "done",
+                  ts: timestamp,
+                  content: content || message.content,
+                  traceId: event.trace_id ?? message.traceId,
+                };
+                return next;
+              }
+            }
+          }
+          const existingIndex = next.findIndex((item) => item.msgId === msgId);
+          if (existingIndex >= 0) {
+            next[existingIndex] = {
+              ...next[existingIndex],
+              content: content || next[existingIndex].content,
+              status: "done",
+              ts: timestamp,
+              traceId: event.trace_id ?? next[existingIndex].traceId,
+            };
+            return next;
+          }
+          const message: ChatHistoryMessage = {
+            id: msgId ?? generateLocalId(),
+            msgId,
+            role: role === "system" ? "system" : role === "user" ? "user" : "assistant",
+            content,
+            ts: timestamp,
+            status: "done",
+            traceId: event.trace_id,
+          };
+          return [...next, message];
+        });
+        return;
+      }
+
+      if (kind === "plan" || kind === "plan.updated") {
+        const data = event.data ?? {};
+        const steps = Array.isArray(data.steps) ? data.steps.map(summarisePlanStep) : [];
+        const revisionValue = typeof data.revision === "number" ? data.revision : undefined;
+        const reasonText = typeof data.reason === "string" ? data.reason : undefined;
+        const planEvent: PlanTimelineEvent = {
+          id: event.id,
+          ts: event.ts ?? new Date().toISOString(),
+          revision: revisionValue,
+          reason: reasonText,
+          steps,
+        };
+        setPlanEvents((existing) => {
+          const index = existing.findIndex((item) => item.id === planEvent.id);
+          if (index >= 0) {
+            const next = [...existing];
+            next[index] = planEvent;
+            return next;
+          }
+          return [...existing, planEvent].sort((a, b) => {
+            const aTime = new Date(a.ts).getTime();
+            const bTime = new Date(b.ts).getTime();
+            return aTime - bTime;
+          });
+        });
+        return;
+      }
+
+      if (kind === "progress") {
+        const pct = extractNumeric(event.data?.pct);
+        if (pct !== null) {
+          setProgressPct(Math.max(0, Math.min(1, pct)));
+        }
+        return;
+      }
+
+      if (kind.startsWith("tool")) {
+        const data = event.data ?? {};
+        const spanKey = event.span_id ?? event.id;
+        const status: SkillEvent["status"] =
+          kind === "tool.failed" ? "failed" : kind === "tool.started" ? "started" : "succeeded";
+        const name =
+          typeof data.name === "string"
+            ? data.name
+            : typeof data.tool === "string"
+              ? data.tool
+              : "tool";
+        const result = data.result ?? data.output ?? data.response;
+        const cost = extractNumeric(data.cost ?? result?.cost);
+        const latencyMs = extractNumeric(data.latency_ms ?? result?.latency_ms);
+        const tokens = extractTokens(result);
+        const argsSummary = summariseArgs(data.args);
+        const resultSummary = summariseResult(result ?? data.error ?? data.message);
+        setSkillEvents((previous) => {
+          let updated = false;
+          const next = previous.map((item) => {
+            if (item.type === "tool" && (item.id === spanKey || item.spanId === spanKey)) {
+              updated = true;
+              return {
+                ...item,
+                ts: event.ts ?? item.ts,
+                status,
+                name,
+                spanId: event.span_id ?? item.spanId,
+                argsSummary: argsSummary ?? item.argsSummary,
+                resultSummary: resultSummary ?? item.resultSummary,
+                cost: cost ?? item.cost ?? null,
+                latencyMs: latencyMs ?? item.latencyMs ?? null,
+                tokens: tokens ?? item.tokens ?? null,
+              };
+            }
+            return item;
+          });
+          if (!updated) {
+            const entry: SkillEvent = {
+              type: "tool",
+              id: spanKey ?? generateLocalId(),
+              ts: event.ts ?? new Date().toISOString(),
+              name,
+              status,
+              spanId: event.span_id,
+              argsSummary,
+              resultSummary,
+              cost: cost ?? null,
+              latencyMs: latencyMs ?? null,
+              tokens: tokens ?? null,
+            };
+            next.push(entry);
+          }
+          return next.sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+        });
+        return;
+      }
+
+      if (kind === "reflect.note" || kind === "score" || kind === "ask" || kind === "log") {
+        const level =
+          kind === "reflect.note"
+            ? event.data?.level
+            : kind === "score"
+              ? "score"
+              : kind === "ask"
+                ? "ask"
+                : (event.data?.level ?? "log");
+        const text =
+          kind === "score"
+            ? t("panels.skills.scoreNote", {
+                value: event.data?.value ?? "–",
+                passed: String(event.data?.passed ?? ""),
+              })
+            : kind === "ask"
+              ? (event.data?.question ?? "")
+              : typeof event.data?.text === "string"
+                ? event.data.text
+                : (event.data?.message ?? "");
+        if (typeof text === "string" && text.trim().length > 0) {
+          setSkillEvents((previous) => {
+            if (previous.some((item) => item.id === event.id)) {
+              return previous;
+            }
+            const entry: SkillEvent = {
+              type: "note",
+              id: event.id,
+              ts: event.ts ?? new Date().toISOString(),
+              level: typeof level === "string" ? level : undefined,
+              text,
+            };
+            return [...previous, entry].sort(
+              (a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime(),
+            );
+          });
+        }
+        if (kind === "log" && event.data?.level === "error") {
+          setRunStatus("error");
+          setRunError(event.data?.message ?? t("chat.runFailure"));
+        }
+        return;
+      }
+
+      if (kind === "user.confirm.request") {
+        const prompt =
+          typeof event.data?.prompt === "string"
+            ? event.data.prompt
+            : typeof event.data?.message === "string"
+              ? event.data.message
+              : t("confirmation.defaultPrompt");
+        setConfirmationRequest({
+          id: event.id,
+          ts: event.ts ?? new Date().toISOString(),
+          message: prompt,
+          context: event.data,
+          level: event.data?.level,
+        });
+        setRunStatus("awaiting-confirmation");
+        setChatHistory((history) => [
+          ...history,
+          {
+            id: generateLocalId(),
+            role: "system",
+            content: t("confirmation.systemNotice", { message: prompt }),
+            ts: event.ts ?? new Date().toISOString(),
+            status: "pending",
+          },
+        ]);
+        return;
+      }
+
+      if (kind === "final" || kind === "run.finished") {
+        const outputs = event.data?.outputs ?? event.data?.result ?? event.data;
+        setFinalOutput(outputs);
+        setRunStatus("completed");
+        setProgressPct(1);
+        closeStream();
+        return;
+      }
+
+      if (kind === "error") {
+        setRunStatus("error");
+        setRunError(
+          typeof event.data?.message === "string" ? event.data.message : t("chat.runFailure"),
+        );
+        closeStream();
+      }
+    },
+    [closeStream, t, traceId],
+  );
+
+  const startStream = useCallback(
+    (runId: string) => {
+      if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
+        return;
+      }
+      closeStream();
+      currentTraceRef.current = runId;
+      try {
+        const source = new window.EventSource(`/api/runs/${encodeURIComponent(runId)}/stream`);
+        eventSourceRef.current = source;
+        source.onopen = () => {
+          retryAttemptRef.current = 0;
+        };
+        source.onmessage = (evt) => {
+          const payload = parseStreamPayload(evt.data);
+          if (payload) {
+            handleStreamEvent(payload);
+          }
+        };
+        source.onerror = () => {
+          if (eventSourceRef.current) {
+            eventSourceRef.current.close();
+            eventSourceRef.current = null;
+          }
+          const attempt = retryAttemptRef.current + 1;
+          retryAttemptRef.current = attempt;
+          const delay = Math.min(15000, 1000 * Math.pow(2, attempt - 1));
+          if (typeof window !== "undefined") {
+            if (retryTimerRef.current != null) {
+              window.clearTimeout(retryTimerRef.current);
+            }
+            retryTimerRef.current = window.setTimeout(() => {
+              if (currentTraceRef.current === runId) {
+                startStream(runId);
+              }
+            }, delay);
+          }
+        };
+      } catch (error) {
+        console.error("failed to open run stream", error);
+      }
+    },
+    [closeStream, handleStreamEvent],
+  );
 
   const handleSaveConversation = useCallback(() => {
     const entries: Array<Record<string, unknown>> = chatHistory.map((message) => ({
@@ -119,9 +607,9 @@ const HomePage: NextPage = () => {
   }, [chatHistory, draftInput, traceId]);
 
   const handleRun = useCallback(async () => {
-    if (isRunning) return;
-    const prompt = input.trim();
-    if (!prompt) return;
+    if (!draftInput || runStatus === "running" || runStatus === "awaiting-confirmation") {
+      return;
+    }
 
     const previousHistory = chatHistory;
     const previousTraceId = traceId;
@@ -130,126 +618,85 @@ const HomePage: NextPage = () => {
     const userMessage: ChatHistoryMessage = {
       id: localId,
       role: "user",
-      content: prompt,
+      content: draftInput,
       ts: createdAt,
       status: "pending",
       traceId,
     };
-    const historyForRequest = [...previousHistory, userMessage];
 
-    setChatHistory(historyForRequest);
-    setIsRunning(true);
-    setRunError(null);
+    setChatHistory([...previousHistory, userMessage]);
+    setRunStatus("running");
+    resetForRun();
     setTraceId(undefined);
-    setLatestResponse(null);
-    setLatencyMs(null);
-    setCost(null);
-    setFinalOutput(null);
     setInput("");
-    const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+
     try {
       const serialisedHistory = serialiseHistoryForRequest(previousHistory);
       const messagesForRequest = serialisedHistory.map(({ role, content }) => ({ role, content }));
 
-      const response = await fetch("/api/chat/send", {
+      const response = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          text: prompt,
+          message: draftInput,
           messages: messagesForRequest,
           history: serialisedHistory,
           ...(previousTraceId ? { trace_id: previousTraceId } : {}),
         }),
       });
+
       const data: ChatSendResponse | null = await response.json().catch(() => null);
-      if (!response.ok || !data || data.error || data.message_error) {
+      if (!response.ok || !data) {
         const errorMessage =
           (data?.error as { message?: string } | undefined)?.message ??
-          data?.message_error ??
-          data?.message?.content ??
           t("errors.requestFailed", { status: response.status });
         throw new Error(errorMessage);
       }
-      setLatestResponse(data);
-      const resolvedTraceId = data.trace_id ?? data.message?.trace_id ?? previousTraceId ?? traceId;
-      setTraceId(resolvedTraceId);
-      setFinalOutput(data.result ?? data.final ?? data.output ?? data.message ?? null);
 
-      const computedLatency =
-        data.metrics?.latency_ms ??
-        (typeof performance !== "undefined"
-          ? Math.round(performance.now() - startedAt)
-          : Date.now() - startedAt);
-      const computedCost = data.metrics?.cost ?? null;
-      setLatencyMs(typeof computedLatency === "number" ? computedLatency : null);
-      setCost(typeof computedCost === "number" ? computedCost : null);
-
-      const assistantPayload = (data.message ?? data.result ?? data.output ?? data.final ?? {}) as {
-        content?: string;
-        text?: string;
-        msg_id?: string;
-        ts?: string;
-        trace_id?: string;
-        error?: string;
-      };
-      const isCompleted = (data.reason ?? "completed") === "completed";
-      const assistantMsgId = assistantPayload.msg_id ?? data.msg_id ?? generateLocalId();
-      const assistantTs = assistantPayload.ts ?? new Date().toISOString();
-      const assistantErrorText =
-        typeof assistantPayload.error === "string"
-          ? assistantPayload.error
-          : undefined;
-      const assistantContentRaw =
-        typeof assistantPayload.content === "string"
-          ? assistantPayload.content
-          : typeof assistantPayload.text === "string"
-            ? assistantPayload.text
-            : assistantErrorText ??
-              (assistantPayload && typeof assistantPayload === "object"
-                ? JSON.stringify(assistantPayload)
-                : "");
-      const assistantContent =
-        typeof assistantContentRaw === "string" && assistantContentRaw.length > 0
-          ? assistantContentRaw
-          : assistantErrorText ?? "";
-
-      setChatHistory((history) => {
-        const updatedHistory: ChatHistoryMessage[] = history.map((message) =>
+      setChatHistory((history) =>
+        history.map((message) =>
           message.id === localId
             ? {
                 ...message,
-                msgId: data.msg_id ?? message.msgId,
-                traceId: resolvedTraceId,
-                status: "done" as const,
+                status: "sent",
               }
             : message,
-        );
-        const assistantMessage: ChatHistoryMessage = {
-          id: assistantMsgId ?? generateLocalId(),
-          msgId: assistantMsgId,
-          role: "assistant",
-          content: assistantContent,
-          ts: assistantTs,
-          status: isCompleted ? ("done" as const) : ("error" as const),
-          traceId: resolvedTraceId,
-          latencyMs: typeof computedLatency === "number" ? computedLatency : null,
-          cost: typeof computedCost === "number" ? computedCost : null,
-          error: isCompleted ? null : assistantContent || assistantErrorText || null,
-          failureReason: isCompleted ? null : data.reason ?? null,
-          reviewNotes: Array.isArray(data.review?.notes) ? data.review?.notes ?? [] : undefined,
-        };
-        return [...updatedHistory, assistantMessage];
-      });
+        ),
+      );
+
+      setTraceId(data.trace_id);
+      currentTraceRef.current = data.trace_id;
+
+      if (Array.isArray(data.events)) {
+        data.events.forEach((item, index) => {
+          const envelope: StreamEventEnvelope = {
+            id: `${item.span_id ?? "event"}-${index}-${generateLocalId()}`,
+            ts: item.ts,
+            type: item.type,
+            trace_id: data.trace_id,
+            span_id: item.span_id,
+            parent_span_id: item.parent_span_id,
+            data: item.data,
+          };
+          handleStreamEvent(envelope);
+        });
+      }
+
+      if (data.result !== undefined) {
+        setFinalOutput(data.result);
+      }
+
+      startStream(data.trace_id);
     } catch (err: any) {
       const errorMessage = err?.message ?? t("chat.runFailure");
       setRunError(errorMessage);
-      setFinalOutput(null);
+      setRunStatus("error");
       setChatHistory((history) => {
         const updated = history.map((message) =>
           message.id === localId
             ? {
                 ...message,
-                status: "error" as const,
+                status: "error",
                 error: errorMessage,
               }
             : message,
@@ -261,16 +708,14 @@ const HomePage: NextPage = () => {
             role: "system",
             content: t("chat.errorPrefix", { message: errorMessage }),
             ts: new Date().toISOString(),
-            status: "error" as const,
+            status: "error",
             error: errorMessage,
           },
         ];
       });
       setTraceId(previousTraceId);
-    } finally {
-      setIsRunning(false);
     }
-  }, [chatHistory, input, isRunning, t, traceId]);
+  }, [chatHistory, draftInput, handleStreamEvent, resetForRun, runStatus, startStream, t, traceId]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
@@ -278,6 +723,35 @@ const HomePage: NextPage = () => {
       void handleRun();
     },
     [handleRun],
+  );
+
+  const handleDecision = useCallback(
+    (decision: "approve" | "reject") => {
+      if (!confirmationRequest) return;
+      setConfirmationRequest(null);
+      const now = new Date().toISOString();
+      setChatHistory((history) => [
+        ...history,
+        {
+          id: generateLocalId(),
+          role: "system",
+          content:
+            decision === "approve"
+              ? t("confirmation.approved", { message: confirmationRequest.message })
+              : t("confirmation.denied", { message: confirmationRequest.message }),
+          ts: now,
+          status: "done",
+        },
+      ]);
+      if (decision === "approve") {
+        setRunStatus("running");
+      } else {
+        setRunStatus("error");
+        setRunError(t("confirmation.deniedStatus"));
+        closeStream();
+      }
+    },
+    [closeStream, confirmationRequest, t],
   );
 
   const tabItems = useMemo(
@@ -288,17 +762,118 @@ const HomePage: NextPage = () => {
     [t],
   );
 
-  const statusText = runError
-    ? runError
-    : isRunning
-      ? t("chat.statusIndicator.running")
-      : chatHistory.length > 0
-        ? t("chat.statusIndicator.ready")
-        : t("chat.statusIndicator.idle");
+  const statusText = useMemo(() => {
+    if (runStatus === "error") {
+      return runError ?? t("chat.statusIndicator.error");
+    }
+    if (runStatus === "running") {
+      return t("chat.statusIndicator.running");
+    }
+    if (runStatus === "awaiting-confirmation") {
+      return t("chat.statusIndicator.awaitingConfirmation");
+    }
+    if (chatHistory.length > 0) {
+      return t("chat.statusIndicator.ready");
+    }
+    return t("chat.statusIndicator.idle");
+  }, [chatHistory.length, runError, runStatus, t]);
 
-  const statusTone = runError ? "text-orange-300" : isRunning ? "text-sky-200" : "text-slate-200";
+  const statusTone =
+    runStatus === "error"
+      ? "text-orange-300"
+      : runStatus === "running"
+        ? "text-sky-200"
+        : runStatus === "awaiting-confirmation"
+          ? "text-amber-200"
+          : "text-slate-200";
 
   const disableSave = !chatHistory.length && !draftInput;
+
+  const metrics = useMemo(() => {
+    let cost = 0;
+    let latency = 0;
+    let tokens = 0;
+    for (const event of skillEvents) {
+      if (event.type === "tool" && event.status !== "started") {
+        if (typeof event.cost === "number") cost += event.cost;
+        if (typeof event.latencyMs === "number") latency += event.latencyMs;
+        if (typeof event.tokens === "number") tokens += event.tokens;
+      }
+    }
+    return { cost, latency, tokens };
+  }, [skillEvents]);
+
+  const formatDateTime = useCallback(
+    (value: string) => {
+      try {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return value;
+        }
+        return new Intl.DateTimeFormat(locale, {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        }).format(date);
+      } catch {
+        return value;
+      }
+    },
+    [locale],
+  );
+
+  const planLabels = useMemo(
+    () => ({
+      heading: t("panels.plan.heading"),
+      filterPlaceholder: t("panels.plan.filter"),
+      collapse: t("panels.plan.collapse"),
+      expand: t("panels.plan.expand"),
+      empty: t("panels.plan.empty"),
+      updatedAt: (value: string) => t("panels.plan.updatedAt", { value: formatDateTime(value) }),
+      revision: (value?: number) =>
+        value != null ? t("panels.plan.revision", { value }) : t("panels.plan.revisionUnknown"),
+      reason: (value?: string) =>
+        value && value.length > 0
+          ? t("panels.plan.reason", { reason: value })
+          : t("panels.plan.reasonUnknown"),
+      stepCount: (count: number) => t("panels.plan.stepCount", { count }),
+    }),
+    [formatDateTime, t],
+  );
+
+  const skillLabels = useMemo(
+    () => ({
+      heading: t("panels.skills.heading"),
+      filterPlaceholder: t("panels.skills.filter"),
+      collapse: t("panels.skills.collapse"),
+      expand: t("panels.skills.expand"),
+      empty: t("panels.skills.empty"),
+      status: {
+        started: t("panels.skills.status.started"),
+        succeeded: t("panels.skills.status.succeeded"),
+        failed: t("panels.skills.status.failed"),
+      },
+      metricLabels: {
+        latency: t("chat.metrics.latency"),
+        cost: t("chat.metrics.cost"),
+        tokens: t("chat.metrics.tokens"),
+      },
+      metrics: {
+        cost: (value?: number | null) =>
+          typeof value === "number" ? value.toFixed(4) : t("panels.skills.metric.na"),
+        latency: (value?: number | null) =>
+          typeof value === "number" ? `${value.toFixed(0)} ms` : t("panels.skills.metric.na"),
+        tokens: (value?: number | null) =>
+          typeof value === "number" ? value.toLocaleString() : t("panels.skills.metric.na"),
+      },
+      noteLabel: (level?: string) =>
+        level && level.length > 0
+          ? t("panels.skills.noteLabel", { level })
+          : t("panels.skills.note"),
+      scoreNote: t("panels.skills.score"),
+    }),
+    [t],
+  );
 
   return (
     <div className={shellClass} data-testid="chat-shell">
@@ -384,7 +959,7 @@ const HomePage: NextPage = () => {
                 </div>
               </div>
 
-              <ChatMessageList messages={chatHistory} isRunning={isRunning} />
+              <ChatMessageList messages={chatHistory} isRunning={runStatus === "running"} />
 
               {draftInput ? (
                 <div
@@ -423,15 +998,19 @@ const HomePage: NextPage = () => {
                     }
                   }}
                   placeholder={t("chat.placeholder")}
-                  className={`${insetSurfaceClass} min-h-[9rem] w-full resize-y border-slate-800/70 bg-slate-950/70 p-4 text-sm text-slate-100 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400`}
+                  className={`${inputSurfaceClass} min-h-[9rem] w-full resize-y`}
                 />
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <button
                     type="submit"
-                    disabled={isRunning}
+                    disabled={runStatus === "running" || runStatus === "awaiting-confirmation"}
                     className={`${primaryButtonClass} w-full sm:w-auto`}
                   >
-                    {isRunning ? t("chat.submit.running") : t("chat.submit.run")}
+                    {runStatus === "running"
+                      ? t("chat.submit.running")
+                      : runStatus === "awaiting-confirmation"
+                        ? t("chat.submit.confirming")
+                        : t("chat.submit.run")}
                   </button>
                   <span className={`${subtleTextClass} text-sm`}>{statusText}</span>
                 </div>
@@ -446,27 +1025,39 @@ const HomePage: NextPage = () => {
               >
                 <div className="flex items-center justify-between gap-3">
                   <h3 id="run-stats-title" className={headingClass}>
-                    Run stats
+                    {t("chat.metrics.heading")}
                   </h3>
                   <span className={`${badgeClass} ${statusTone} bg-transparent normal-case`}>
                     {statusText}
                   </span>
                 </div>
-                <dl className="grid gap-4 sm:grid-cols-3">
+                <dl className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
                     <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.traceId")}</dt>
                     <dd className="font-mono text-sm text-slate-200">{traceId ?? "–"}</dd>
                   </div>
                   <div className="space-y-2">
+                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.progress")}</dt>
+                    <dd className="text-sm text-slate-200">
+                      {typeof progressPct === "number" ? `${Math.round(progressPct * 100)}%` : "–"}
+                    </dd>
+                  </div>
+                  <div className="space-y-2">
                     <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.latency")}</dt>
                     <dd className="text-sm text-slate-200">
-                      {typeof latencyMs === "number" ? `${latencyMs.toFixed(0)} ms` : "–"}
+                      {metrics.latency > 0 ? `${metrics.latency.toFixed(0)} ms` : "–"}
                     </dd>
                   </div>
                   <div className="space-y-2">
                     <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.cost")}</dt>
                     <dd className="text-sm text-slate-200">
-                      {typeof cost === "number" ? cost.toFixed(4) : "–"}
+                      {metrics.cost > 0 ? metrics.cost.toFixed(4) : "–"}
+                    </dd>
+                  </div>
+                  <div className="space-y-2">
+                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.tokens")}</dt>
+                    <dd className="text-sm text-slate-200">
+                      {metrics.tokens > 0 ? metrics.tokens.toLocaleString() : "–"}
                     </dd>
                   </div>
                 </dl>
@@ -476,7 +1067,7 @@ const HomePage: NextPage = () => {
                   </p>
                 ) : (
                   <p className={`${subtleTextClass} text-xs`}>
-                    Status updates as new events stream in from the agent runtime.
+                    {t("chat.metrics.streamingNotice")}
                   </p>
                 )}
               </section>
@@ -490,13 +1081,41 @@ const HomePage: NextPage = () => {
                   <h3 id="raw-response-title" className={headingClass}>
                     {t("chat.latestResponse")}
                   </h3>
-                  {latestResponse ? (
+                  {lastEvent ? (
                     <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>updated</span>
                   ) : null}
                 </div>
                 <pre className="max-h-[28rem] overflow-auto rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-xs leading-relaxed text-slate-200">
-                  {latestResponse ? JSON.stringify(latestResponse, null, 2) : t("chat.noResponse")}
+                  {lastEvent ? JSON.stringify(lastEvent, null, 2) : t("chat.noResponse")}
                 </pre>
+              </section>
+
+              <section
+                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+                data-testid="plan-panel"
+              >
+                <PlanTimeline
+                  events={planEvents}
+                  filter={planFilter}
+                  collapsed={planCollapsed}
+                  onFilterChange={setPlanFilter}
+                  onToggleCollapse={() => setPlanCollapsed((value) => !value)}
+                  labels={planLabels}
+                />
+              </section>
+
+              <section
+                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+                data-testid="skill-panel-wrapper"
+              >
+                <SkillPanel
+                  events={skillEvents}
+                  filter={skillFilter}
+                  collapsed={skillCollapsed}
+                  onFilterChange={setSkillFilter}
+                  onToggleCollapse={() => setSkillCollapsed((value) => !value)}
+                  labels={skillLabels}
+                />
               </section>
             </div>
           </div>
@@ -506,6 +1125,44 @@ const HomePage: NextPage = () => {
           </section>
         )}
       </main>
+
+      {confirmationRequest ? (
+        <div className="fixed inset-0 z-40 flex items-center justify-center p-6">
+          <div className={modalBackdropClass} aria-hidden="true" />
+          <div
+            className={modalSurfaceClass}
+            role="dialog"
+            aria-modal="true"
+            data-testid="confirmation-modal"
+          >
+            <div className="space-y-4">
+              <div>
+                <h2 className={`${headingClass} text-xl`}>{t("confirmation.title")}</h2>
+                <p className={`${subtleTextClass} text-sm`}>{t("confirmation.subtitle")}</p>
+              </div>
+              <div className={`${insetSurfaceClass} border border-amber-500/50 bg-amber-500/5 p-4`}>
+                <p className="text-sm text-amber-100">{confirmationRequest.message}</p>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  className={`${outlineButtonClass} w-full sm:w-auto`}
+                  onClick={() => handleDecision("reject")}
+                >
+                  {t("confirmation.reject")}
+                </button>
+                <button
+                  type="button"
+                  className={`${primaryButtonClass} w-full sm:w-auto`}
+                  onClick={() => handleDecision("approve")}
+                >
+                  {t("confirmation.approve")}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/tests/ui/chat-stream.pw.ts
+++ b/tests/ui/chat-stream.pw.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Chat stream interactions", () => {
+  test("replays SSE events and supports filtering", async ({ page }) => {
+    await page.route("**/api/run", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ trace_id: "trace-sse", events: [] }),
+      });
+    });
+
+    await page.addInitScript(() => {
+      const control: any = {
+        instance: null,
+        connect(instance: any) {
+          this.instance = instance;
+          setTimeout(() => {
+            if (typeof instance.onopen === "function") {
+              instance.onopen(new MessageEvent("open"));
+            }
+          }, 0);
+        },
+        emit(event: any) {
+          if (this.instance && typeof this.instance.onmessage === "function") {
+            this.instance.onmessage(new MessageEvent("message", { data: JSON.stringify(event) }));
+          }
+        },
+        error() {
+          if (this.instance && typeof this.instance.onerror === "function") {
+            this.instance.onerror(new Event("error"));
+          }
+        },
+      };
+      (window as any).__AOS_STREAM_CONTROL__ = control;
+      class MockEventSource {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSED = 2;
+        url: string;
+        readyState = MockEventSource.CONNECTING;
+        onopen: ((event: MessageEvent) => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onerror: ((event: Event) => void) | null = null;
+        constructor(url: string) {
+          this.url = url;
+          this.readyState = MockEventSource.OPEN;
+          control.connect(this);
+        }
+        addEventListener(type: string, listener: any) {
+          if (type === "message") this.onmessage = listener;
+          if (type === "error") this.onerror = listener;
+          if (type === "open") this.onopen = listener;
+        }
+        removeEventListener(type: string) {
+          if (type === "message") this.onmessage = null;
+          if (type === "error") this.onerror = null;
+          if (type === "open") this.onopen = null;
+        }
+        close() {
+          this.readyState = MockEventSource.CLOSED;
+        }
+      }
+      (window as any).EventSource = MockEventSource;
+    });
+
+    await page.goto("/");
+    await page.getByLabel(/聊天输入|Chat input/i).fill("stream test");
+
+    await Promise.all([
+      page.waitForRequest("**/api/run"),
+      page.getByRole("button", { name: /run|运行/i }).click(),
+    ]);
+
+    const emitEvents = async () => {
+      const now = new Date().toISOString();
+      await page.evaluate(
+        ([timestamp]) => {
+          const control = (window as any).__AOS_STREAM_CONTROL__;
+          control.emit({
+            id: "evt-plan",
+            ts: timestamp,
+            type: "plan.updated",
+            data: {
+              revision: 1,
+              reason: "initial",
+              steps: [
+                { id: "step-1", title: "Collect data", description: "gather recent metrics" },
+              ],
+            },
+          });
+          control.emit({
+            id: "evt-tool-start",
+            ts: timestamp,
+            type: "tool.started",
+            span_id: "tool-1",
+            data: {
+              name: "search.docs",
+              args: { query: "status report" },
+            },
+          });
+          control.emit({
+            id: "evt-tool-success",
+            ts: timestamp,
+            type: "tool.succeeded",
+            span_id: "tool-1",
+            data: {
+              name: "search.docs",
+              args: { query: "status report" },
+              result: {
+                text: "All systems nominal",
+                latency_ms: 128,
+                cost: 0.0025,
+                tokens: 345,
+              },
+            },
+          });
+          control.emit({
+            id: "evt-note",
+            ts: timestamp,
+            type: "reflect.note",
+            data: { text: "Ready to summarise", level: "info" },
+          });
+          control.emit({
+            id: "evt-confirm",
+            ts: timestamp,
+            type: "user.confirm.request",
+            data: { prompt: "Allow publishing the summary?" },
+          });
+        },
+        [now],
+      );
+    };
+
+    await emitEvents();
+
+    await expect(page.getByTestId("plan-events")).toContainText("Collect data");
+    await page.getByTestId("plan-filter-input").fill("collect");
+    await expect(page.getByTestId("plan-events")).toContainText("Collect data");
+
+    const toolCard = page
+      .getByTestId("skill-events")
+      .getByRole("listitem")
+      .filter({ hasText: /search\.docs/i });
+    await expect(toolCard).toContainText(/已完成|succeeded/i);
+    await expect(toolCard).toContainText(/0\.0025/);
+
+    const confirmationModal = page.getByTestId("confirmation-modal");
+    await expect(confirmationModal).toBeVisible();
+    await confirmationModal.getByRole("button", { name: /允许|Allow/i }).click();
+    await expect(confirmationModal).toBeHidden();
+
+    await page.evaluate(
+      ([timestamp]) => {
+        const control = (window as any).__AOS_STREAM_CONTROL__;
+        control.emit({
+          id: "evt-final",
+          ts: timestamp,
+          type: "agent.final",
+          data: { outputs: { text: "Summary" } },
+        });
+      },
+      [new Date().toISOString()],
+    );
+
+    await expect(page.getByTestId("run-stats-panel")).toContainText(/Ready|就绪/);
+    await expect(page.getByTestId("run-stats-panel")).toContainText(/345/);
+    await expect(page.getByTestId("raw-response-panel")).toContainText("agent.final");
+  });
+});


### PR DESCRIPTION
### Summary
- refactor the chat page to subscribe to `/api/runs/:id/stream` via EventSource, track run metrics, and surface plan, skill, and confirmation UI updates
- add reusable PlanTimeline and SkillPanel components plus supporting theme/localisation updates
- update LogFlowPanel to page through `/api/runs/:id/events`, surface cost/token stats, and cover the UI with a new Playwright chat stream test

### Plan
- scope: chat run streaming UI, sidebar panels, log flow pagination, localisation/theme/test updates; out-of-scope: backend behaviour, legacy adapter formatting fixes
- risks: SSE reconnect edge cases, UI regressions, reliance on new events API; rollback: revert the commit

### Diff Overview
- `pages/index.tsx`: switch to EventSource streaming, manage plan/skill/confirmation state, expose metrics and modals
- `components/PlanTimeline.tsx`, `components/SkillPanel.tsx`: introduce filterable/collapsible plan and tool panels
- `components/LogFlowPanel.tsx`: call the paginated events API and expose aggregate stats
- `lib/theme.ts`, `locales/*`: refresh styling tokens and translations for new panels and prompts
- `tests/ui/chat-stream.pw.ts`: cover SSE replay, filtering, and confirmation interactions

### Test Evidence
- `pnpm lint` *(fails: existing prettier/@next lint violations in legacy adapters)*
- `pnpm test` *(pass)*
- `pnpm test:ui --update-snapshots` *(fails: container missing Playwright system deps)*

### Impact & Migration
- requires `/api/runs/:id/stream` SSE endpoint and `/api/runs/:id/events` pagination API to be available

### Checklist
- [ ] Lint
- [ ] Types
- [ ] Tests
- [ ] Docs
- [ ] Security scan

------
https://chatgpt.com/codex/tasks/task_e_68cb9aa46cd4832b8e65e5f09c2c4b85