### PR TITLE
Emit tool status events and record skill usage

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import OpenAI, {
   APIConnectionError,
@@ -316,6 +317,7 @@ export interface DefaultToolInvokerOptions extends CreateMcpRegistryOptions {
 export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}): ToolInvoker {
   const mcpRegistry = createMcpRegistry(options);
   const enableRemote = options.enableRemoteMcp ?? true;
+  const eventBus = options.eventBus;
 
   const mcpClientPromise: Promise<MCPClient | null> = enableRemote
     ? (options.mcpClientPromise ??
@@ -328,9 +330,41 @@ export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}
         }))
     : Promise.resolve(null);
 
+  const publishSkillUsage = async (
+    call: ToolCall,
+    ctx: ToolContext,
+    result: ToolResult,
+    extra: Record<string, unknown> = {},
+  ) => {
+    if (!eventBus) {
+      return;
+    }
+    const latency =
+      typeof (result as any)?.latency_ms === "number" ? (result as any).latency_ms : undefined;
+    const cost = typeof (result as any)?.cost === "number" ? (result as any).cost : undefined;
+    await eventBus.publish({
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: "skill.used",
+      version: 1,
+      trace_id: ctx.trace_id,
+      span_id: ctx.span_id,
+      parent_span_id: ctx.parent_span_id,
+      data: {
+        name: call.name,
+        args: call.args,
+        ok: result.ok,
+        latency_ms: latency,
+        cost,
+        ...extra,
+      },
+    });
+  };
+
   return async (call: ToolCall, ctx: ToolContext) => {
     const localResult = await mcpRegistry.invoke(call, ctx);
     if (localResult !== null) {
+      await publishSkillUsage(call, ctx, localResult, { source: "registry" });
       return localResult;
     }
 
@@ -343,13 +377,20 @@ export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}
             traceId: ctx?.trace_id,
           });
           if (remoteResult.ok || !isToolNotFoundError(remoteResult)) {
+            await publishSkillUsage(call, ctx, remoteResult, {
+              source: "remote",
+              server: route.serverId,
+              tool: route.toolName,
+            });
             return remoteResult;
           }
         }
       }
     }
 
-    return invokeLocalTool(call);
+    const fallbackResult = await invokeLocalTool(call);
+    await publishSkillUsage(call, ctx, fallbackResult, { source: "builtin" });
+    return fallbackResult;
   };
 }
 

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -80,6 +80,7 @@ export type CoreEvent =
       latency_ms?: number;
       status?: "started" | "succeeded" | "failed";
     }
+  | { type: "reflect.note"; text: string; level?: LogLevel; origin_step?: string }
   | { type: "ask"; question: string; origin_step?: string }
   | { type: "score"; value: number; passed: boolean; notes?: string[] }
   | { type: "final"; outputs: any; reason?: string }
@@ -183,6 +184,17 @@ export async function runLoop(
         op: "llm.chat",
         args: { prompt: context.input ?? "" },
       };
+      await ensurePromise(
+        emit(
+          {
+            type: "tool",
+            name: fallbackStep.op,
+            args: fallbackStep.args,
+            status: "started",
+          },
+          { spanId: fallbackStep.id, parentSpanId: planSpanId },
+        ),
+      );
       const outcome = await kernel.act(fallbackStep);
       actions.push(outcome);
       await ensurePromise(
@@ -192,8 +204,16 @@ export async function runLoop(
             name: fallbackStep.op,
             args: fallbackStep.args,
             result: outcome.result,
-            cost: outcome.result.ok ? outcome.result.cost : undefined,
-            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+            cost:
+              "cost" in outcome.result && typeof (outcome.result as any).cost === "number"
+                ? (outcome.result as any).cost
+                : undefined,
+            latency_ms:
+              "latency_ms" in outcome.result &&
+              typeof (outcome.result as any).latency_ms === "number"
+                ? (outcome.result as any).latency_ms
+                : undefined,
+            status: outcome.result.ok ? "succeeded" : "failed",
           },
           { spanId: fallbackStep.id, parentSpanId: planSpanId },
         ),
@@ -212,6 +232,17 @@ export async function runLoop(
           { spanId: step.id, parentSpanId: planSpanId },
         ),
       );
+      await ensurePromise(
+        emit(
+          {
+            type: "tool",
+            name: step.op,
+            args: step.args,
+            status: "started",
+          },
+          { spanId: step.id, parentSpanId: planSpanId },
+        ),
+      );
       const outcome = await kernel.act(step);
       actions.push(outcome);
       await ensurePromise(
@@ -221,8 +252,16 @@ export async function runLoop(
             name: step.op,
             args: step.args,
             result: outcome.result,
-            cost: outcome.result.ok ? outcome.result.cost : undefined,
-            latency_ms: outcome.result.ok ? outcome.result.latency_ms : undefined,
+            cost:
+              "cost" in outcome.result && typeof (outcome.result as any).cost === "number"
+                ? (outcome.result as any).cost
+                : undefined,
+            latency_ms:
+              "latency_ms" in outcome.result &&
+              typeof (outcome.result as any).latency_ms === "number"
+                ? (outcome.result as any).latency_ms
+                : undefined,
+            status: outcome.result.ok ? "succeeded" : "failed",
           },
           { spanId: step.id, parentSpanId: planSpanId },
         ),
@@ -269,6 +308,21 @@ export async function runLoop(
     }
 
     lastReview = await kernel.review(actions);
+    const reviewNotes = Array.isArray(lastReview.notes)
+      ? lastReview.notes.filter((note): note is string => typeof note === "string" && note.trim().length > 0)
+      : [];
+    for (const note of reviewNotes) {
+      await ensurePromise(
+        emit(
+          {
+            type: "reflect.note",
+            text: note,
+            level: lastReview.passed ? "info" : "warn",
+          },
+          { spanId: planSpanId, parentSpanId: traceSpanId },
+        ),
+      );
+    }
     await ensurePromise(
       emit(
         {

--- a/lib/logflowMessages.ts
+++ b/lib/logflowMessages.ts
@@ -9,6 +9,8 @@ function summarise(event: EventEnvelope): string {
       const revision = data?.revision ?? "?";
       return `Plan revision ${revision} with ${steps} step${steps === 1 ? "" : "s"}`;
     }
+    case "tool.started":
+      return `Tool ${data?.name ?? "(unknown)"} started`;
     case "tool.succeeded":
       return `Tool ${data?.name ?? "(unknown)"} succeeded`;
     case "tool.failed":
@@ -19,6 +21,8 @@ function summarise(event: EventEnvelope): string {
       return `Progress ${Math.round((data?.pct ?? 0) * 100)}% (${data?.step ?? "step"})`;
     case "run.finished":
       return `Run finished (${data?.reason ?? "completed"})`;
+    case "final.answer":
+      return "Final answer ready";
     case "run.failed":
       return `Run failed${data?.message ? `: ${data.message}` : ""}`;
     case "run.ask":
@@ -27,6 +31,10 @@ function summarise(event: EventEnvelope): string {
       return `Score ${data?.value ?? "?"} (${data?.passed ? "pass" : "fail"})`;
     case "run.log":
       return typeof data?.message === "string" ? data.message : "Log";
+    case "reflect.note":
+      return typeof data?.text === "string" ? data.text : "Reflection";
+    case "skill.used":
+      return `Skill ${data?.name ?? "(unknown)"} used`;
     default:
       return event.type;
   }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -88,6 +88,9 @@
         "succeeded": "succeeded",
         "failed": "failed"
       },
+      "skillLevel": "Skill",
+      "skillUsed": "Skill used: {name}",
+      "unnamedSkill": "unnamed skill",
       "metric": {
         "na": "–"
       },

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -88,6 +88,9 @@
         "succeeded": "已完成",
         "failed": "失败"
       },
+      "skillLevel": "技能",
+      "skillUsed": "命中技能：{name}",
+      "unnamedSkill": "未命名技能",
       "metric": {
         "na": "–"
       },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -424,6 +424,38 @@ const HomePage: NextPage = () => {
         return;
       }
 
+      if (kind === "skill.used") {
+        const data = event.data ?? {};
+        const rawName = typeof data.name === "string" ? data.name.trim() : "";
+        const name = rawName || t("panels.skills.unnamedSkill");
+        const argsSummary = summariseArgs(data.args);
+        const source = typeof data.source === "string" ? data.source.trim() : "";
+        const pieces = [t("panels.skills.skillUsed", { name })];
+        if (source) {
+          pieces.push(source);
+        }
+        if (argsSummary) {
+          pieces.push(argsSummary);
+        }
+        const level = t("panels.skills.skillLevel");
+        setSkillEvents((previous) => {
+          if (previous.some((item) => item.id === event.id)) {
+            return previous;
+          }
+          const entry: SkillEvent = {
+            type: "note",
+            id: event.id,
+            ts: event.ts ?? new Date().toISOString(),
+            level,
+            text: pieces.join(" · "),
+          };
+          return [...previous, entry].sort(
+            (a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime(),
+          );
+        });
+        return;
+      }
+
       if (kind === "reflect.note" || kind === "score" || kind === "ask" || kind === "log") {
         const level =
           kind === "reflect.note"
@@ -496,9 +528,21 @@ const HomePage: NextPage = () => {
         return;
       }
 
-      if (kind === "final" || kind === "run.finished") {
+      if (kind === "final" || kind === "final.answer") {
         const outputs = event.data?.outputs ?? event.data?.result ?? event.data;
         setFinalOutput(outputs);
+        setRunStatus("completed");
+        setProgressPct(1);
+        if (kind === "final") {
+          closeStream();
+        }
+        return;
+      }
+
+      if (kind === "run.finished") {
+        const outputs =
+          event.data?.final ?? event.data?.outputs ?? event.data?.result ?? event.data;
+        setFinalOutput((previous) => previous ?? outputs);
         setRunStatus("completed");
         setProgressPct(1);
         closeStream();

--- a/runtime/events.ts
+++ b/runtime/events.ts
@@ -59,11 +59,20 @@ function mapCoreEventType(event: CoreEvent): string {
     case "plan":
       return "plan.updated";
     case "tool":
+      if (event.status === "started") {
+        return "tool.started";
+      }
+      if (event.status === "failed") {
+        return "tool.failed";
+      }
+      if (event.status === "succeeded") {
+        return "tool.succeeded";
+      }
       return event.result && event.result.ok === false ? "tool.failed" : "tool.succeeded";
     case "progress":
       return "run.progress";
     case "final":
-      return "run.finished";
+      return "final.answer";
     case "log":
       return "run.log";
     case "ask":
@@ -77,7 +86,8 @@ function mapCoreEventType(event: CoreEvent): string {
 
 function enrichEventData(event: CoreEvent): CoreEvent {
   if (event.type === "tool") {
-    const status = event.result && event.result.ok === false ? "failed" : "succeeded";
+    const status =
+      event.status ?? (event.result && event.result.ok === false ? "failed" : "succeeded");
     return { ...event, status };
   }
   return event;

--- a/tests/mcpWorkspace.test.ts
+++ b/tests/mcpWorkspace.test.ts
@@ -128,6 +128,12 @@ describe("mcp workspace registry", () => {
         expect((writeResult.data as any).bytes > 0).toBe(true);
       }
 
+      const skillUsageEvents = recordedEvents.filter((event) => event.type === "skill.used");
+      expect(skillUsageEvents.length > 0).toBe(true);
+      expect(
+        skillUsageEvents.some((event) => (event.data as any)?.name === "file.write"),
+      ).toBe(true);
+
       const mcpResultEvent = recordedEvents.find(
         (event) => event.type === "mcp.result" && (event.data as any).tool === "file.write",
       );

--- a/tests/runLoop.test.ts
+++ b/tests/runLoop.test.ts
@@ -35,6 +35,12 @@ function isAskEvent(
   return entry.event.type === "ask";
 }
 
+function isReflectNoteEvent(
+  entry: EmittedEntry,
+): entry is { event: Extract<CoreEvent, { type: "reflect.note" }>; span?: EmitSpanOptions } {
+  return entry.event.type === "reflect.note";
+}
+
 describe("runLoop", () => {
   it("executes plan steps and resolves when review passes", async () => {
     const emitted: EmittedEntry[] = [];
@@ -84,10 +90,17 @@ describe("runLoop", () => {
       (item): item is { event: Extract<CoreEvent, { type: "tool" }>; span?: EmitSpanOptions } =>
         item.event.type === "tool",
     );
-    expect(toolEvents).toHaveLength(2);
-    expect(toolEvents.map((item) => item.span?.spanId)).toEqual(["s1", "s2"]);
+    expect(toolEvents).toHaveLength(4);
+    const startedTools = toolEvents.filter((item) => item.event.status === "started");
+    expect(startedTools.map((item) => item.span?.spanId)).toEqual(["s1", "s2"]);
+    const succeededTools = toolEvents.filter((item) => item.event.status === "succeeded");
+    expect(succeededTools.map((item) => item.span?.spanId)).toEqual(["s1", "s2"]);
+    expect(succeededTools.every((item) => item.event.result?.ok === true)).toBe(true);
     expect(toolEvents.every((item) => item.span?.parentSpanId === "plan-1")).toBe(true);
     expect(toolEvents.some((item) => item.event.name === "tool.echo")).toBeTruthy();
+
+    const reflectNotes = emitted.filter(isReflectNoteEvent);
+    expect(reflectNotes.map((item) => item.event.text)).toEqual(["ok"]);
 
     const finalEvent = emitted.find(isFinalEvent);
     expect(finalEvent?.event.reason).toBe("completed");
@@ -328,8 +341,9 @@ describe("runLoop", () => {
       (item): item is { event: Extract<CoreEvent, { type: "tool" }>; span?: EmitSpanOptions } =>
         item.event.type === "tool",
     );
-    expect(toolEvents).toHaveLength(1);
-    expect(toolEvents[0]?.event.result?.ok).toBe(false);
+    expect(toolEvents).toHaveLength(2);
+    const failedTool = toolEvents.find((item) => item.event.status === "failed");
+    expect(failedTool?.event.result?.ok).toBe(false);
 
     const planEvents = emitted.filter((item) => item.event.type === "plan");
     expect(planEvents).toHaveLength(1);

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,15 +173,29 @@
           "run.started",
           "run.progress",
           "plan.updated",
+          "tool.started",
           "tool.succeeded",
           "tool.failed",
+          "reflect.note",
           "run.log",
           "run.ask",
           "run.score",
+          "skill.used",
         ];
 
         streamEvents.forEach((eventName) => {
           source.addEventListener(eventName, handleEnvelopeEvent);
+        });
+
+        source.addEventListener("final.answer", (evt) => {
+          handleEnvelopeEvent(evt);
+          try {
+            const payload = JSON.parse(evt.data);
+            status.textContent = "Final answer ready";
+            finalOutput.textContent = JSON.stringify(payload.data?.outputs ?? payload.data ?? null, null, 2);
+          } catch (error) {
+            console.error("Failed to parse final answer payload", error);
+          }
         });
 
         source.addEventListener("run.finished", async (evt) => {


### PR DESCRIPTION
## Summary
- emit dedicated tool.started and tool.succeeded/failed core events and add reflect.note outputs during review
- publish skill.used envelopes from the default tool invoker, surface new event types through runtime mapping, SSE, UI, and logflow summaries
- localise new skill usage strings and ensure frontend handles final.answer events without dropping run.finished updates

## Testing
- `pnpm test runLoop`


------
https://chatgpt.com/codex/tasks/task_e_68cd7d02ca50832bb8b6cfc4627ac3f2