### PR TITLE
feat: add guardian oversight panel

### DIFF
--- a/lib/guardian/index.ts
+++ b/lib/guardian/index.ts
@@ -1,0 +1,344 @@
+const API_BASE = process.env.NEXT_PUBLIC_AOS_API_BASE ?? "";
+
+function resolveUrl(path: string): string {
+  if (path.startsWith("http")) {
+    return path;
+  }
+  return `${API_BASE}${path}`;
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const candidate =
+      payload && typeof payload === "object" && "message" in payload
+        ? (payload as Record<string, unknown>).message
+        : undefined;
+    const message =
+      typeof candidate === "string" ? candidate : `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+  return (payload ?? {}) as T;
+}
+
+export type GuardianBudgetStatus = "ok" | "warning" | "critical";
+
+export interface GuardianBudget {
+  currency: string;
+  limit: number;
+  used: number;
+  remaining: number;
+  status: GuardianBudgetStatus;
+  updatedAt?: string;
+}
+
+export type GuardianAlertSeverity = "info" | "warning" | "critical";
+export type GuardianAlertStatus = "open" | "approved" | "rejected" | "resolved";
+
+export interface GuardianAlert {
+  id: string;
+  createdAt: string;
+  updatedAt?: string;
+  message: string;
+  severity: GuardianAlertSeverity;
+  status: GuardianAlertStatus;
+  requireApproval: boolean;
+  traceId?: string;
+  replayUrl?: string;
+  detailsUrl?: string;
+}
+
+export interface GuardianAlertEvent {
+  type: "alert.created" | "alert.updated" | "alert.resolved" | "budget.updated";
+  alert?: GuardianAlert;
+  budget?: GuardianBudget;
+}
+
+interface GuardianBudgetDto {
+  currency?: string;
+  limit?: number;
+  used?: number;
+  remaining?: number;
+  status?: string;
+  updated_at?: string;
+  updatedAt?: string;
+}
+
+interface GuardianAlertDto {
+  id?: string;
+  created_at?: string;
+  updated_at?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  message?: string;
+  severity?: string;
+  status?: string;
+  require_approval?: boolean;
+  requireApproval?: boolean;
+  trace_id?: string;
+  traceId?: string;
+  replay_url?: string;
+  replayUrl?: string;
+  details_url?: string;
+  detailsUrl?: string;
+}
+
+interface GuardianAlertEventDto {
+  type?: string;
+  alert?: GuardianAlertDto | null;
+  budget?: GuardianBudgetDto | null;
+}
+
+function ensureNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function normaliseBudget(raw: unknown): GuardianBudget | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const dto = raw as GuardianBudgetDto;
+  const limit = ensureNumber(dto.limit, ensureNumber((raw as any).budget_limit));
+  const used = ensureNumber(dto.used, ensureNumber((raw as any).budget_used));
+  const remainingValue =
+    "remaining" in dto && dto.remaining != null ? ensureNumber(dto.remaining) : limit - used;
+  const statusCandidate = (dto.status ?? (raw as any).budget_status) as string | undefined;
+  const status: GuardianBudgetStatus =
+    statusCandidate === "warning" || statusCandidate === "critical" ? statusCandidate : "ok";
+  const currency =
+    typeof dto.currency === "string" && dto.currency.trim().length > 0 ? dto.currency : "USD";
+  const updatedAt =
+    typeof dto.updatedAt === "string" && dto.updatedAt.length > 0
+      ? dto.updatedAt
+      : typeof dto.updated_at === "string" && dto.updated_at.length > 0
+        ? dto.updated_at
+        : undefined;
+  return {
+    currency,
+    limit,
+    used,
+    remaining: Math.max(0, remainingValue),
+    status,
+    ...(updatedAt ? { updatedAt } : {}),
+  } satisfies GuardianBudget;
+}
+
+function normaliseAlert(raw: unknown): GuardianAlert | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const dto = raw as GuardianAlertDto;
+  if (typeof dto.id !== "string" || dto.id.length === 0) {
+    return null;
+  }
+  const createdAt =
+    typeof dto.createdAt === "string" && dto.createdAt.length > 0
+      ? dto.createdAt
+      : typeof dto.created_at === "string" && dto.created_at.length > 0
+        ? dto.created_at
+        : new Date().toISOString();
+  const updatedAt =
+    typeof dto.updatedAt === "string" && dto.updatedAt.length > 0
+      ? dto.updatedAt
+      : typeof dto.updated_at === "string" && dto.updated_at.length > 0
+        ? dto.updated_at
+        : undefined;
+  const severityCandidate = dto.severity?.toLowerCase();
+  const severity: GuardianAlertSeverity =
+    severityCandidate === "warning" || severityCandidate === "critical"
+      ? severityCandidate
+      : "info";
+  const statusCandidate = dto.status?.toLowerCase();
+  const status: GuardianAlertStatus =
+    statusCandidate === "approved" ||
+    statusCandidate === "rejected" ||
+    statusCandidate === "resolved"
+      ? statusCandidate
+      : "open";
+  const requireApproval = Boolean(dto.requireApproval ?? dto.require_approval);
+  const traceId =
+    typeof dto.traceId === "string" && dto.traceId.length > 0
+      ? dto.traceId
+      : typeof dto.trace_id === "string" && dto.trace_id.length > 0
+        ? dto.trace_id
+        : undefined;
+  const replayUrl =
+    typeof dto.replayUrl === "string" && dto.replayUrl.length > 0
+      ? dto.replayUrl
+      : typeof dto.replay_url === "string" && dto.replay_url.length > 0
+        ? dto.replay_url
+        : undefined;
+  const detailsUrl =
+    typeof dto.detailsUrl === "string" && dto.detailsUrl.length > 0
+      ? dto.detailsUrl
+      : typeof dto.details_url === "string" && dto.details_url.length > 0
+        ? dto.details_url
+        : undefined;
+  const message =
+    typeof dto.message === "string" && dto.message.length > 0 ? dto.message : "Guardian alert";
+  return {
+    id: dto.id,
+    createdAt,
+    ...(updatedAt ? { updatedAt } : {}),
+    message,
+    severity,
+    status,
+    requireApproval,
+    ...(traceId ? { traceId } : {}),
+    ...(replayUrl ? { replayUrl } : {}),
+    ...(detailsUrl ? { detailsUrl } : {}),
+  } satisfies GuardianAlert;
+}
+
+function parseAlertEvent(raw: unknown): GuardianAlertEvent | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const dto = raw as GuardianAlertEventDto;
+  const typeCandidate = typeof dto.type === "string" ? dto.type : "";
+  const normalisedType = ((): GuardianAlertEvent["type"] | null => {
+    if (typeCandidate === "alert.created" || typeCandidate === "alert.updated") {
+      return typeCandidate;
+    }
+    if (typeCandidate === "alert.resolved" || typeCandidate === "resolved") {
+      return "alert.resolved";
+    }
+    if (typeCandidate === "budget.updated" || typeCandidate === "budget") {
+      return "budget.updated";
+    }
+    return null;
+  })();
+  if (!normalisedType) {
+    return null;
+  }
+  const alert = dto.alert ? normaliseAlert(dto.alert) : undefined;
+  const budget = dto.budget ? normaliseBudget(dto.budget) : undefined;
+  return {
+    type: normalisedType,
+    ...(alert ? { alert } : {}),
+    ...(budget ? { budget } : {}),
+  } satisfies GuardianAlertEvent;
+}
+
+export async function fetchGuardianBudget(): Promise<GuardianBudget> {
+  const response = await fetch(resolveUrl("/api/guardian/budget"), {
+    headers: { Accept: "application/json" },
+  });
+  const payload = await parseJson<GuardianBudgetDto>(response);
+  const budget = normaliseBudget(payload);
+  if (!budget) {
+    throw new Error("Invalid guardian budget payload");
+  }
+  return budget;
+}
+
+export interface GuardianAlertSubscriptionOptions {
+  onEvent: (event: GuardianAlertEvent) => void;
+  onError?: (error: Error) => void;
+}
+
+export function subscribeGuardianAlerts(options: GuardianAlertSubscriptionOptions): () => void {
+  if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
+    return () => {};
+  }
+  const url = resolveUrl("/api/guardian/alerts/stream");
+  let closed = false;
+  let source: EventSource | null = null;
+  const handleError = (error: Error) => {
+    if (options.onError) {
+      options.onError(error);
+    }
+  };
+  try {
+    source = new window.EventSource(url);
+  } catch (error) {
+    handleError(error instanceof Error ? error : new Error("Failed to connect to guardian alerts"));
+    return () => {};
+  }
+  const handleMessage = (event: MessageEvent<string>) => {
+    if (!event.data) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(event.data) as GuardianAlertEventDto;
+      const normalised = parseAlertEvent(parsed);
+      if (normalised) {
+        options.onEvent(normalised);
+      }
+    } catch (error) {
+      handleError(error instanceof Error ? error : new Error("Failed to parse guardian event"));
+    }
+  };
+  source.onmessage = handleMessage;
+  source.onerror = () => {
+    handleError(new Error("Guardian alert stream disconnected"));
+    if (source) {
+      source.close();
+    }
+  };
+  return () => {
+    if (!closed) {
+      closed = true;
+      if (source) {
+        source.close();
+      }
+    }
+  };
+}
+
+export interface GuardianApprovalRequest {
+  alertId: string;
+  decision: "approve" | "reject";
+  note?: string;
+}
+
+export interface GuardianApprovalResponse {
+  status: GuardianAlertStatus;
+  alert: GuardianAlert | null;
+  message?: string;
+}
+
+export async function submitGuardianApproval(
+  input: GuardianApprovalRequest,
+): Promise<GuardianApprovalResponse> {
+  const response = await fetch(resolveUrl("/api/guardian/approvals"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      alert_id: input.alertId,
+      alertId: input.alertId,
+      decision: input.decision,
+      note: input.note,
+    }),
+  });
+  const payload = await parseJson<{
+    status?: string;
+    alert?: GuardianAlertDto | null;
+    message?: string;
+  }>(response);
+  const alert = payload.alert ? normaliseAlert(payload.alert) : null;
+  const statusCandidate = payload.status?.toLowerCase();
+  const status: GuardianAlertStatus =
+    statusCandidate === "approved" ||
+    statusCandidate === "rejected" ||
+    statusCandidate === "resolved"
+      ? statusCandidate
+      : (alert?.status ?? (input.decision === "approve" ? "approved" : "rejected"));
+  return {
+    status,
+    alert,
+    ...(payload.message && typeof payload.message === "string" ? { message: payload.message } : {}),
+  } satisfies GuardianApprovalResponse;
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -63,6 +63,49 @@
       }
     }
   },
+  "guardian": {
+    "heading": "Guardian oversight",
+    "subtitle": "Monitor budget and respond to runtime alerts.",
+    "status": {
+      "loading": "Loading…",
+      "idle": "No data",
+      "ok": "Within budget",
+      "warning": "Approaching limit",
+      "critical": "Budget exceeded",
+      "error": "Unavailable"
+    },
+    "budget": {
+      "limit": "Budget limit",
+      "used": "Spent",
+      "remaining": "Remaining",
+      "updatedAt": "Updated {value}"
+    },
+    "alerts": {
+      "heading": "Active alerts",
+      "loading": "Listening for Guardian alerts…",
+      "empty": "No alerts at the moment.",
+      "streamError": "Unable to connect to Guardian alerts.",
+      "approve": "Approve",
+      "reject": "Reject",
+      "replay": "Replay",
+      "submitted": "Decision submitted",
+      "error": "Submission failed",
+      "status": {
+        "open": "Awaiting action",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "resolved": "Resolved"
+      },
+      "severity": {
+        "info": "Info",
+        "warning": "Warning",
+        "critical": "Critical"
+      }
+    },
+    "error": {
+      "detail": "Guardian error: {message}"
+    }
+  },
   "panels": {
     "plan": {
       "heading": "Plan timeline",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -63,6 +63,49 @@
       }
     }
   },
+  "guardian": {
+    "heading": "Guardian 守护",
+    "subtitle": "监控预算并及时处理运行期告警。",
+    "status": {
+      "loading": "加载中…",
+      "idle": "暂无数据",
+      "ok": "预算正常",
+      "warning": "接近上限",
+      "critical": "已超出预算",
+      "error": "暂不可用"
+    },
+    "budget": {
+      "limit": "预算上限",
+      "used": "已消耗",
+      "remaining": "剩余额度",
+      "updatedAt": "更新时间 {value}"
+    },
+    "alerts": {
+      "heading": "告警列表",
+      "loading": "正在订阅 Guardian 告警…",
+      "empty": "当前没有新的告警。",
+      "streamError": "无法连接 Guardian 告警流。",
+      "approve": "批准",
+      "reject": "拒绝",
+      "replay": "回放",
+      "submitted": "审批已提交",
+      "error": "提交失败",
+      "status": {
+        "open": "待处理",
+        "approved": "已批准",
+        "rejected": "已拒绝",
+        "resolved": "已关闭"
+      },
+      "severity": {
+        "info": "提示",
+        "warning": "警告",
+        "critical": "严重"
+      }
+    },
+    "error": {
+      "detail": "Guardian 错误：{message}"
+    }
+  },
   "panels": {
     "plan": {
       "heading": "计划时间线",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,15 @@ import PlanTimeline, {
 import SkillPanel, { type SkillEvent } from "../components/SkillPanel";
 import { useI18n } from "../lib/i18n/index";
 import {
+  fetchGuardianBudget,
+  subscribeGuardianAlerts,
+  submitGuardianApproval,
+  type GuardianAlert,
+  type GuardianAlertEvent,
+  type GuardianBudget,
+  type GuardianBudgetStatus,
+} from "../lib/guardian/index";
+import {
   badgeClass,
   headerSurfaceClass,
   headingClass,
@@ -62,6 +71,30 @@ interface ConfirmationRequestState {
 }
 
 type RunStatus = "idle" | "running" | "awaiting-confirmation" | "completed" | "error";
+
+type GuardianStatusKey = GuardianBudgetStatus | "loading" | "idle" | "error";
+
+const GUARDIAN_STATUS_TONES: Record<GuardianStatusKey, string> = {
+  ok: "bg-emerald-500/10 text-emerald-200",
+  warning: "bg-amber-500/10 text-amber-200",
+  critical: "bg-rose-500/10 text-rose-200",
+  loading: "bg-slate-700/30 text-slate-200",
+  idle: "bg-slate-700/30 text-slate-200",
+  error: "bg-rose-500/10 text-rose-200",
+};
+
+const GUARDIAN_SEVERITY_TONES: Record<GuardianAlert["severity"], string> = {
+  info: "bg-slate-700/40 text-slate-100",
+  warning: "bg-amber-500/10 text-amber-200",
+  critical: "bg-rose-500/10 text-rose-200",
+};
+
+const GUARDIAN_ALERT_STATUS_TONES: Record<GuardianAlert["status"], string> = {
+  open: "bg-sky-500/10 text-sky-200",
+  approved: "bg-emerald-500/10 text-emerald-200",
+  rejected: "bg-rose-500/10 text-rose-200",
+  resolved: "bg-slate-700/40 text-slate-100",
+};
 
 const generateLocalId = (): string => {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -230,6 +263,14 @@ const HomePage: NextPage = () => {
     null,
   );
   const [progressPct, setProgressPct] = useState<number | null>(null);
+  const [guardianBudget, setGuardianBudget] = useState<GuardianBudget | null>(null);
+  const [guardianAlerts, setGuardianAlerts] = useState<GuardianAlert[]>([]);
+  const [guardianLoading, setGuardianLoading] = useState(true);
+  const [guardianError, setGuardianError] = useState<string | null>(null);
+  const [guardianStreamError, setGuardianStreamError] = useState<string | null>(null);
+  const [guardianSubmissions, setGuardianSubmissions] = useState<
+    Record<string, "pending" | "success" | "error">
+  >({});
   const eventSourceRef = useRef<EventSource | null>(null);
   const retryTimerRef = useRef<number | null>(null);
   const retryAttemptRef = useRef(0);
@@ -264,6 +305,68 @@ const HomePage: NextPage = () => {
   }, []);
 
   useEffect(() => () => closeStream(), [closeStream]);
+
+  useEffect(() => {
+    let active = true;
+    setGuardianLoading(true);
+    fetchGuardianBudget()
+      .then((budget) => {
+        if (!active) return;
+        setGuardianBudget(budget);
+        setGuardianError(null);
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setGuardianError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (active) {
+          setGuardianLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const upsertGuardianAlert = useCallback((updated: GuardianAlert) => {
+    setGuardianAlerts((current) => {
+      const index = current.findIndex((item) => item.id === updated.id);
+      const next =
+        index >= 0
+          ? current.map((item, position) => (position === index ? { ...item, ...updated } : item))
+          : [...current, updated];
+      next.sort((a, b) => {
+        const aTime = Date.parse(a.updatedAt ?? a.createdAt ?? "");
+        const bTime = Date.parse(b.updatedAt ?? b.createdAt ?? "");
+        return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
+      });
+      return next.slice(0, 10);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return () => {};
+    }
+    const unsubscribe = subscribeGuardianAlerts({
+      onEvent: (event: GuardianAlertEvent) => {
+        if (event.budget) {
+          setGuardianBudget(event.budget);
+          setGuardianError(null);
+          setGuardianLoading(false);
+        }
+        if (event.alert) {
+          upsertGuardianAlert(event.alert);
+        }
+        setGuardianStreamError(null);
+      },
+      onError: (error) => {
+        setGuardianStreamError(error.message);
+      },
+    });
+    return unsubscribe;
+  }, [upsertGuardianAlert]);
 
   const handleStreamEvent = useCallback(
     (event: StreamEventEnvelope) => {
@@ -789,6 +892,34 @@ const HomePage: NextPage = () => {
     [closeStream, confirmationRequest, t],
   );
 
+  const handleGuardianDecision = useCallback(
+    (alertId: string, decision: "approve" | "reject") => {
+      setGuardianSubmissions((previous) => ({ ...previous, [alertId]: "pending" }));
+      void submitGuardianApproval({ alertId, decision })
+        .then((result) => {
+          if (result.alert) {
+            upsertGuardianAlert(result.alert);
+          } else {
+            setGuardianAlerts((current) => {
+              const index = current.findIndex((item) => item.id === alertId);
+              if (index === -1) {
+                return current;
+              }
+              const next = [...current];
+              next[index] = { ...next[index], status: result.status };
+              return next;
+            });
+          }
+          setGuardianSubmissions((previous) => ({ ...previous, [alertId]: "success" }));
+        })
+        .catch((error: unknown) => {
+          console.warn("Guardian approval failed", error);
+          setGuardianSubmissions((previous) => ({ ...previous, [alertId]: "error" }));
+        });
+    },
+    [upsertGuardianAlert],
+  );
+
   const tabItems = useMemo(
     () => [
       { id: "chat" as const, label: t("layout.tabs.chat") },
@@ -838,6 +969,16 @@ const HomePage: NextPage = () => {
     return { cost, latency, tokens };
   }, [skillEvents]);
 
+  const guardianStatusKey: GuardianStatusKey = guardianError
+    ? "error"
+    : guardianLoading
+      ? "loading"
+      : guardianBudget
+        ? guardianBudget.status
+        : "idle";
+  const guardianStatusTone = GUARDIAN_STATUS_TONES[guardianStatusKey];
+  const guardianStatusLabel = t(`guardian.status.${guardianStatusKey}`);
+
   const formatDateTime = useCallback(
     (value: string) => {
       try {
@@ -852,6 +993,21 @@ const HomePage: NextPage = () => {
         }).format(date);
       } catch {
         return value;
+      }
+    },
+    [locale],
+  );
+
+  const formatCurrencyValue = useCallback(
+    (value?: number | null, currency?: string) => {
+      if (typeof value !== "number" || Number.isNaN(value)) {
+        return "–";
+      }
+      const unit = currency && currency.length > 0 ? currency : "USD";
+      try {
+        return new Intl.NumberFormat(locale, { style: "currency", currency: unit }).format(value);
+      } catch {
+        return `${value.toFixed(2)} ${unit}`;
       }
     },
     [locale],
@@ -1053,6 +1209,172 @@ const HomePage: NextPage = () => {
             </section>
 
             <div className="grid gap-6" data-testid="sidebar-panels">
+              <section
+                aria-labelledby="guardian-panel-title"
+                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+                data-testid="guardian-panel"
+              >
+                <div className="space-y-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <h3 id="guardian-panel-title" className={headingClass}>
+                        {t("guardian.heading")}
+                      </h3>
+                      <p className={`${subtleTextClass} text-xs`}>{t("guardian.subtitle")}</p>
+                    </div>
+                    <span className={`${badgeClass} ${guardianStatusTone} normal-case`}>
+                      {guardianStatusLabel}
+                    </span>
+                  </div>
+                  {guardianError ? (
+                    <p className="text-xs text-rose-200">
+                      {t("guardian.error.detail", { message: guardianError })}
+                    </p>
+                  ) : null}
+                  <dl className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <dt className={`${labelClass} text-slate-400`}>
+                        {t("guardian.budget.limit")}
+                      </dt>
+                      <dd className="text-sm text-slate-200">
+                        {guardianBudget
+                          ? formatCurrencyValue(guardianBudget.limit, guardianBudget.currency)
+                          : "–"}
+                      </dd>
+                    </div>
+                    <div className="space-y-2">
+                      <dt className={`${labelClass} text-slate-400`}>
+                        {t("guardian.budget.used")}
+                      </dt>
+                      <dd className="text-sm text-slate-200">
+                        {guardianBudget
+                          ? formatCurrencyValue(guardianBudget.used, guardianBudget.currency)
+                          : "–"}
+                      </dd>
+                    </div>
+                    <div className="space-y-2">
+                      <dt className={`${labelClass} text-slate-400`}>
+                        {t("guardian.budget.remaining")}
+                      </dt>
+                      <dd className="text-sm text-slate-200">
+                        {guardianBudget
+                          ? formatCurrencyValue(guardianBudget.remaining, guardianBudget.currency)
+                          : "–"}
+                      </dd>
+                    </div>
+                  </dl>
+                  {guardianBudget?.updatedAt ? (
+                    <p className={`${subtleTextClass} text-xs`}>
+                      {t("guardian.budget.updatedAt", {
+                        value: formatDateTime(guardianBudget.updatedAt),
+                      })}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h4 className={`${labelClass} text-slate-300`}>
+                      {t("guardian.alerts.heading")}
+                    </h4>
+                    <span className={`${badgeClass} bg-slate-900/70 text-slate-300`}>
+                      {guardianAlerts.length}
+                    </span>
+                  </div>
+                  {guardianStreamError ? (
+                    <p className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-100">
+                      {t("guardian.alerts.streamError")}
+                    </p>
+                  ) : null}
+                  {guardianAlerts.length === 0 ? (
+                    <p className={`${subtleTextClass} text-sm`}>
+                      {guardianLoading
+                        ? t("guardian.alerts.loading")
+                        : guardianError
+                          ? t("guardian.alerts.streamError")
+                          : t("guardian.alerts.empty")}
+                    </p>
+                  ) : (
+                    <ul className="space-y-3">
+                      {guardianAlerts.map((alert) => {
+                        const submissionState = guardianSubmissions[alert.id];
+                        const isPending = submissionState === "pending";
+                        const replayHref =
+                          alert.replayUrl ??
+                          alert.detailsUrl ??
+                          (alert.traceId ? `/episodes/${alert.traceId}` : null);
+                        const showApproval = alert.requireApproval && alert.status === "open";
+                        return (
+                          <li
+                            key={alert.id}
+                            className={`${insetSurfaceClass} border border-slate-800/70 bg-slate-950/50 p-4`}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="space-y-2">
+                                <p className="text-sm text-slate-100">{alert.message}</p>
+                                <div className="flex flex-wrap gap-2">
+                                  <span
+                                    className={`${badgeClass} ${GUARDIAN_SEVERITY_TONES[alert.severity]}`}
+                                  >
+                                    {t(`guardian.alerts.severity.${alert.severity}`)}
+                                  </span>
+                                  <span
+                                    className={`${badgeClass} ${GUARDIAN_ALERT_STATUS_TONES[alert.status]}`}
+                                  >
+                                    {t(`guardian.alerts.status.${alert.status}`)}
+                                  </span>
+                                </div>
+                                <p className={`${subtleTextClass} text-xs`}>
+                                  {formatDateTime(alert.updatedAt ?? alert.createdAt)}
+                                </p>
+                              </div>
+                              {replayHref ? (
+                                <a
+                                  href={replayHref}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
+                                >
+                                  {t("guardian.alerts.replay")}
+                                </a>
+                              ) : null}
+                            </div>
+                            {showApproval ? (
+                              <div className="flex flex-wrap gap-3 pt-3">
+                                <button
+                                  type="button"
+                                  onClick={() => handleGuardianDecision(alert.id, "approve")}
+                                  disabled={isPending}
+                                  className={`${primaryButtonClass} px-3 py-1.5 text-xs`}
+                                >
+                                  {t("guardian.alerts.approve")}
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => handleGuardianDecision(alert.id, "reject")}
+                                  disabled={isPending}
+                                  className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
+                                >
+                                  {t("guardian.alerts.reject")}
+                                </button>
+                              </div>
+                            ) : null}
+                            {submissionState === "success" ? (
+                              <p className={`${subtleTextClass} pt-2 text-xs`}>
+                                {t("guardian.alerts.submitted")}
+                              </p>
+                            ) : null}
+                            {submissionState === "error" ? (
+                              <p className="pt-2 text-xs text-rose-200">
+                                {t("guardian.alerts.error")}
+                              </p>
+                            ) : null}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              </section>
               <section
                 aria-labelledby="run-stats-title"
                 className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}

--- a/tests/homePage.i18n.test.tsx
+++ b/tests/homePage.i18n.test.tsx
@@ -16,6 +16,8 @@ describe("HomePage internationalisation", () => {
     expect(html.includes("AgentOS · 对话与日志流")).toBe(true);
     expect(html.includes("保存对话")).toBe(true);
     expect(html.includes("聊天输入")).toBe(true);
+    expect(html.includes("Guardian 守护")).toBe(true);
+    expect(html.includes("告警列表")).toBe(true);
   });
 
   it("renders English copy when locale changes", () => {
@@ -28,5 +30,7 @@ describe("HomePage internationalisation", () => {
     expect(html.includes("AgentOS · Chat + LogFlow")).toBe(true);
     expect(html.includes("Save conversation")).toBe(true);
     expect(html.includes("Chat input")).toBe(true);
+    expect(html.includes("Guardian oversight")).toBe(true);
+    expect(html.includes("Active alerts")).toBe(true);
   });
 });

--- a/tests/llmChat.test.ts
+++ b/tests/llmChat.test.ts
@@ -96,7 +96,8 @@ describe("llm.chat via OpenAI SDK", () => {
     if (result.ok) {
       expect(result.data.content).toBe("你好");
       expect(typeof result.latency_ms).toBe("number");
-      expect(result.latency_ms >= 0).toBe(true);
+      const latency = result.latency_ms ?? 0;
+      expect(latency >= 0).toBe(true);
     }
   });
 

--- a/tests/ui/chat-page.pw.ts
+++ b/tests/ui/chat-page.pw.ts
@@ -7,6 +7,7 @@ test.describe("Chat page", () => {
 
     await expect(page.getByRole("heading", { name: /agentos · chat \+ logflow/i })).toBeVisible();
     await expect(page.getByRole("button", { name: /run/i })).toBeVisible();
+    await expect(page.getByTestId("guardian-panel")).toBeVisible();
 
     const tokens = await page.evaluate(() => {
       const describeElement = (element: Element | null) => {
@@ -69,6 +70,7 @@ test.describe("Chat page", () => {
           document.querySelector('[data-testid="conversation-panel"]'),
         ),
         sidebarPanels: describeElement(document.querySelector('[data-testid="sidebar-panels"]')),
+        guardianPanel: describeElement(document.querySelector('[data-testid="guardian-panel"]')),
         runStatsPanel: describeElement(document.querySelector('[data-testid="run-stats-panel"]')),
         rawResponsePanel: describeElement(
           document.querySelector('[data-testid="raw-response-panel"]'),

--- a/tests/ui/chat-page.pw.ts-snapshots/chat-page-classes-chromium-linux.json
+++ b/tests/ui/chat-page.pw.ts-snapshots/chat-page-classes-chromium-linux.json
@@ -121,6 +121,19 @@
       "grid"
     ]
   },
+  "guardianPanel": {
+    "tag": "section",
+    "classes": [
+      "bg-slate-900/60",
+      "border",
+      "border-slate-800/80",
+      "p-6",
+      "rounded-3xl",
+      "shadow-[0_24px_60px_rgba(8,15,35,0.45)]",
+      "sm:p-7",
+      "space-y-6"
+    ]
+  },
   "runStatsPanel": {
     "tag": "section",
     "classes": [


### PR DESCRIPTION
## Summary
- add a Guardian client wrapper to fetch budget status, subscribe to alert events, and submit approval decisions
- surface a Guardian oversight panel on the chat page showing budget usage, active alerts, and inline approval/replay actions with state updates
- extend i18n resources and regression tests (home page SSR, Playwright snapshot, llm latency assertion) to cover the new Guardian UX

## Testing
- pnpm typecheck
- pnpm test
- pnpm test:ui *(fails: Playwright browser binary unavailable in environment)*
- pnpm exec playwright install chromium *(fails: Playwright CDN returns 403 Forbidden)*
- pnpm lint *(fails: existing ESLint configuration references missing @typescript-eslint/no-unused-vars rule)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7ceee9fc832b9075e5e78cee32cd