### PR TITLE
feat(skills): persist analysis data in sqlite

### DIFF
--- a/packages/skills/pipeline.ts
+++ b/packages/skills/pipeline.ts
@@ -1,14 +1,19 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 import {
   type ReviewStatus,
   type SkillRecord,
-  getSkillById,
-  listSkills,
-  resetSkillsStore,
-  upsertSkills,
+  type SkillsRepository,
+  type SkillUpdateStats,
+  createSqliteSkillsRepository,
 } from "./storage";
+import * as schema from "../../servers/api/src/database/schema";
+export { InMemorySkillsRepository } from "./storage";
 
 export interface ToolCallEvent {
   id: string;
@@ -55,12 +60,6 @@ export interface EventsRepository {
   listToolEvents(options?: { since?: string }): Promise<ToolCallEvent[]>;
 }
 
-export interface SkillsRepository {
-  list(): Promise<SkillRecord[]>;
-  findById(id: string): Promise<SkillRecord | null>;
-  upsert(records: SkillRecord[]): Promise<SkillRecord[]>;
-}
-
 export interface SkillAnalysisPipelineOptions {
   minSamplesForReview?: number;
   clock?: () => Date;
@@ -71,6 +70,13 @@ export interface SkillAnalysisResult {
   aggregated: AggregatedToolCall[];
   candidates: SkillRecord[];
   updatedSkills: SkillRecord[];
+}
+
+export interface RunDefaultSkillAnalysisOptions extends SkillAnalysisPipelineOptions {
+  eventsRepository?: EventsRepository;
+  skillsRepository?: SkillsRepository;
+  db?: BetterSQLite3Database<typeof schema>;
+  dbPath?: string;
 }
 
 const DEFAULT_MIN_SAMPLES_FOR_REVIEW = 3;
@@ -312,20 +318,6 @@ function normaliseEvent(raw: unknown): ToolCallEvent | null {
   } satisfies ToolCallEvent;
 }
 
-export class FileSkillsRepository implements SkillsRepository {
-  async list(): Promise<SkillRecord[]> {
-    return listSkills();
-  }
-
-  async findById(id: string): Promise<SkillRecord | null> {
-    return getSkillById(id);
-  }
-
-  async upsert(records: SkillRecord[]): Promise<SkillRecord[]> {
-    return upsertSkills(records);
-  }
-}
-
 export class InMemoryEventsRepository implements EventsRepository {
   private events: ToolCallEvent[];
 
@@ -339,36 +331,6 @@ export class InMemoryEventsRepository implements EventsRepository {
 
   setEvents(events: ToolCallEvent[]): void {
     this.events = events.map((event) => ({ ...event }));
-  }
-}
-
-export class InMemorySkillsRepository implements SkillsRepository {
-  private records: SkillRecord[];
-
-  constructor(records: SkillRecord[] = []) {
-    this.records = records.map((record) => ({ ...record, template_json: stableClone(record.template_json) }));
-  }
-
-  async list(): Promise<SkillRecord[]> {
-    return this.records.map((record) => ({ ...record, template_json: stableClone(record.template_json) }));
-  }
-
-  async findById(id: string): Promise<SkillRecord | null> {
-    const match = this.records.find((record) => record.id === id);
-    return match ? { ...match, template_json: stableClone(match.template_json) } : null;
-  }
-
-  async upsert(records: SkillRecord[]): Promise<SkillRecord[]> {
-    for (const record of records) {
-      const index = this.records.findIndex((existing) => existing.id === record.id);
-      const cloned = { ...record, template_json: stableClone(record.template_json) };
-      if (index >= 0) {
-        this.records[index] = cloned;
-      } else {
-        this.records.push(cloned);
-      }
-    }
-    return this.list();
   }
 }
 
@@ -392,6 +354,7 @@ export class SkillAnalysisPipeline {
     const aggregated = this.aggregate(deduped);
 
     const updatedRecords: SkillRecord[] = [];
+    const statsBySkill = new Map<string, SkillUpdateStats>();
 
     for (const group of aggregated) {
       if (group.totalCount === 0) {
@@ -399,13 +362,16 @@ export class SkillAnalysisPipeline {
       }
       const draft = await this.summariser.summarise(group);
       const existing = await this.skillsRepository.findById(draft.id);
-      const updated = this.mergeWithExisting(group, draft, existing);
-      updatedRecords.push(updated);
+      const { record, stats } = this.mergeWithExisting(group, draft, existing);
+      updatedRecords.push(record);
+      statsBySkill.set(record.id, stats);
     }
+
+    const runId = randomUUID();
 
     const updatedList =
       updatedRecords.length > 0
-        ? await this.skillsRepository.upsert(updatedRecords)
+        ? await this.skillsRepository.upsert(updatedRecords, { runId, stats: statsBySkill })
         : await this.skillsRepository.list();
 
     const candidates = updatedList.filter((skill) => skill.review_status !== "approved");
@@ -472,7 +438,7 @@ export class SkillAnalysisPipeline {
     group: AggregatedToolCall,
     draft: SkillDraft,
     existing: SkillRecord | null,
-  ): SkillRecord {
+  ): { record: SkillRecord; stats: SkillUpdateStats } {
     const metadata = extractAnalysisMetadata(existing);
     const now = this.now().toISOString();
     const newEvents = group.events.filter((event) => !metadata.eventIds.has(eventKey(event)));
@@ -507,7 +473,7 @@ export class SkillAnalysisPipeline {
 
     const tags = mergeTags(existing?.tags, draft.tags, group.tags);
 
-    return {
+    const record: SkillRecord = {
       id: draft.id,
       name: draft.name,
       description: draft.description,
@@ -520,6 +486,18 @@ export class SkillAnalysisPipeline {
       review_status: reviewStatus,
       last_analyzed_at: now,
     } satisfies SkillRecord;
+
+    const stats: SkillUpdateStats = {
+      totalCount,
+      successCount: totalSuccess,
+      failureCount: totalFailure,
+      newEventCount: newEvents.length,
+      newSuccessCount: newSuccess,
+      newFailureCount: newFailure,
+      lastEventAt: group.lastTimestamp ?? newEvents[newEvents.length - 1]?.timestamp,
+    };
+
+    return { record, stats };
   }
 
   private determineReviewStatus(current: ReviewStatus | undefined, usedCount: number): ReviewStatus {
@@ -535,12 +513,107 @@ export class SkillAnalysisPipeline {
 
 export async function runDefaultSkillAnalysis(
   summariser: SkillSummariser = new HeuristicSkillSummariser(),
-  options: SkillAnalysisPipelineOptions = {},
+  options: RunDefaultSkillAnalysisOptions = {},
 ): Promise<SkillAnalysisResult> {
-  const eventsRepo = new FileEventsRepository();
-  const skillsRepo = new FileSkillsRepository();
-  const pipeline = new SkillAnalysisPipeline(eventsRepo, skillsRepo, summariser, options);
-  return pipeline.run();
+  const eventsRepo = options.eventsRepository ?? new FileEventsRepository();
+  let cleanup: (() => void) | null = null;
+  let skillsRepo = options.skillsRepository;
+
+  if (!skillsRepo) {
+    if (options.db) {
+      skillsRepo = createSqliteSkillsRepository(options.db);
+    } else {
+      const { repository, dispose } = createSqliteRepositoryFromPath(options.dbPath);
+      skillsRepo = repository;
+      cleanup = dispose;
+    }
+  }
+
+  if (!skillsRepo) {
+    throw new Error("Failed to resolve skills repository for analysis");
+  }
+
+  try {
+    const pipeline = new SkillAnalysisPipeline(eventsRepo, skillsRepo, summariser, options);
+    return await pipeline.run();
+  } finally {
+    if (cleanup) {
+      cleanup();
+    }
+  }
 }
 
-export { resetSkillsStore };
+function createSqliteRepositoryFromPath(path?: string): {
+  repository: SkillsRepository;
+  dispose: () => void;
+} {
+  const dbPath = path ?? process.env.AOS_DB_PATH ?? join(process.cwd(), "data", "aos.sqlite");
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const sqlite = new Database(dbPath);
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS skills (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      category TEXT,
+      tags_json TEXT,
+      enabled INTEGER NOT NULL DEFAULT 0,
+      template_json TEXT,
+      used_count INTEGER NOT NULL DEFAULT 0,
+      win_rate REAL NOT NULL DEFAULT 0,
+      review_status TEXT NOT NULL DEFAULT 'draft',
+      last_analyzed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      version INTEGER NOT NULL DEFAULT 0,
+      current_version_id TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS skill_versions (
+      id TEXT PRIMARY KEY,
+      skill_id TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      category TEXT,
+      tags_json TEXT,
+      template_json TEXT,
+      used_count INTEGER NOT NULL DEFAULT 0,
+      win_rate REAL NOT NULL DEFAULT 0,
+      review_status TEXT NOT NULL DEFAULT 'draft',
+      last_analyzed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_unique ON skill_versions(skill_id, version);
+    CREATE INDEX IF NOT EXISTS skill_versions_skill_idx ON skill_versions(skill_id);
+
+    CREATE TABLE IF NOT EXISTS skill_runs (
+      id TEXT PRIMARY KEY,
+      skill_id TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      run_id TEXT NOT NULL,
+      total_count INTEGER NOT NULL,
+      success_count INTEGER NOT NULL,
+      failure_count INTEGER NOT NULL,
+      new_event_count INTEGER NOT NULL DEFAULT 0,
+      new_success_count INTEGER NOT NULL DEFAULT 0,
+      new_failure_count INTEGER NOT NULL DEFAULT 0,
+      last_event_at INTEGER,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS skill_runs_skill_idx ON skill_runs(skill_id);
+    CREATE INDEX IF NOT EXISTS skill_runs_run_idx ON skill_runs(run_id);
+  `);
+  const db = drizzle(sqlite, { schema });
+  const repository = createSqliteSkillsRepository(db);
+  return {
+    repository,
+    dispose: () => sqlite.close(),
+  };
+}

--- a/packages/skills/storage.ts
+++ b/packages/skills/storage.ts
@@ -1,5 +1,8 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { eq, sql } from "drizzle-orm";
+
+import * as schema from "../../servers/api/src/database/schema";
 
 export type ReviewStatus = "draft" | "pending_review" | "approved" | "rejected";
 
@@ -15,6 +18,28 @@ export interface SkillRecord {
   win_rate: number;
   review_status: ReviewStatus;
   last_analyzed_at?: string;
+}
+
+export interface SkillUpdateStats {
+  totalCount: number;
+  successCount: number;
+  failureCount: number;
+  newEventCount: number;
+  newSuccessCount: number;
+  newFailureCount: number;
+  lastEventAt?: string;
+}
+
+export interface SkillUpsertContext {
+  runId?: string;
+  stats?: Map<string, SkillUpdateStats>;
+}
+
+export interface SkillsRepository {
+  list(): Promise<SkillRecord[]>;
+  findById(id: string): Promise<SkillRecord | null>;
+  upsert(records: SkillRecord[], context?: SkillUpsertContext): Promise<SkillRecord[]>;
+  setEnabled(id: string, enabled: boolean): Promise<SkillRecord>;
 }
 
 export class SkillNotFoundError extends Error {
@@ -63,174 +88,321 @@ export const DEFAULT_SKILLS: SkillRecord[] = [
   },
 ];
 
-let memorySkills: SkillRecord[] = cloneSkills(DEFAULT_SKILLS);
+export function createSqliteSkillsRepository(
+  db: BetterSQLite3Database<typeof schema>,
+  options: { seedDefaults?: boolean } = {},
+): SkillsRepository {
+  return new SqliteSkillsRepository(db, options);
+}
+
+export class SqliteSkillsRepository implements SkillsRepository {
+  private readonly db: BetterSQLite3Database<typeof schema>;
+  private readonly seedDefaults: boolean;
+  private defaultsPromise: Promise<void> | null = null;
+
+  constructor(db: BetterSQLite3Database<typeof schema>, options: { seedDefaults?: boolean } = {}) {
+    this.db = db;
+    this.seedDefaults = options.seedDefaults ?? true;
+  }
+
+  async list(): Promise<SkillRecord[]> {
+    await this.ensureDefaults();
+    const rows = await this.db.select().from(schema.skills).orderBy(schema.skills.name);
+    return rows.map((row) => deserializeSkill(row));
+  }
+
+  async findById(id: string): Promise<SkillRecord | null> {
+    await this.ensureDefaults();
+    const rows = await this.db.select().from(schema.skills).where(eq(schema.skills.id, id)).limit(1);
+    const match = rows[0];
+    return match ? deserializeSkill(match) : null;
+  }
+
+  async setEnabled(id: string, enabled: boolean): Promise<SkillRecord> {
+    await this.ensureDefaults();
+    const updatedAt = new Date();
+    await this.db.update(schema.skills).set({ enabled, updatedAt }).where(eq(schema.skills.id, id));
+    const row = await this.findById(id);
+    if (!row) {
+      throw new SkillNotFoundError(id);
+    }
+    return row;
+  }
+
+  async upsert(records: SkillRecord[], context?: SkillUpsertContext): Promise<SkillRecord[]> {
+    await this.ensureDefaults();
+    if (records.length === 0) {
+      return this.list();
+    }
+    const runId = context?.runId ?? randomUUID();
+    const now = new Date();
+
+    await this.db.transaction(async (tx) => {
+      for (const record of records) {
+        const existing = await tx
+          .select()
+          .from(schema.skills)
+          .where(eq(schema.skills.id, record.id))
+          .limit(1);
+        const existingRow = existing[0] ?? null;
+        const version = (existingRow?.version ?? 0) + 1;
+        const versionId = randomUUID();
+        const createdAt = existingRow?.createdAt ?? now;
+        const lastAnalyzedAtDate = parseDate(record.last_analyzed_at);
+
+        await tx
+          .insert(schema.skills)
+          .values({
+            id: record.id,
+            name: record.name,
+            description: record.description,
+            category: record.category ?? null,
+            tags: record.tags ? JSON.stringify(record.tags) : null,
+            enabled: record.enabled,
+            template: JSON.stringify(record.template_json ?? {}),
+            usedCount: record.used_count,
+            winRate: record.win_rate,
+            reviewStatus: record.review_status,
+            lastAnalyzedAt: lastAnalyzedAtDate,
+            createdAt,
+            updatedAt: now,
+            version,
+            currentVersionId: versionId,
+          })
+          .onConflictDoUpdate({
+            target: schema.skills.id,
+            set: {
+              name: record.name,
+              description: record.description,
+              category: record.category ?? null,
+              tags: record.tags ? JSON.stringify(record.tags) : null,
+              enabled: record.enabled,
+              template: JSON.stringify(record.template_json ?? {}),
+              usedCount: record.used_count,
+              winRate: record.win_rate,
+              reviewStatus: record.review_status,
+              lastAnalyzedAt: lastAnalyzedAtDate,
+              updatedAt: now,
+              version,
+              currentVersionId: versionId,
+            },
+          });
+
+        await tx.insert(schema.skillVersions).values({
+          id: versionId,
+          skillId: record.id,
+          version,
+          name: record.name,
+          description: record.description,
+          category: record.category ?? null,
+          tags: record.tags ? JSON.stringify(record.tags) : null,
+          template: JSON.stringify(record.template_json ?? {}),
+          usedCount: record.used_count,
+          winRate: record.win_rate,
+          reviewStatus: record.review_status,
+          lastAnalyzedAt: lastAnalyzedAtDate,
+          createdAt: now,
+        });
+
+        const stats = context?.stats?.get(record.id);
+        if (stats) {
+          await tx.insert(schema.skillRuns).values({
+            id: randomUUID(),
+            skillId: record.id,
+            version,
+            runId,
+            totalCount: stats.totalCount,
+            successCount: stats.successCount,
+            failureCount: stats.failureCount,
+            newEventCount: stats.newEventCount,
+            newSuccessCount: stats.newSuccessCount,
+            newFailureCount: stats.newFailureCount,
+            lastEventAt: parseDate(stats.lastEventAt),
+            createdAt: now,
+          });
+        }
+      }
+    });
+
+    return this.list();
+  }
+
+  private async ensureDefaults(): Promise<void> {
+    if (!this.seedDefaults) {
+      return;
+    }
+    if (!this.defaultsPromise) {
+      this.defaultsPromise = this.db.transaction(async (tx) => {
+        const countResult = await tx
+          .select({ value: sql<number>`count(*)`.as("value") })
+          .from(schema.skills)
+          .limit(1);
+        const count = countResult[0]?.value ?? 0;
+        if (count > 0) {
+          return;
+        }
+        const now = new Date();
+        for (const record of DEFAULT_SKILLS) {
+          const versionId = randomUUID();
+          const lastAnalyzedAt = parseDate(record.last_analyzed_at);
+          await tx.insert(schema.skills).values({
+            id: record.id,
+            name: record.name,
+            description: record.description,
+            category: record.category ?? null,
+            tags: record.tags ? JSON.stringify(record.tags) : null,
+            enabled: record.enabled,
+            template: JSON.stringify(record.template_json ?? {}),
+            usedCount: record.used_count,
+            winRate: record.win_rate,
+            reviewStatus: record.review_status,
+            lastAnalyzedAt,
+            createdAt: now,
+            updatedAt: now,
+            version: 1,
+            currentVersionId: versionId,
+          });
+          await tx.insert(schema.skillVersions).values({
+            id: versionId,
+            skillId: record.id,
+            version: 1,
+            name: record.name,
+            description: record.description,
+            category: record.category ?? null,
+            tags: record.tags ? JSON.stringify(record.tags) : null,
+            template: JSON.stringify(record.template_json ?? {}),
+            usedCount: record.used_count,
+            winRate: record.win_rate,
+            reviewStatus: record.review_status,
+            lastAnalyzedAt,
+            createdAt: now,
+          });
+        }
+      });
+    }
+    await this.defaultsPromise;
+  }
+}
+
+export function createInMemorySkillsRepository(initial: SkillRecord[] = DEFAULT_SKILLS): SkillsRepository {
+  return new InMemorySkillsRepository(initial);
+}
+
+export class InMemorySkillsRepository implements SkillsRepository {
+  private records: Map<string, SkillRecord>;
+
+  constructor(initial: SkillRecord[] = DEFAULT_SKILLS) {
+    this.records = new Map(initial.map((record) => [record.id, cloneSkill(record)]));
+  }
+
+  async list(): Promise<SkillRecord[]> {
+    return [...this.records.values()].map((record) => cloneSkill(record));
+  }
+
+  async findById(id: string): Promise<SkillRecord | null> {
+    const match = this.records.get(id);
+    return match ? cloneSkill(match) : null;
+  }
+
+  async setEnabled(id: string, enabled: boolean): Promise<SkillRecord> {
+    const match = this.records.get(id);
+    if (!match) {
+      throw new SkillNotFoundError(id);
+    }
+    match.enabled = enabled;
+    return cloneSkill(match);
+  }
+
+  async upsert(records: SkillRecord[]): Promise<SkillRecord[]> {
+    for (const record of records) {
+      this.records.set(record.id, cloneSkill(record));
+    }
+    return this.list();
+  }
+}
+
+export async function resetSkillsStore(
+  db: BetterSQLite3Database<typeof schema>,
+  options: { skills?: SkillRecord[] } = {},
+): Promise<void> {
+  const skills = options.skills ?? DEFAULT_SKILLS;
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    await tx.delete(schema.skillRuns);
+    await tx.delete(schema.skillVersions);
+    await tx.delete(schema.skills);
+    for (const record of skills) {
+      const versionId = randomUUID();
+      const lastAnalyzedAt = parseDate(record.last_analyzed_at);
+      await tx.insert(schema.skills).values({
+        id: record.id,
+        name: record.name,
+        description: record.description,
+        category: record.category ?? null,
+        tags: record.tags ? JSON.stringify(record.tags) : null,
+        enabled: record.enabled,
+        template: JSON.stringify(record.template_json ?? {}),
+        usedCount: record.used_count,
+        winRate: record.win_rate,
+        reviewStatus: record.review_status,
+        lastAnalyzedAt,
+        createdAt: now,
+        updatedAt: now,
+        version: 1,
+        currentVersionId: versionId,
+      });
+      await tx.insert(schema.skillVersions).values({
+        id: versionId,
+        skillId: record.id,
+        version: 1,
+        name: record.name,
+        description: record.description,
+        category: record.category ?? null,
+        tags: record.tags ? JSON.stringify(record.tags) : null,
+        template: JSON.stringify(record.template_json ?? {}),
+        usedCount: record.used_count,
+        winRate: record.win_rate,
+        reviewStatus: record.review_status,
+        lastAnalyzedAt,
+        createdAt: now,
+      });
+    }
+  });
+}
 
 function cloneSkill(record: SkillRecord): SkillRecord {
   return {
     ...record,
+    ...(record.category ? { category: record.category } : {}),
     ...(record.tags ? { tags: [...record.tags] } : {}),
     template_json: JSON.parse(JSON.stringify(record.template_json ?? {})),
+    ...(record.last_analyzed_at ? { last_analyzed_at: record.last_analyzed_at } : {}),
   };
 }
 
-function cloneSkills(skills: SkillRecord[]): SkillRecord[] {
-  return skills.map((skill) => cloneSkill(skill));
-}
-
-const getSkillsStorePath = (): string =>
-  process.env.AOS_SKILLS_PATH ?? join(process.cwd(), "runtime", "skills.json");
-
-async function readFromFile(): Promise<SkillRecord[] | null> {
-  const filePath = getSkillsStorePath();
-  try {
-    const payload = await readFile(filePath, "utf8");
-    const parsed = JSON.parse(payload);
-    if (!Array.isArray(parsed)) {
-      return null;
-    }
-    const normalised = parsed
-      .map((entry) => normaliseSkill(entry))
-      .filter((entry): entry is SkillRecord => entry !== null);
-    if (normalised.length === 0) {
-      return null;
-    }
-    return normalised;
-  } catch (error) {
-    return null;
-  }
-}
-
-function normaliseSkill(raw: unknown): SkillRecord | null {
-  if (!raw || typeof raw !== "object") {
-    return null;
-  }
-  const candidate = raw as Record<string, unknown>;
-  const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
-  const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
-  const description =
-    typeof candidate.description === "string" ? candidate.description.trim() : "";
-  if (!id || !name || !description) {
-    return null;
-  }
-
-  const enabledValue = candidate.enabled;
-  const enabled = typeof enabledValue === "boolean" ? enabledValue : true;
-  const category =
-    typeof candidate.category === "string" && candidate.category.trim().length > 0
-      ? candidate.category.trim()
-      : undefined;
-  const tags = Array.isArray(candidate.tags)
-    ? candidate.tags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0)
-    : undefined;
-  const templateValue =
-    typeof candidate.template_json === "object" && candidate.template_json !== null
-      ? (candidate.template_json as Record<string, unknown>)
-      : {};
-  const usedCount =
-    typeof candidate.used_count === "number" && Number.isFinite(candidate.used_count)
-      ? Math.max(0, Math.floor(candidate.used_count))
-      : 0;
-  const winRate =
-    typeof candidate.win_rate === "number" && Number.isFinite(candidate.win_rate)
-      ? Math.min(1, Math.max(0, candidate.win_rate))
-      : 0;
-  const reviewStatus = isReviewStatus(candidate.review_status)
-    ? candidate.review_status
-    : "pending_review";
-  const lastAnalyzedAt =
-    typeof candidate.last_analyzed_at === "string" && candidate.last_analyzed_at.length > 0
-      ? candidate.last_analyzed_at
-      : undefined;
-
+function deserializeSkill(row: typeof schema.skills.$inferSelect): SkillRecord {
   return {
-    id,
-    name,
-    description,
-    enabled,
-    template_json: JSON.parse(JSON.stringify(templateValue)),
-    used_count: usedCount,
-    win_rate: winRate,
-    review_status: reviewStatus,
-    ...(category ? { category } : {}),
-    ...(tags && tags.length > 0 ? { tags: [...tags] } : {}),
-    ...(lastAnalyzedAt ? { last_analyzed_at: lastAnalyzedAt } : {}),
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    category: row.category ?? undefined,
+    tags: row.tags ? (JSON.parse(row.tags) as string[]) : undefined,
+    enabled: Boolean(row.enabled),
+    template_json: row.template ? JSON.parse(row.template) : {},
+    used_count: row.usedCount ?? 0,
+    win_rate: row.winRate ?? 0,
+    review_status: (row.reviewStatus as ReviewStatus) ?? "draft",
+    last_analyzed_at: row.lastAnalyzedAt ? row.lastAnalyzedAt.toISOString() : undefined,
   };
 }
 
-function isReviewStatus(value: unknown): value is ReviewStatus {
-  return value === "draft" || value === "pending_review" || value === "approved" || value === "rejected";
-}
-
-async function persistSkills(skills: SkillRecord[]): Promise<void> {
-  const filePath = getSkillsStorePath();
-  try {
-    await mkdir(dirname(filePath), { recursive: true });
-    await writeFile(filePath, JSON.stringify(skills, null, 2), "utf8");
-  } catch (error) {
-    console.warn("Failed to persist skills store", error);
+function parseDate(value: string | Date | null | undefined): Date | null {
+  if (!value) {
+    return null;
   }
-}
-
-async function ensureMemoryStore(): Promise<SkillRecord[]> {
-  const stored = await readFromFile();
-  if (stored) {
-    memorySkills = cloneSkills(stored);
+  if (value instanceof Date) {
+    return value;
   }
-  return memorySkills;
-}
-
-export async function listSkills(): Promise<SkillRecord[]> {
-  const skills = await ensureMemoryStore();
-  return cloneSkills(skills);
-}
-
-export async function listCandidateSkills(): Promise<SkillRecord[]> {
-  const skills = await ensureMemoryStore();
-  return cloneSkills(skills.filter((skill) => skill.review_status !== "approved"));
-}
-
-export async function getSkillById(id: string): Promise<SkillRecord | null> {
-  const skills = await ensureMemoryStore();
-  const match = skills.find((skill) => skill.id === id);
-  return match ? cloneSkill(match) : null;
-}
-
-export async function setSkillEnabled(id: string, enabled: boolean): Promise<SkillRecord> {
-  const skills = await ensureMemoryStore();
-  const match = skills.find((skill) => skill.id === id);
-  if (!match) {
-    throw new SkillNotFoundError(id);
-  }
-  match.enabled = enabled;
-  await persistSkills(skills);
-  return cloneSkill(match);
-}
-
-export async function upsertSkills(records: SkillRecord[]): Promise<SkillRecord[]> {
-  const skills = await ensureMemoryStore();
-  for (const record of records) {
-    const index = skills.findIndex((skill) => skill.id === record.id);
-    if (index >= 0) {
-      skills[index] = cloneSkill({ ...skills[index], ...record });
-    } else {
-      skills.push(cloneSkill(record));
-    }
-  }
-  await persistSkills(skills);
-  return cloneSkills(skills);
-}
-
-export async function resetSkillsStore(options?: {
-  skills?: SkillRecord[];
-  persist?: boolean;
-}): Promise<void> {
-  const { skills = DEFAULT_SKILLS, persist = false } = options ?? {};
-  memorySkills = cloneSkills(skills);
-  const filePath = getSkillsStorePath();
-  if (!persist) {
-    await rm(filePath, { force: true });
-    return;
-  }
-  await mkdir(dirname(filePath), { recursive: true });
-  await writeFile(filePath, JSON.stringify(skills, null, 2), "utf8");
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/servers/api/src/database/database.service.ts
+++ b/servers/api/src/database/database.service.ts
@@ -14,6 +14,9 @@ type RunEventInsert = typeof schema.runEvents.$inferInsert;
 type RunEventRow = typeof schema.runEvents.$inferSelect;
 type McpInsert = typeof schema.mcpConfigs.$inferInsert;
 type McpRow = typeof schema.mcpConfigs.$inferSelect;
+type SkillRow = typeof schema.skills.$inferSelect;
+type SkillVersionRow = typeof schema.skillVersions.$inferSelect;
+type SkillRunRow = typeof schema.skillRuns.$inferSelect;
 
 type DatabaseMode = "sqlite" | "memory";
 
@@ -21,6 +24,9 @@ interface MemoryStore {
   runs: Map<string, RunRow>;
   runEvents: Map<string, RunEventRow[]>;
   mcpConfigs: Map<string, McpRow>;
+  skills: Map<string, SkillRow>;
+  skillVersions: Map<string, SkillVersionRow>;
+  skillRuns: Map<string, SkillRunRow>;
 }
 
 @Injectable()
@@ -60,6 +66,9 @@ export class DatabaseService implements OnModuleDestroy {
       runs: new Map<string, RunRow>(),
       runEvents: new Map<string, RunEventRow[]>(),
       mcpConfigs: new Map<string, McpRow>(),
+      skills: new Map<string, SkillRow>(),
+      skillVersions: new Map<string, SkillVersionRow>(),
+      skillRuns: new Map<string, SkillRunRow>(),
     };
   }
 
@@ -111,6 +120,63 @@ export class DatabaseService implements OnModuleDestroy {
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
+
+      CREATE TABLE IF NOT EXISTS skills (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        category TEXT,
+        tags_json TEXT,
+        enabled INTEGER NOT NULL DEFAULT 0,
+        template_json TEXT,
+        used_count INTEGER NOT NULL DEFAULT 0,
+        win_rate REAL NOT NULL DEFAULT 0,
+        review_status TEXT NOT NULL DEFAULT 'draft',
+        last_analyzed_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        version INTEGER NOT NULL DEFAULT 0,
+        current_version_id TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS skill_versions (
+        id TEXT PRIMARY KEY,
+        skill_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        category TEXT,
+        tags_json TEXT,
+        template_json TEXT,
+        used_count INTEGER NOT NULL DEFAULT 0,
+        win_rate REAL NOT NULL DEFAULT 0,
+        review_status TEXT NOT NULL DEFAULT 'draft',
+        last_analyzed_at INTEGER,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_unique ON skill_versions(skill_id, version);
+      CREATE INDEX IF NOT EXISTS skill_versions_skill_idx ON skill_versions(skill_id);
+
+      CREATE TABLE IF NOT EXISTS skill_runs (
+        id TEXT PRIMARY KEY,
+        skill_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        run_id TEXT NOT NULL,
+        total_count INTEGER NOT NULL,
+        success_count INTEGER NOT NULL,
+        failure_count INTEGER NOT NULL,
+        new_event_count INTEGER NOT NULL DEFAULT 0,
+        new_success_count INTEGER NOT NULL DEFAULT 0,
+        new_failure_count INTEGER NOT NULL DEFAULT 0,
+        last_event_at INTEGER,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS skill_runs_skill_idx ON skill_runs(skill_id);
+      CREATE INDEX IF NOT EXISTS skill_runs_run_idx ON skill_runs(run_id);
     `);
   }
 

--- a/servers/api/src/database/schema.ts
+++ b/servers/api/src/database/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, real, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const runs = sqliteTable("runs", {
   id: text("id").primaryKey(),
@@ -48,3 +48,70 @@ export const mcpConfigs = sqliteTable("mcp_configs", {
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 });
+
+export const skills = sqliteTable("skills", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description").notNull(),
+  category: text("category"),
+  tags: text("tags_json"),
+  enabled: integer("enabled", { mode: "boolean" }).notNull().default(false),
+  template: text("template_json"),
+  usedCount: integer("used_count").notNull().default(0),
+  winRate: real("win_rate").notNull().default(0),
+  reviewStatus: text("review_status").notNull().default("draft"),
+  lastAnalyzedAt: integer("last_analyzed_at", { mode: "timestamp_ms" }),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  version: integer("version").notNull().default(0),
+  currentVersionId: text("current_version_id"),
+});
+
+export const skillVersions = sqliteTable(
+  "skill_versions",
+  {
+    id: text("id").primaryKey(),
+    skillId: text("skill_id")
+      .notNull()
+      .references(() => skills.id, { onDelete: "cascade" }),
+    version: integer("version").notNull(),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    category: text("category"),
+    tags: text("tags_json"),
+    template: text("template_json"),
+    usedCount: integer("used_count").notNull().default(0),
+    winRate: real("win_rate").notNull().default(0),
+    reviewStatus: text("review_status").notNull().default("draft"),
+    lastAnalyzedAt: integer("last_analyzed_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    skillIdx: index("skill_versions_skill_idx").on(table.skillId),
+    uniqueSkillVersion: uniqueIndex("skill_versions_unique").on(table.skillId, table.version),
+  }),
+);
+
+export const skillRuns = sqliteTable(
+  "skill_runs",
+  {
+    id: text("id").primaryKey(),
+    skillId: text("skill_id")
+      .notNull()
+      .references(() => skills.id, { onDelete: "cascade" }),
+    version: integer("version").notNull(),
+    runId: text("run_id").notNull(),
+    totalCount: integer("total_count").notNull(),
+    successCount: integer("success_count").notNull(),
+    failureCount: integer("failure_count").notNull(),
+    newEventCount: integer("new_event_count").notNull().default(0),
+    newSuccessCount: integer("new_success_count").notNull().default(0),
+    newFailureCount: integer("new_failure_count").notNull().default(0),
+    lastEventAt: integer("last_event_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    skillIdx: index("skill_runs_skill_idx").on(table.skillId),
+    runIdx: index("skill_runs_run_idx").on(table.runId),
+  }),
+);

--- a/servers/api/src/skills/skills.service.ts
+++ b/servers/api/src/skills/skills.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from "@nestjs/common";
 
 import {
-  listSkills,
-  setSkillEnabled,
   SkillNotFoundError,
   type SkillRecord,
+  type SkillsRepository,
+  createInMemorySkillsRepository,
+  createSqliteSkillsRepository,
 } from "../../../../packages/skills/storage";
 import {
   HeuristicSkillSummariser,
   runDefaultSkillAnalysis,
 } from "../../../../packages/skills/pipeline";
+import { DatabaseService } from "../database/database.service";
 
 export interface SkillsAnalysisResult {
   analyzed: number;
@@ -18,17 +20,25 @@ export interface SkillsAnalysisResult {
 
 @Injectable()
 export class SkillsService {
+  private readonly repository: SkillsRepository;
+
+  constructor(private readonly database: DatabaseService) {
+    this.repository = database.db
+      ? createSqliteSkillsRepository(database.db)
+      : createInMemorySkillsRepository();
+  }
+
   async list(): Promise<SkillRecord[]> {
-    return listSkills();
+    return this.repository.list();
   }
 
   async listCandidates(): Promise<SkillRecord[]> {
-    const skills = await listSkills();
+    const skills = await this.repository.list();
     return skills.filter((skill) => skill.review_status !== "approved");
   }
 
   async setEnabled(id: string, enabled: boolean): Promise<SkillRecord> {
-    return setSkillEnabled(id, enabled);
+    return this.repository.setEnabled(id, enabled);
   }
 
   isNotFound(error: unknown): error is SkillNotFoundError {
@@ -37,7 +47,10 @@ export class SkillsService {
 
   async analyze(): Promise<SkillsAnalysisResult> {
     const summariser = new HeuristicSkillSummariser();
-    const result = await runDefaultSkillAnalysis(summariser);
+    const result = await runDefaultSkillAnalysis(summariser, {
+      skillsRepository: this.repository,
+      db: this.database.db ?? undefined,
+    });
     return { analyzed: result.analyzedEvents, candidates: result.candidates };
   }
 }

--- a/tests/api/skillsAnalyze.test.ts
+++ b/tests/api/skillsAnalyze.test.ts
@@ -8,6 +8,7 @@ import type { INestApplication } from "@nestjs/common";
 
 import { AppModule } from "../../servers/api/src/app.module";
 import { resetSkillsStore } from "../../packages/skills/storage";
+import { DatabaseService } from "../../servers/api/src/database/database.service";
 import { SkillsController } from "../../servers/api/src/skills/skills.controller";
 
 describe("skills API", () => {
@@ -25,8 +26,6 @@ describe("skills API", () => {
     process.env.AOS_DB_PATH = dbPath;
     process.env.AOS_EPISODES_DIR = episodesDir;
     process.env.AOS_API_KEY = "";
-
-    await resetSkillsStore({ skills: [], persist: true });
 
     const events = [
       {
@@ -63,6 +62,10 @@ describe("skills API", () => {
     await app.init();
 
     const skillsController = app.get(SkillsController);
+    const database = app.get(DatabaseService);
+    if (database.db) {
+      await resetSkillsStore(database.db, { skills: [] });
+    }
 
     try {
       const analyzeRes = await skillsController.analyzeSkills();
@@ -79,7 +82,9 @@ describe("skills API", () => {
     } finally {
       await app.close();
       await rm(tmpDir, { recursive: true, force: true });
-      await resetSkillsStore();
+      if (database.db) {
+        await resetSkillsStore(database.db, { skills: [] });
+      }
       process.env = { ...originalEnv };
     }
   });

--- a/tests/skillsPipeline.test.ts
+++ b/tests/skillsPipeline.test.ts
@@ -59,7 +59,7 @@ describe("SkillAnalysisPipeline", () => {
 
   it("aggregates tool events and generates candidate skills", async () => {
     const eventsRepo = new InMemoryEventsRepository(baseEvents);
-    const skillsRepo = new InMemorySkillsRepository();
+    const skillsRepo = new InMemorySkillsRepository([]);
     const summariser = new HeuristicSkillSummariser();
     const pipeline = new SkillAnalysisPipeline(eventsRepo, skillsRepo, summariser, {
       minSamplesForReview: 2,


### PR DESCRIPTION
## Summary
- add new Drizzle schemas for skills, skill_versions, and skill_runs and bootstrap them in the database service
- refactor the shared skills repository, analysis pipeline, and API service to use the sqlite-backed store instead of runtime JSON files
- update vitest suites to cover the database-backed workflow

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7ceaca84832ba9dfc39a87411bf9