### PR TITLE
feat: require approval for sensitive tool actions

### DIFF
--- a/adapters/core.ts
+++ b/adapters/core.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import OpenAI, {
   APIConnectionError,
@@ -158,6 +159,139 @@ interface OpenAiClientLike {
 
 type OpenAiFactory = (config: LLMConfig, timeoutMs: number) => OpenAiClientLike;
 
+export type ApprovalDecision = "approve" | "reject";
+
+export interface SensitiveToolApprovalRequest {
+  runId: string;
+  requestId: string;
+  call: ToolCall;
+  spanId?: string;
+}
+
+export interface SensitiveToolApprovalAdapter {
+  awaitApproval(request: SensitiveToolApprovalRequest): Promise<ApprovalDecision>;
+}
+
+const SENSITIVE_TOOL_NAMES = new Set([
+  "file.write",
+  "http.post",
+  "http.put",
+  "http.patch",
+  "http.delete",
+]);
+
+const SENSITIVE_TOOL_KEYWORDS = new Set([
+  "write",
+  "delete",
+  "update",
+  "publish",
+  "send",
+  "post",
+  "put",
+  "patch",
+  "exec",
+]);
+
+function normaliseToolName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function isSensitiveTool(name: string): boolean {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const normalised = normaliseToolName(trimmed);
+  if (SENSITIVE_TOOL_NAMES.has(normalised)) {
+    return true;
+  }
+  const segments = normalised.split(".");
+  const last = segments[segments.length - 1];
+  if (SENSITIVE_TOOL_KEYWORDS.has(last)) {
+    return true;
+  }
+  return false;
+}
+
+async function requestSensitiveToolApproval(
+  call: ToolCall,
+  ctx: ToolContext,
+  options: DefaultToolInvokerOptions,
+): Promise<ApprovalDecision | null> {
+  if (!options.eventBus) {
+    return options.approvalAdapter ? "approve" : null;
+  }
+  const traceId = ctx.trace_id;
+  if (!traceId) {
+    return options.approvalAdapter ? "approve" : null;
+  }
+
+  const requestId = randomUUID();
+  const message = `检测到敏感工具 ${call.name}，请确认是否继续执行。`;
+  await options.eventBus.publish({
+    id: requestId,
+    ts: new Date().toISOString(),
+    type: "user.confirm.request",
+    version: 1,
+    trace_id: traceId,
+    span_id: ctx.span_id,
+    data: {
+      request_id: requestId,
+      tool: call.name,
+      args: call.args,
+      message,
+      level: "warn",
+    },
+  });
+
+  if (!options.approvalAdapter) {
+    return "approve";
+  }
+
+  try {
+    const decision = await options.approvalAdapter.awaitApproval({
+      runId: traceId,
+      requestId,
+      call,
+      spanId: ctx.span_id,
+    });
+    if (decision === "reject") {
+      await options.eventBus.publish({
+        id: randomUUID(),
+        ts: new Date().toISOString(),
+        type: "guardian.alert",
+        version: 1,
+        trace_id: traceId,
+        span_id: ctx.span_id,
+        data: {
+          request_id: requestId,
+          tool: call.name,
+          reason: "用户拒绝执行敏感操作",
+        },
+        level: "error",
+      });
+    }
+    return decision;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "approval rejected";
+    await options.eventBus.publish({
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: "guardian.alert",
+      version: 1,
+      trace_id: traceId,
+      span_id: ctx.span_id,
+      data: {
+        request_id: requestId,
+        tool: call.name,
+        reason,
+      },
+      level: "error",
+    });
+    return "reject";
+  }
+}
+
 const defaultOpenAiFactory: OpenAiFactory = (config, timeoutMs) =>
   new OpenAI({
     apiKey: config.apiKey,
@@ -311,6 +445,7 @@ async function handleChat(args: any): Promise<ToolResult> {
 export interface DefaultToolInvokerOptions extends CreateMcpRegistryOptions {
   enableRemoteMcp?: boolean;
   mcpClientPromise?: Promise<MCPClient | null>;
+  approvalAdapter?: SensitiveToolApprovalAdapter;
 }
 
 export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}): ToolInvoker {
@@ -329,6 +464,19 @@ export function createDefaultToolInvoker(options: DefaultToolInvokerOptions = {}
     : Promise.resolve(null);
 
   return async (call: ToolCall, ctx: ToolContext) => {
+    if (isSensitiveTool(call.name)) {
+      const decision = await requestSensitiveToolApproval(call, ctx, options);
+      if (decision === "reject") {
+        const denialMessage = "用户拒绝执行敏感操作";
+        return {
+          ok: false,
+          code: "tool.denied",
+          message: denialMessage,
+          retryable: false,
+        } satisfies ToolError;
+      }
+    }
+
     const localResult = await mcpRegistry.invoke(call, ctx);
     if (localResult !== null) {
       return localResult;

--- a/pages/api/run.ts
+++ b/pages/api/run.ts
@@ -33,6 +33,15 @@ interface RunEventsResponse {
   }>;
 }
 
+export interface RunApprovalRequest {
+  requestId: string;
+  decision: "approve" | "reject";
+}
+
+export interface RunApprovalResponse {
+  decision: "approve" | "reject";
+}
+
 export interface RunApiResponse {
   trace_id: string;
   status?: string;
@@ -218,6 +227,33 @@ export async function getLocalRunStream(runId: string) {
   const stream = runs.stream(runId);
   const events = await runs.getRunEvents(runId);
   return { stream, events };
+}
+
+export async function submitRemoteApproval(
+  apiBase: string,
+  runId: string,
+  payload: RunApprovalRequest,
+  headers: Record<string, string>,
+): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${apiBase}/runs/${encodeURIComponent(runId)}/approval`, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await parseJsonSafe<any>(response);
+  return { status: response.status, body };
+}
+
+export async function submitLocalApproval(
+  runId: string,
+  payload: RunApprovalRequest,
+): Promise<RunApprovalResponse> {
+  const app = await getLocalApp();
+  const runs = app.get(RunsService);
+  return runs.decideApproval(runId, payload.requestId, payload.decision);
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {

--- a/pages/api/runs/[runId]/approval.ts
+++ b/pages/api/runs/[runId]/approval.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  buildAuthHeaders,
+  resolveApiBaseUrl,
+  submitLocalApproval,
+  submitRemoteApproval,
+  type RunApprovalRequest,
+} from "../../run";
+
+function normaliseDecision(value: unknown): "approve" | "reject" | null {
+  if (value === "approve" || value === "reject") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const lower = value.toLowerCase();
+    if (lower === "approve" || lower === "approved") {
+      return "approve";
+    }
+    if (lower === "reject" || lower === "denied" || lower === "deny") {
+      return "reject";
+    }
+  }
+  return null;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const { runId } = req.query;
+
+  if (typeof runId !== "string" || !runId) {
+    res.status(400).json({ error: { message: "runId is required" } });
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({ error: { message: "Method Not Allowed" } });
+    return;
+  }
+
+  const requestId =
+    typeof req.body?.requestId === "string"
+      ? req.body.requestId
+      : typeof req.body?.request_id === "string"
+        ? req.body.request_id
+        : typeof req.body?.id === "string"
+          ? req.body.id
+          : null;
+  const decision = normaliseDecision(req.body?.decision);
+
+  if (!requestId) {
+    res.status(400).json({ error: { message: "requestId is required" } });
+    return;
+  }
+
+  if (!decision) {
+    res.status(400).json({ error: { message: "decision must be approve or reject" } });
+    return;
+  }
+
+  const payload: RunApprovalRequest = { requestId, decision };
+  const apiBase = resolveApiBaseUrl();
+  const headers = buildAuthHeaders();
+
+  try {
+    if (apiBase) {
+      const { status, body } = await submitRemoteApproval(apiBase, runId, payload, headers);
+      if (status >= 200 && status < 300) {
+        res.status(status).json(body ?? { decision });
+        return;
+      }
+      res.status(status).json(
+        body ?? { error: { message: `approval request failed with status ${status}` } },
+      );
+      return;
+    }
+
+    const result = await submitLocalApproval(runId, payload);
+    res.status(200).json(result);
+  } catch (error: any) {
+    const message = error?.message ?? "failed to submit approval";
+    res.status(500).json({ error: { message } });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -59,6 +59,7 @@ interface ConfirmationRequestState {
   message: string;
   context?: any;
   level?: string;
+  tool?: string;
 }
 
 type RunStatus = "idle" | "running" | "awaiting-confirmation" | "completed" | "error";
@@ -475,12 +476,19 @@ const HomePage: NextPage = () => {
             : typeof event.data?.message === "string"
               ? event.data.message
               : t("confirmation.defaultPrompt");
+        const requestId =
+          typeof event.data?.request_id === "string"
+            ? event.data.request_id
+            : typeof event.id === "string"
+              ? event.id
+              : generateLocalId();
         setConfirmationRequest({
-          id: event.id,
+          id: requestId,
           ts: event.ts ?? new Date().toISOString(),
           message: prompt,
           context: event.data,
           level: event.data?.level,
+          tool: typeof event.data?.tool === "string" ? event.data.tool : undefined,
         });
         setRunStatus("awaiting-confirmation");
         setChatHistory((history) => [
@@ -762,31 +770,80 @@ const HomePage: NextPage = () => {
 
   const handleDecision = useCallback(
     (decision: "approve" | "reject") => {
-      if (!confirmationRequest) return;
-      setConfirmationRequest(null);
-      const now = new Date().toISOString();
-      setChatHistory((history) => [
-        ...history,
-        {
-          id: generateLocalId(),
-          role: "system",
-          content:
-            decision === "approve"
-              ? t("confirmation.approved", { message: confirmationRequest.message })
-              : t("confirmation.denied", { message: confirmationRequest.message }),
-          ts: now,
-          status: "done",
-        },
-      ]);
-      if (decision === "approve") {
-        setRunStatus("running");
-      } else {
-        setRunStatus("error");
-        setRunError(t("confirmation.deniedStatus"));
-        closeStream();
+      if (!confirmationRequest || !traceId) {
+        return;
       }
+      const pendingRequest = confirmationRequest;
+      setConfirmationRequest(null);
+      const requestBody = {
+        requestId: pendingRequest.id,
+        decision,
+      };
+
+      void (async () => {
+        try {
+          const response = await fetch(`/api/runs/${encodeURIComponent(traceId)}/approval`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody),
+          });
+
+          if (!response.ok) {
+            let errorMessage = t("chat.runFailure");
+            try {
+              const payload = await response.json();
+              if (typeof payload?.error?.message === "string") {
+                errorMessage = payload.error.message;
+              }
+            } catch {
+              // ignore json parse errors
+            }
+            throw new Error(errorMessage);
+          }
+
+          const now = new Date().toISOString();
+          setChatHistory((history) => [
+            ...history,
+            {
+              id: generateLocalId(),
+              role: "system",
+              content:
+                decision === "approve"
+                  ? t("confirmation.approved", { message: pendingRequest.message })
+                  : t("confirmation.denied", { message: pendingRequest.message }),
+              ts: now,
+              status: "done",
+            },
+          ]);
+
+          if (decision === "approve") {
+            setRunStatus("running");
+          } else {
+            setRunStatus("error");
+            setRunError(t("confirmation.deniedStatus"));
+            closeStream();
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error && error.message ? error.message : t("chat.runFailure");
+          setRunStatus("error");
+          setRunError(message);
+          setChatHistory((history) => [
+            ...history,
+            {
+              id: generateLocalId(),
+              role: "system",
+              content: t("chat.errorPrefix", { message }),
+              ts: new Date().toISOString(),
+              status: "error",
+              error: message,
+            },
+          ]);
+          closeStream();
+        }
+      })();
     },
-    [closeStream, confirmationRequest, t],
+    [closeStream, confirmationRequest, t, traceId],
   );
 
   const tabItems = useMemo(

--- a/servers/api/src/runs/run-kernel.factory.ts
+++ b/servers/api/src/runs/run-kernel.factory.ts
@@ -1,5 +1,9 @@
 import { Injectable } from "@nestjs/common";
-import { createChatKernel, createDefaultToolInvoker } from "../../../../adapters/core";
+import {
+  createChatKernel,
+  createDefaultToolInvoker,
+  type SensitiveToolApprovalAdapter,
+} from "../../../../adapters/core";
 import type { AgentKernel } from "../../../../core/agent";
 import type { ChatMessage } from "../../../../types/chat";
 import type { EventBus } from "../../../../runtime/events";
@@ -9,6 +13,7 @@ export interface CreateKernelOptions {
   message: string;
   history: ChatMessage[];
   eventBus: EventBus;
+  approvalAdapter?: SensitiveToolApprovalAdapter;
 }
 
 export interface RunKernelFactory {
@@ -20,7 +25,10 @@ export const RUN_KERNEL_FACTORY = Symbol("RUN_KERNEL_FACTORY");
 @Injectable()
 export class DefaultRunKernelFactory implements RunKernelFactory {
   async createKernel(options: CreateKernelOptions): Promise<AgentKernel> {
-    const toolInvoker = createDefaultToolInvoker({ eventBus: options.eventBus });
+    const toolInvoker = createDefaultToolInvoker({
+      eventBus: options.eventBus,
+      approvalAdapter: options.approvalAdapter,
+    });
     return createChatKernel({
       message: options.message,
       traceId: options.traceId,

--- a/servers/api/src/runs/runs.service.ts
+++ b/servers/api/src/runs/runs.service.ts
@@ -8,6 +8,7 @@ import {
   type EmitSpanOptions,
   type RunLoopResult,
 } from "../../../../core/agent";
+import type { ApprovalDecision, SensitiveToolApprovalRequest } from "../../../../adapters/core";
 import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../../../runtime/events";
 import { EpisodeLogger } from "../../../../runtime/episode";
 import type { ChatMessage } from "../../../../types/chat";
@@ -22,7 +23,13 @@ type RunRowType = typeof runs.$inferSelect;
 type RunPatch = Partial<Omit<RunRowType, "id">>;
 type RunEventInsertRow = typeof runEvents.$inferInsert;
 
-export type RunStatus = "running" | "completed" | "awaiting_input" | "no_plan" | "failed";
+export type RunStatus =
+  | "running"
+  | "completed"
+  | "awaiting_input"
+  | "awaiting_confirmation"
+  | "no_plan"
+  | "failed";
 
 export interface RunSummary {
   id: string;
@@ -61,6 +68,12 @@ interface StreamEvent {
   data: any;
 }
 
+interface PendingApprovalEntry {
+  request: SensitiveToolApprovalRequest;
+  resolve: (decision: ApprovalDecision) => void;
+  reject: (error: unknown) => void;
+}
+
 function normaliseMessage(raw: unknown): string {
   if (typeof raw === "string") {
     return raw;
@@ -93,6 +106,7 @@ function normaliseHistory(raw: unknown): ChatMessage[] {
 export class RunsService {
   private readonly logger = new Logger(RunsService.name);
   private readonly streams = new Map<string, ReplaySubject<StreamEvent>>();
+  private readonly pendingApprovals = new Map<string, PendingApprovalEntry>();
 
   constructor(
     @Inject(DatabaseService) private readonly database: DatabaseService,
@@ -181,6 +195,71 @@ export class RunsService {
     return subject.asObservable();
   }
 
+  async decideApproval(
+    runId: string,
+    requestId: string,
+    decision: ApprovalDecision,
+  ): Promise<{ decision: ApprovalDecision }> {
+    const key = this.buildApprovalKey(runId, requestId);
+    const entry = this.pendingApprovals.get(key);
+    if (!entry) {
+      throw new NotFoundException(`approval ${requestId} for run ${runId} not found`);
+    }
+    this.pendingApprovals.delete(key);
+
+    if (decision === "approve") {
+      await this.setRunStatus(runId, "running");
+    }
+
+    entry.resolve(decision);
+    return { decision };
+  }
+
+  private buildApprovalKey(runId: string, requestId: string): string {
+    return `${runId}:${requestId}`;
+  }
+
+  private async setRunStatus(runId: string, status: RunStatus): Promise<void> {
+    const patch: RunPatch = { status, updatedAt: new Date() };
+    if (this.database.isMemoryMode()) {
+      this.database.updateRun(runId, patch);
+    } else {
+      await this.database
+        .db!.update(runs)
+        .set(patch)
+        .where(eq(runs.id, runId))
+        .run();
+    }
+  }
+
+  private async waitForApproval(request: SensitiveToolApprovalRequest): Promise<ApprovalDecision> {
+    const key = this.buildApprovalKey(request.runId, request.requestId);
+    if (this.pendingApprovals.has(key)) {
+      return Promise.reject(
+        new Error(`duplicate approval request ${request.requestId}`),
+      );
+    }
+
+    await this.setRunStatus(request.runId, "awaiting_confirmation");
+
+    return new Promise<ApprovalDecision>((resolve, reject) => {
+      this.pendingApprovals.set(key, { request, resolve, reject });
+    });
+  }
+
+  private resolvePendingApprovals(runId: string, error?: unknown): void {
+    for (const [key, entry] of this.pendingApprovals.entries()) {
+      if (entry.request.runId === runId) {
+        this.pendingApprovals.delete(key);
+        if (error) {
+          entry.reject(error);
+        } else {
+          entry.resolve("reject");
+        }
+      }
+    }
+  }
+
   private async executeRun(runId: string, request: StartRunRequest): Promise<void> {
     const eventBus = new EventBus();
     const logger = new EpisodeLogger({ traceId: runId, dir: this.config.episodesDir });
@@ -196,11 +275,17 @@ export class RunsService {
 
     const history = request.history ?? [];
 
+    const approvalAdapter = {
+      awaitApproval: (request: SensitiveToolApprovalRequest) =>
+        this.waitForApproval(request),
+    };
+
     const kernel = await this.kernelFactory.createKernel({
       traceId: runId,
       message: request.message,
       history,
       eventBus,
+      approvalAdapter,
     });
 
     const emit = async (event: CoreEvent, span?: EmitSpanOptions): Promise<void> => {
@@ -256,6 +341,7 @@ export class RunsService {
   }
 
   private async handleRunCompletion(runId: string, result: RunLoopResult): Promise<void> {
+    this.resolvePendingApprovals(runId);
     const status = this.mapRunStatus(result.reason);
     const finishedAt = new Date();
     const finalJson = result.final != null ? JSON.stringify(result.final) : null;
@@ -287,6 +373,7 @@ export class RunsService {
   }
 
   private async handleRunFailure(runId: string, error: unknown): Promise<void> {
+    this.resolvePendingApprovals(runId, error);
     const finishedAt = new Date();
     const message = error instanceof Error ? error.message : "unknown error";
     const failurePatch: RunPatch = {

--- a/tests/api/run.e2e.test.ts
+++ b/tests/api/run.e2e.test.ts
@@ -8,6 +8,7 @@ import type { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 
 import { AppModule } from "../../servers/api/src/app.module";
+import { createDefaultToolInvoker } from "../../adapters/core";
 import {
   RUN_KERNEL_FACTORY,
   type CreateKernelOptions,
@@ -15,7 +16,14 @@ import {
 } from "../../servers/api/src/runs/run-kernel.factory";
 import { AgentController } from "../../servers/api/src/agent/agent.controller";
 import { RunsService } from "../../servers/api/src/runs/runs.service";
-import type { ActionOutcome, AgentKernel, Plan, PlanStep, ReviewResult } from "../../core/agent";
+import type {
+  ActionOutcome,
+  AgentKernel,
+  Plan,
+  PlanStep,
+  ReviewResult,
+  ToolInvoker,
+} from "../../core/agent";
 
 class StubKernel implements AgentKernel {
   private planned = false;
@@ -62,6 +70,81 @@ class StubKernelFactory implements RunKernelFactory {
   async createKernel(options: CreateKernelOptions): Promise<AgentKernel> {
     return new StubKernel(options.message);
   }
+}
+
+class SensitiveKernel implements AgentKernel {
+  private planned = false;
+
+  constructor(private readonly toolInvoker: ToolInvoker, private readonly traceId: string) {}
+
+  async perceive(): Promise<void> {}
+
+  async plan(): Promise<Plan> {
+    if (this.planned) {
+      return { revision: 2, steps: [] } satisfies Plan;
+    }
+    this.planned = true;
+    const step: PlanStep = {
+      id: `write-step-${randomUUID()}`,
+      op: "file.write",
+      args: { path: "output.txt", content: "hello" },
+      description: "write file",
+    };
+    return {
+      revision: 1,
+      reason: "sensitive",
+      steps: [step],
+    } satisfies Plan;
+  }
+
+  async act(step: PlanStep): Promise<ActionOutcome> {
+    const result = await this.toolInvoker({ name: step.op, args: step.args }, {
+      trace_id: this.traceId,
+      span_id: step.id,
+    });
+    return { step, result } satisfies ActionOutcome;
+  }
+
+  async review(actions: ActionOutcome[]): Promise<ReviewResult> {
+    const passed = actions.every((action) => action.result.ok);
+    return { score: passed ? 1 : 0, passed } satisfies ReviewResult;
+  }
+
+  async renderFinal(actions: ActionOutcome[]): Promise<any> {
+    return {
+      actions: actions.map((action) => ({
+        id: action.step.id,
+        ok: action.result.ok,
+      })),
+    };
+  }
+}
+
+class SensitiveKernelFactory implements RunKernelFactory {
+  async createKernel(options: CreateKernelOptions): Promise<AgentKernel> {
+    const toolInvoker = createDefaultToolInvoker({
+      eventBus: options.eventBus,
+      approvalAdapter: options.approvalAdapter,
+    });
+    return new SensitiveKernel(toolInvoker, options.traceId);
+  }
+}
+
+async function waitForRunStatus(
+  service: RunsService,
+  runId: string,
+  expected: string,
+  timeoutMs = 5000,
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const summary = await service.getRun(runId);
+    if (summary.status === expected) {
+      return summary;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${runId} did not reach status ${expected}`);
 }
 
 describe("API run endpoints", () => {
@@ -134,4 +217,65 @@ describe("API run endpoints", () => {
       await rm(tmpDir, { recursive: true, force: true });
     }
   }, 10000);
+
+  it("requires approval for sensitive tools", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "aos-approval-"));
+    process.env.AOS_API_KEY = "test-key";
+    process.env.AOS_DB_PATH = join(tmpDir, "test.sqlite");
+    process.env.AOS_EPISODES_DIR = join(tmpDir, "episodes");
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(RUN_KERNEL_FACTORY)
+      .useClass(SensitiveKernelFactory)
+      .compile();
+
+    const app: INestApplication = moduleRef.createNestApplication();
+    app.setGlobalPrefix("api");
+    await app.init();
+
+    const agentController = app.get(AgentController);
+    const runsService = app.get(RunsService);
+
+    try {
+      const { runId: approveRunId } = await agentController.startRun({ message: "approve" });
+      const approveId = approveRunId as string;
+      await waitForRunStatus(runsService, approveId, "awaiting_confirmation");
+
+      const approvalEvents = await runsService.getRunEvents(approveId);
+      const approvalRequest = approvalEvents.find((evt) => evt.type === "user.confirm.request");
+      expect(approvalRequest).toBeDefined();
+      const approvalRequestId =
+        (approvalRequest?.data as any)?.request_id ?? approvalRequest?.id ?? "";
+      expect(typeof approvalRequestId).toBe("string");
+
+      await runsService.decideApproval(approveId, approvalRequestId, "approve");
+      const approvedSummary = await waitForRunStatus(runsService, approveId, "completed");
+      expect(approvedSummary.status).toBe("completed");
+
+      const approvedEvents = await runsService.getRunEvents(approveId);
+      const hasGuardianAlert = approvedEvents.some((evt) => evt.type === "guardian.alert");
+      expect(hasGuardianAlert).toBe(false);
+
+      const { runId: rejectRunId } = await agentController.startRun({ message: "reject" });
+      const rejectId = rejectRunId as string;
+      await waitForRunStatus(runsService, rejectId, "awaiting_confirmation");
+      const rejectEvents = await runsService.getRunEvents(rejectId);
+      const rejectRequest = rejectEvents.find((evt) => evt.type === "user.confirm.request");
+      expect(rejectRequest).toBeDefined();
+      const rejectRequestId =
+        (rejectRequest?.data as any)?.request_id ?? rejectRequest?.id ?? "";
+      expect(typeof rejectRequestId).toBe("string");
+
+      await runsService.decideApproval(rejectId, rejectRequestId, "reject");
+      const failedSummary = await waitForRunStatus(runsService, rejectId, "failed");
+      expect(failedSummary.status).toBe("failed");
+
+      const eventsAfterReject = await runsService.getRunEvents(rejectId);
+      const guardianAlert = eventsAfterReject.find((evt) => evt.type === "guardian.alert");
+      expect(guardianAlert).toBeDefined();
+    } finally {
+      await app.close();
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 20000);
 });

--- a/tests/ui/chat-stream.pw.ts
+++ b/tests/ui/chat-stream.pw.ts
@@ -10,6 +10,17 @@ test.describe("Chat stream interactions", () => {
       });
     });
 
+    const approvalPayloads: any[] = [];
+    await page.route("**/api/runs/trace-sse/approval", async (route: any) => {
+      const body = JSON.parse(route.request().postData() ?? "{}");
+      approvalPayloads.push(body);
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: body.decision ?? "approve" }),
+      });
+    });
+
     await page.addInitScript(() => {
       const control: any = {
         instance: null,
@@ -147,8 +158,14 @@ test.describe("Chat stream interactions", () => {
 
     const confirmationModal = page.getByTestId("confirmation-modal");
     await expect(confirmationModal).toBeVisible();
-    await confirmationModal.getByRole("button", { name: /允许|Allow/i }).click();
+    await Promise.all([
+      page.waitForRequest("**/api/runs/trace-sse/approval"),
+      confirmationModal.getByRole("button", { name: /允许|Allow/i }).click(),
+    ]);
     await expect(confirmationModal).toBeHidden();
+
+    expect(approvalPayloads).toHaveLength(1);
+    expect(approvalPayloads[0]).toMatchObject({ requestId: "evt-confirm", decision: "approve" });
 
     await page.evaluate(
       ([timestamp]: [string]) => {
@@ -166,5 +183,98 @@ test.describe("Chat stream interactions", () => {
     await expect(page.getByTestId("run-stats-panel")).toContainText(/Ready|就绪/);
     await expect(page.getByTestId("run-stats-panel")).toContainText(/345/);
     await expect(page.getByTestId("raw-response-panel")).toContainText("agent.final");
+  });
+
+  test("handles rejection of confirmation requests", async ({ page }) => {
+    await page.route("**/api/run", async (route: any) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ trace_id: "trace-reject", events: [] }),
+      });
+    });
+
+    const rejectPayloads: any[] = [];
+    await page.route("**/api/runs/trace-reject/approval", async (route: any) => {
+      const body = JSON.parse(route.request().postData() ?? "{}");
+      rejectPayloads.push(body);
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "reject" }),
+      });
+    });
+
+    await page.addInitScript(() => {
+      const control: any = {
+        instance: null,
+        connect(instance: any) {
+          this.instance = instance;
+          setTimeout(() => {
+            instance.onopen?.(new MessageEvent("open"));
+          }, 0);
+        },
+        emit(event: any) {
+          this.instance?.onmessage?.(new MessageEvent("message", { data: JSON.stringify(event) }));
+        },
+      };
+      (window as any).__AOS_STREAM_CONTROL__ = control;
+      class MockEventSource {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSED = 2;
+        readyState = MockEventSource.OPEN;
+        onopen: ((event: MessageEvent) => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onerror: ((event: Event) => void) | null = null;
+        constructor(public url: string) {
+          control.connect(this);
+        }
+        addEventListener(type: string, listener: any) {
+          if (type === "message") this.onmessage = listener;
+          if (type === "error") this.onerror = listener;
+          if (type === "open") this.onopen = listener;
+        }
+        removeEventListener(type: string) {}
+        close() {
+          this.readyState = MockEventSource.CLOSED;
+        }
+      }
+      (window as any).EventSource = MockEventSource;
+    });
+
+    await page.goto("/");
+    await page.getByLabel(/聊天输入|Chat input/i).fill("reject case");
+
+    await Promise.all([
+      page.waitForRequest("**/api/run"),
+      page.getByRole("button", { name: /run|运行/i }).click(),
+    ]);
+
+    await page.evaluate(() => {
+      const control = (window as any).__AOS_STREAM_CONTROL__;
+      control.emit({
+        id: "evt-reject",
+        ts: new Date().toISOString(),
+        type: "user.confirm.request",
+        data: { prompt: "Reject?", request_id: "evt-reject" },
+      });
+    });
+
+    const confirmationModal = page.getByTestId("confirmation-modal");
+    await expect(confirmationModal).toBeVisible();
+    await Promise.all([
+      page.waitForRequest("**/api/runs/trace-reject/approval"),
+      confirmationModal.getByRole("button", { name: /拒绝|Reject/i }).click(),
+    ]);
+    await expect(confirmationModal).toBeHidden();
+
+    expect(rejectPayloads).toHaveLength(1);
+    expect(rejectPayloads[0]).toMatchObject({ requestId: "evt-reject", decision: "reject" });
+
+    await expect(page.getByTestId("conversation-panel")).toContainText(/用户已拒绝|denied/i, {
+      timeout: 5000,
+    });
+    await expect(page.getByTestId("run-stats-panel")).toContainText(/被用户取消|cancelled/i);
   });
 });


### PR DESCRIPTION
## Summary
- 在默认工具调用器中识别文件写入等敏感工具，触发 `user.confirm.request` 事件并在拒绝时写入 `guardian.alert`
- 为 RunsService 引入审批状态管理与接口支持，在运行工厂传递审批适配器
- 扩展前端与 API 路由以提交审批决策，并补充后端与 UI 端到端测试验证审批流程

## Testing
- pnpm test
- pnpm test:ui --reporter=line *(fails: 未预装 Playwright 浏览器，需运行 `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7ce86bf8832bbe147d65042b446c