### PR TITLE
feat: enforce run budgets and guardian alerts

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -71,6 +71,9 @@ function logEvent(event: CoreEvent) {
     case "log":
       console.log(`[${time}] ${event.level}`, event.message);
       break;
+    case "terminated":
+      console.log(`[${time}] terminated/${event.reason}`, event.context);
+      break;
   }
 }
 

--- a/core/agent.ts
+++ b/core/agent.ts
@@ -83,6 +83,7 @@ export type CoreEvent =
   | { type: "ask"; question: string; origin_step?: string }
   | { type: "score"; value: number; passed: boolean; notes?: string[] }
   | { type: "final"; outputs: any; reason?: string }
+  | { type: "terminated"; reason: TerminationReason; context: RunTerminationContext }
   | { type: "log"; level: LogLevel; message: string; detail?: any }
   | {
       type: "chat.msg";
@@ -117,18 +118,41 @@ export interface AgentKernel {
 export interface RunLoopOptions {
   maxIterations?: number;
   context?: AgentContext;
+  budget?: RunLoopBudget;
 }
 
 export interface RunLoopResult {
   actions: ActionOutcome[];
   final?: any;
-  reason: "completed" | "no-plan" | "ask" | "max-iterations" | "non-retryable-error";
+  reason: "completed" | "no-plan" | "ask" | "max-iterations" | "non-retryable-error" | "terminated";
   review?: ReviewResult;
+  metrics: RunLoopMetrics;
+  termination?: RunTerminationContext;
 }
 
 const ensurePromise = async <T>(value: T | Promise<T>): Promise<T> => value;
 
 export type EmitSpanOptions = EventMetadata;
+
+export type TerminationReason = "step-limit" | "cost-limit" | "latency-limit";
+
+export interface RunLoopBudget {
+  maxSteps?: number;
+  maxCost?: number;
+  maxLatencyMs?: number;
+}
+
+export interface RunLoopMetrics {
+  stepCount: number;
+  totalCost: number;
+  totalLatencyMs: number;
+}
+
+export interface RunTerminationContext {
+  reason: TerminationReason;
+  limit: number;
+  metrics: RunLoopMetrics;
+}
 
 export async function runLoop(
   kernel: AgentKernel,
@@ -139,6 +163,41 @@ export async function runLoop(
   const actions: ActionOutcome[] = [];
   const context = options.context ?? { traceId: randomUUID() };
   const traceSpanId = context.traceId;
+  const budget = options.budget;
+  const metrics: RunLoopMetrics = { stepCount: 0, totalCost: 0, totalLatencyMs: 0 };
+
+  const recordOutcome = (outcome: ActionOutcome) => {
+    metrics.stepCount += 1;
+    if (outcome.result && outcome.result.ok) {
+      const { cost, latency_ms } = outcome.result;
+      if (typeof cost === "number" && Number.isFinite(cost)) {
+        metrics.totalCost += cost;
+      }
+      if (typeof latency_ms === "number" && Number.isFinite(latency_ms)) {
+        metrics.totalLatencyMs += latency_ms;
+      }
+    }
+  };
+
+  const checkBudgetLimits = (): RunTerminationContext | undefined => {
+    if (!budget) {
+      return undefined;
+    }
+    if (typeof budget.maxSteps === "number" && budget.maxSteps >= 0 && metrics.stepCount >= budget.maxSteps) {
+      return { reason: "step-limit", limit: budget.maxSteps, metrics: { ...metrics } };
+    }
+    if (typeof budget.maxCost === "number" && Number.isFinite(budget.maxCost) && metrics.totalCost >= budget.maxCost) {
+      return { reason: "cost-limit", limit: budget.maxCost, metrics: { ...metrics } };
+    }
+    if (
+      typeof budget.maxLatencyMs === "number" &&
+      Number.isFinite(budget.maxLatencyMs) &&
+      metrics.totalLatencyMs >= budget.maxLatencyMs
+    ) {
+      return { reason: "latency-limit", limit: budget.maxLatencyMs, metrics: { ...metrics } };
+    }
+    return undefined;
+  };
 
   await ensurePromise(kernel.perceive(context));
   await ensurePromise(
@@ -185,6 +244,7 @@ export async function runLoop(
       };
       const outcome = await kernel.act(fallbackStep);
       actions.push(outcome);
+      recordOutcome(outcome);
       await ensurePromise(
         emit(
           {
@@ -198,11 +258,21 @@ export async function runLoop(
           { spanId: fallbackStep.id, parentSpanId: planSpanId },
         ),
       );
+      const termination = checkBudgetLimits();
+      if (termination) {
+        await ensurePromise(
+          emit(
+            { type: "terminated", reason: termination.reason, context: termination },
+            { spanId: traceSpanId },
+          ),
+        );
+        return { actions, reason: "terminated", metrics, termination };
+      }
       const finalOutputs = await kernel.renderFinal(actions);
       await ensurePromise(
         emit({ type: "final", outputs: finalOutputs, reason: "no-plan" }, { spanId: traceSpanId }),
       );
-      return { actions, final: finalOutputs, reason: "no-plan" };
+      return { actions, final: finalOutputs, reason: "no-plan", metrics };
     }
 
     for (const step of steps) {
@@ -214,6 +284,7 @@ export async function runLoop(
       );
       const outcome = await kernel.act(step);
       actions.push(outcome);
+      recordOutcome(outcome);
       await ensurePromise(
         emit(
           {
@@ -247,7 +318,18 @@ export async function runLoop(
             { spanId: traceSpanId },
           ),
         );
-        return { actions, final: finalOutputs, reason: "non-retryable-error" };
+        return { actions, final: finalOutputs, reason: "non-retryable-error", metrics };
+      }
+
+      const termination = checkBudgetLimits();
+      if (termination) {
+        await ensurePromise(
+          emit(
+            { type: "terminated", reason: termination.reason, context: termination },
+            { spanId: traceSpanId },
+          ),
+        );
+        return { actions, reason: "terminated", metrics, termination };
       }
 
       if (outcome.ask) {
@@ -264,7 +346,7 @@ export async function runLoop(
             },
           ),
         );
-        return { actions, reason: "ask" };
+        return { actions, reason: "ask", metrics };
       }
     }
 
@@ -294,6 +376,7 @@ export async function runLoop(
         final: finalOutputs,
         reason: "completed",
         review: lastReview,
+        metrics,
       };
     }
   }
@@ -308,5 +391,5 @@ export async function runLoop(
       { spanId: traceSpanId },
     ),
   );
-  return { actions, reason: "max-iterations", review: lastReview };
+  return { actions, reason: "max-iterations", review: lastReview, metrics };
 }

--- a/runtime/events.ts
+++ b/runtime/events.ts
@@ -64,6 +64,8 @@ function mapCoreEventType(event: CoreEvent): string {
       return "run.progress";
     case "final":
       return "run.finished";
+    case "terminated":
+      return "run.terminated";
     case "log":
       return "run.log";
     case "ask":

--- a/servers/api/src/runs/runs.service.ts
+++ b/servers/api/src/runs/runs.service.ts
@@ -7,8 +7,9 @@ import {
   type CoreEvent,
   type EmitSpanOptions,
   type RunLoopResult,
+  type RunLoopBudget,
 } from "../../../../core/agent";
-import { EventBus, wrapCoreEvent, type EventEnvelope } from "../../../../runtime/events";
+import { EventBus, createRunEvent, wrapCoreEvent, type EventEnvelope } from "../../../../runtime/events";
 import { EpisodeLogger } from "../../../../runtime/episode";
 import type { ChatMessage } from "../../../../types/chat";
 import { DatabaseService } from "../database/database.service";
@@ -54,6 +55,7 @@ interface StartRunRequest {
   message: string;
   history: ChatMessage[];
   traceId?: string;
+  budget?: RunLoopBudget;
 }
 
 interface StreamEvent {
@@ -89,6 +91,64 @@ function normaliseHistory(raw: unknown): ChatMessage[] {
   return history;
 }
 
+function parseNumeric(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function normaliseBudget(raw: unknown): RunLoopBudget | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as Record<string, unknown>;
+  const budget: RunLoopBudget = {};
+
+  const stepKeys = ["maxSteps", "max_steps", "stepLimit", "step_limit", "steps"];
+  for (const key of stepKeys) {
+    const value = parseNumeric(source[key]);
+    if (value !== undefined) {
+      budget.maxSteps = value;
+      break;
+    }
+  }
+
+  const costKeys = ["maxCost", "max_cost", "costLimit", "cost_limit", "limit", "usd", "budget"];
+  for (const key of costKeys) {
+    const value = parseNumeric(source[key]);
+    if (value !== undefined) {
+      budget.maxCost = value;
+      break;
+    }
+  }
+
+  const latencyKeys = [
+    "maxLatencyMs",
+    "max_latency_ms",
+    "latencyLimitMs",
+    "latency_limit_ms",
+    "tool_latency_limit_ms",
+  ];
+  for (const key of latencyKeys) {
+    const value = parseNumeric(source[key]);
+    if (value !== undefined) {
+      budget.maxLatencyMs = value;
+      break;
+    }
+  }
+
+  return Object.keys(budget).length > 0 ? budget : undefined;
+}
+
 @Injectable()
 export class RunsService {
   private readonly logger = new Logger(RunsService.name);
@@ -105,6 +165,10 @@ export class RunsService {
       message: normaliseMessage(payload?.message ?? payload?.input ?? ""),
       history: normaliseHistory(payload?.messages ?? payload?.history),
       traceId: typeof payload?.trace_id === "string" ? payload.trace_id : undefined,
+      budget:
+        payload && typeof payload === "object"
+          ? normaliseBudget((payload as Record<string, unknown>).budget)
+          : undefined,
     };
 
     const runId = request.traceId && request.traceId.length > 0 ? request.traceId : randomUUID();
@@ -129,7 +193,11 @@ export class RunsService {
       await this.database.db!.insert(runs).values(runRecord).onConflictDoNothing().run();
     }
 
-    this.recordSyntheticEvent(runId, "run.started", { runId, message: request.message }).catch(
+    this.recordSyntheticEvent(runId, "run.started", {
+      runId,
+      message: request.message,
+      budget: request.budget ?? null,
+    }).catch(
       (error) => {
         this.logger.error(`failed to persist run.started event for ${runId}`, error as Error);
       },
@@ -248,7 +316,23 @@ export class RunsService {
     try {
       const result = await runLoop(kernel, emit, {
         context: { traceId: runId, input: request.message },
+        budget: request.budget,
       });
+      if (result.reason === "terminated" && result.termination) {
+        await eventBus.publish(
+          createRunEvent(
+            runId,
+            "guardian.alert",
+            {
+              runId,
+              reason: result.termination.reason,
+              limit: result.termination.limit,
+              metrics: result.termination.metrics,
+            },
+            { level: "warn" },
+          ),
+        );
+      }
       await this.handleRunCompletion(runId, result);
     } catch (error) {
       await this.handleRunFailure(runId, error);
@@ -259,14 +343,18 @@ export class RunsService {
     const status = this.mapRunStatus(result.reason);
     const finishedAt = new Date();
     const finalJson = result.final != null ? JSON.stringify(result.final) : null;
+    const resolvedReason =
+      result.reason === "terminated"
+        ? `terminated:${result.termination?.reason ?? "budget"}`
+        : result.reason;
 
     const completionPatch: RunPatch = {
       status,
-      reason: result.reason,
+      reason: resolvedReason,
       finalResult: finalJson,
       finishedAt,
       updatedAt: finishedAt,
-      stepCount: result.actions.length,
+      stepCount: result.metrics.stepCount,
     };
 
     if (this.database.isMemoryMode()) {
@@ -281,6 +369,8 @@ export class RunsService {
       reason: result.reason,
       review: result.review ?? null,
       final: result.final ?? null,
+      metrics: result.metrics,
+      termination: result.termination ?? null,
     });
 
     this.completeStream(runId);

--- a/tests/replay.test.ts
+++ b/tests/replay.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { EpisodeLogger } from "../runtime/episode";
 import { replayEpisode } from "../runtime/replay";
-import type { EventEnvelope } from "../runtime/events";
+import { wrapCoreEvent, type EventEnvelope } from "../runtime/events";
+import type { CoreEvent } from "../core/agent";
 
 describe("replayEpisode", () => {
   let counter = 0;
@@ -27,6 +28,13 @@ describe("replayEpisode", () => {
     const logger = new EpisodeLogger({ traceId, dir });
 
     const first = await logger.append(createEvent(traceId, "run.progress", { step: "act" }));
+    const alert = await logger.append(
+      createEvent(traceId, "guardian.alert", {
+        reason: "step-limit",
+        limit: 1,
+        metrics: { stepCount: 1, totalLatencyMs: 100, totalCost: 0.5 },
+      }),
+    );
     const second = await logger.append(
       createEvent(traceId, "run.finished", { outputs: { answer: 42 }, reason: "completed" }),
     );
@@ -39,10 +47,11 @@ describe("replayEpisode", () => {
       },
     });
 
-    expect(events).toHaveLength(2);
+    expect(events).toHaveLength(3);
     expect(events[0].ln).toBe(first.ln);
-    expect(events[1].ln).toBe(second.ln);
-    expect(seen).toEqual(["run.progress", "run.finished"]);
+    expect(events[1].ln).toBe(alert.ln);
+    expect(events[2].ln).toBe(second.ln);
+    expect(seen).toEqual(["run.progress", "guardian.alert", "run.finished"]);
   });
 
   it("throws when the episode file is missing", async () => {
@@ -54,5 +63,25 @@ describe("replayEpisode", () => {
       caught = /episode not found/i.test(String(error));
     }
     expect(caught).toBe(true);
+  });
+});
+
+describe("event mapping", () => {
+  it("wraps terminated core events as run.terminated envelopes", () => {
+    const event: CoreEvent = {
+      type: "terminated",
+      reason: "cost-limit",
+      context: {
+        reason: "cost-limit",
+        limit: 10,
+        metrics: { stepCount: 3, totalLatencyMs: 120, totalCost: 11 },
+      },
+    };
+
+    const envelope = wrapCoreEvent("trace-wrap", event);
+    expect(envelope.type).toBe("run.terminated");
+    const data = envelope.data as CoreEvent;
+    expect(data.type).toBe("terminated");
+    expect((data as any).context.limit).toBe(10);
   });
 });

--- a/tests/runLoop.test.ts
+++ b/tests/runLoop.test.ts
@@ -10,6 +10,7 @@ import {
   type ToolResult,
   type CoreEvent,
   type EmitSpanOptions,
+  type ReviewResult,
 } from "../core/agent";
 
 type EmittedEntry = { event: CoreEvent; span?: EmitSpanOptions };
@@ -65,16 +66,17 @@ describe("runLoop", () => {
       },
     };
 
-    const result = await runLoop(
-      kernel,
-      (event: CoreEvent, span?: EmitSpanOptions) => {
-        emitted.push({ event, span });
-      },
-      { maxIterations: 3, context: { traceId: "trace-run-loop", input: "hi" } },
-    );
+  const result = await runLoop(
+    kernel,
+    (event: CoreEvent, span?: EmitSpanOptions) => {
+      emitted.push({ event, span });
+    },
+    { maxIterations: 3, context: { traceId: "trace-run-loop", input: "hi" } },
+  );
 
-    expect(result.reason).toBe("completed");
-    expect(result.final).toBe("HI THERE");
+  expect(result.reason).toBe("completed");
+  expect(result.final).toBe("HI THERE");
+  expect(result.metrics.stepCount).toBe(2);
     expect(emitted.some((item) => item.event.type === "plan")).toBeTruthy();
     const planEvent = emitted.find(isPlanEvent);
     expect(planEvent?.span?.spanId).toBe("plan-1");
@@ -508,5 +510,60 @@ describe("runLoop", () => {
     expect(result.reason).toBe("completed");
     expect(result.review?.passed).toBe(true);
     expect(result.actions).toHaveLength(2);
+  });
+
+  it("terminates when the configured step budget is reached", async () => {
+    const emitted: EmittedEntry[] = [];
+    let planned = false;
+    const kernel: AgentKernel = {
+      async perceive() {
+        /* no-op */
+      },
+      async plan(): Promise<Plan> {
+        if (planned) {
+          return { steps: [] };
+        }
+        planned = true;
+        return {
+          steps: [
+            { id: "limit-1", op: "tool.echo", args: { value: "first" } },
+            { id: "limit-2", op: "tool.echo", args: { value: "second" } },
+          ],
+        } satisfies Plan;
+      },
+      async act(step) {
+        const result: ToolResult<string> = {
+          ok: true,
+          data: step.args.value,
+          latency_ms: 25,
+          cost: 0.5,
+        };
+        return { step, result } satisfies ActionOutcome<string>;
+      },
+      async review() {
+        return { score: 0, passed: false } satisfies ReviewResult;
+      },
+      async renderFinal() {
+        return null;
+      },
+    } satisfies AgentKernel;
+
+    const result = await runLoop(
+      kernel,
+      (event: CoreEvent, span?: EmitSpanOptions) => {
+        emitted.push({ event, span });
+      },
+      { context: { traceId: "trace-budget" }, budget: { maxSteps: 1 } },
+    );
+
+    expect(result.reason).toBe("terminated");
+    expect(result.termination?.reason).toBe("step-limit");
+    expect(result.termination?.limit).toBe(1);
+    expect(result.metrics.stepCount).toBe(1);
+    expect(result.metrics.totalLatencyMs).toBe(25);
+    expect(result.metrics.totalCost).toBe(0.5);
+    const terminationEvent = emitted.find((entry) => entry.event.type === "terminated");
+    expect(terminationEvent).toBeTruthy();
+    expect((terminationEvent?.event as any).context?.metrics?.stepCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add budget tracking and termination events to the core run loop so runs can stop when budgets are exceeded
- track tool metrics in the run service, emit guardian alerts, and persist budget context with run completion records
- map new event types for replay/streaming and cover them with updated unit tests

## Testing
- pnpm test -- runLoop

------
https://chatgpt.com/codex/tasks/task_e_68cd7ce47c2c832b9d490d4806f3c3ba