### PR TITLE
feat(ui): 拆分聊天布局组件

### DIFF
--- a/components/chat/ChatMain.tsx
+++ b/components/chat/ChatMain.tsx
@@ -1,0 +1,118 @@
+import type { ChangeEvent, FC, FormEventHandler, KeyboardEvent } from "react";
+
+import ChatMessageList, { type ChatHistoryMessage } from "../ChatMessageList";
+import {
+  badgeClass,
+  insetSurfaceClass,
+  inputSurfaceClass,
+  labelClass,
+  panelSurfaceClass,
+  primaryButtonClass,
+  subtleTextClass,
+} from "../../lib/theme";
+
+interface ChatMainProps {
+  panelTitle: string;
+  statusToneClass: string;
+  statusText: string;
+  traceId?: string | null;
+  messages: ChatHistoryMessage[];
+  isRunning: boolean;
+  finalPreview?: string | null;
+  finalPreviewLabel: string;
+  inputLabel: string;
+  inputPlaceholder: string;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  onRunShortcut: () => void | Promise<void>;
+  submitLabel: string;
+  submitDisabled?: boolean;
+  helperText: string;
+}
+
+const ChatMain: FC<ChatMainProps> = ({
+  panelTitle,
+  statusToneClass,
+  statusText,
+  traceId,
+  messages,
+  isRunning,
+  finalPreview,
+  finalPreviewLabel,
+  inputLabel,
+  inputPlaceholder,
+  inputValue,
+  onInputChange,
+  onSubmit,
+  onRunShortcut,
+  submitLabel,
+  submitDisabled,
+  helperText,
+}) => {
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onInputChange(event.target.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void onRunShortcut();
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby="conversation-title"
+      className={`${panelSurfaceClass} space-y-6 p-6 sm:p-8`}
+      data-testid="conversation-panel"
+    >
+      <h3 id="conversation-title" className="sr-only">
+        {panelTitle}
+      </h3>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className={`${badgeClass} ${statusToneClass} bg-transparent normal-case`}>
+          {statusText}
+        </span>
+        {traceId ? (
+          <span className="font-mono text-xs text-slate-400 sm:text-sm">{traceId}</span>
+        ) : null}
+      </div>
+
+      <ChatMessageList messages={messages} isRunning={isRunning} />
+
+      {finalPreview ? (
+        <div className={`${insetSurfaceClass} border border-sky-500/40 bg-sky-500/5 p-4`}>
+          <div className={`${labelClass} text-sky-200`}>{finalPreviewLabel}</div>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-slate-100">{finalPreview}</p>
+        </div>
+      ) : null}
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <label htmlFor="prompt" className={`${labelClass} text-slate-300`}>
+          {inputLabel}
+        </label>
+        <textarea
+          id="prompt"
+          value={inputValue}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={inputPlaceholder}
+          className={`${inputSurfaceClass} min-h-[9rem] w-full resize-y`}
+        />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="submit"
+            disabled={submitDisabled}
+            className={`${primaryButtonClass} w-full sm:w-auto`}
+          >
+            {submitLabel}
+          </button>
+          <span className={`${subtleTextClass} text-sm`}>{helperText}</span>
+        </div>
+      </form>
+    </section>
+  );
+};
+
+export default ChatMain;

--- a/components/chat/InsightsPanel.tsx
+++ b/components/chat/InsightsPanel.tsx
@@ -1,0 +1,343 @@
+import type { FC } from "react";
+
+import PlanTimeline, { type PlanTimelineEvent, type PlanTimelineLabels } from "../PlanTimeline";
+import SkillPanel, { type SkillEvent, type SkillPanelLabels } from "../SkillPanel";
+import {
+  badgeClass,
+  headingClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  panelSurfaceClass,
+  primaryButtonClass,
+  subtleTextClass,
+} from "../../lib/theme";
+
+interface GuardianBudgetSummary {
+  limitLabel: string;
+  limitValue: string;
+  usedLabel: string;
+  usedValue: string;
+  remainingLabel: string;
+  remainingValue: string;
+  updatedAtText?: string | null;
+}
+
+interface GuardianAlertDisplay {
+  id: string;
+  message: string;
+  severityLabel: string;
+  severityToneClass: string;
+  statusLabel: string;
+  statusToneClass: string;
+  timestamp: string;
+  replayHref?: string | null;
+  showApproval: boolean;
+  isPending: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  submittedText?: string;
+  errorText?: string;
+}
+
+interface GuardianPanelProps {
+  heading: string;
+  subtitle: string;
+  statusToneClass: string;
+  statusLabel: string;
+  errorText?: string | null;
+  budget: GuardianBudgetSummary;
+  alertsHeading: string;
+  alertsCount: number;
+  alertsEmptyText: string;
+  alertsStreamErrorText?: string | null;
+  alertsReplayLabel: string;
+  alertsApproveLabel: string;
+  alertsRejectLabel: string;
+  alertsSubmittedLabel: string;
+  alerts: GuardianAlertDisplay[];
+}
+
+interface RunStatItem {
+  label: string;
+  value: string;
+}
+
+interface RunStatsProps {
+  title: string;
+  statusToneClass: string;
+  statusText: string;
+  items: RunStatItem[];
+  errorMessage?: string | null;
+  noticeText: string;
+}
+
+interface RawResponseProps {
+  title: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  collapseLabel: string;
+  expandLabel: string;
+  content: string;
+  summary: string;
+}
+
+interface InsightsPanelProps {
+  guardianPanel: GuardianPanelProps;
+  runStats: RunStatsProps;
+  rawResponse: RawResponseProps;
+  planTimeline: {
+    events: PlanTimelineEvent[];
+    filter: string;
+    collapsed: boolean;
+    onFilterChange: (value: string) => void;
+    onToggleCollapse: () => void;
+    labels: PlanTimelineLabels;
+  };
+  skillPanel: {
+    events: SkillEvent[];
+    filter: string;
+    collapsed: boolean;
+    onFilterChange: (value: string) => void;
+    onToggleCollapse: () => void;
+    labels: SkillPanelLabels;
+  };
+}
+
+const GuardianPanel: FC<GuardianPanelProps> = ({
+  heading,
+  subtitle,
+  statusToneClass,
+  statusLabel,
+  errorText,
+  budget,
+  alertsHeading,
+  alertsCount,
+  alertsEmptyText,
+  alertsStreamErrorText,
+  alertsReplayLabel,
+  alertsApproveLabel,
+  alertsRejectLabel,
+  alertsSubmittedLabel,
+  alerts,
+}) => (
+  <section
+    aria-labelledby="guardian-panel-title"
+    className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+    data-testid="guardian-panel"
+  >
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 id="guardian-panel-title" className={headingClass}>
+            {heading}
+          </h3>
+          <p className={`${subtleTextClass} text-xs`}>{subtitle}</p>
+        </div>
+        <span className={`${badgeClass} ${statusToneClass} normal-case`}>{statusLabel}</span>
+      </div>
+      {errorText ? <p className="text-xs text-rose-200">{errorText}</p> : null}
+      <dl className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <dt className={`${labelClass} text-slate-400`}>{budget.limitLabel}</dt>
+          <dd className="text-sm text-slate-200">{budget.limitValue}</dd>
+        </div>
+        <div className="space-y-2">
+          <dt className={`${labelClass} text-slate-400`}>{budget.usedLabel}</dt>
+          <dd className="text-sm text-slate-200">{budget.usedValue}</dd>
+        </div>
+        <div className="space-y-2">
+          <dt className={`${labelClass} text-slate-400`}>{budget.remainingLabel}</dt>
+          <dd className="text-sm text-slate-200">{budget.remainingValue}</dd>
+        </div>
+      </dl>
+      {budget.updatedAtText ? (
+        <p className={`${subtleTextClass} text-xs`}>{budget.updatedAtText}</p>
+      ) : null}
+    </div>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <h4 className={`${labelClass} text-slate-300`}>{alertsHeading}</h4>
+        <span className={`${badgeClass} bg-slate-900/70 text-slate-300`}>{alertsCount}</span>
+      </div>
+      {alertsStreamErrorText ? (
+        <p className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-100">
+          {alertsStreamErrorText}
+        </p>
+      ) : null}
+      {alerts.length === 0 ? (
+        <p className={`${subtleTextClass} text-sm`}>{alertsEmptyText}</p>
+      ) : (
+        <ul className="space-y-3">
+          {alerts.map((alert) => (
+            <li
+              key={alert.id}
+              className={`${insetSurfaceClass} border border-slate-800/70 bg-slate-950/50 p-4`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-2">
+                  <p className="text-sm text-slate-100">{alert.message}</p>
+                  <div className="flex flex-wrap gap-2">
+                    <span className={`${badgeClass} ${alert.severityToneClass}`}>
+                      {alert.severityLabel}
+                    </span>
+                    <span className={`${badgeClass} ${alert.statusToneClass}`}>
+                      {alert.statusLabel}
+                    </span>
+                  </div>
+                  <p className={`${subtleTextClass} text-xs`}>{alert.timestamp}</p>
+                </div>
+                {alert.replayHref ? (
+                  <a
+                    href={alert.replayHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
+                  >
+                    {alertsReplayLabel}
+                  </a>
+                ) : null}
+              </div>
+              {alert.showApproval ? (
+                <div className="flex flex-wrap gap-3 pt-3">
+                  <button
+                    type="button"
+                    onClick={alert.onApprove}
+                    disabled={alert.isPending}
+                    className={`${primaryButtonClass} px-3 py-1.5 text-xs`}
+                  >
+                    {alertsApproveLabel}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={alert.onReject}
+                    disabled={alert.isPending}
+                    className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
+                  >
+                    {alertsRejectLabel}
+                  </button>
+                </div>
+              ) : null}
+              {alert.submittedText ? (
+                <p className={`${subtleTextClass} pt-2 text-xs`}>{alert.submittedText}</p>
+              ) : null}
+              {alert.errorText ? (
+                <p className="pt-2 text-xs text-rose-200">{alert.errorText}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  </section>
+);
+
+const RunStatsSection: FC<RunStatsProps> = ({
+  title,
+  statusToneClass,
+  statusText,
+  items,
+  errorMessage,
+  noticeText,
+}) => (
+  <section
+    aria-labelledby="run-stats-title"
+    className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+    data-testid="run-stats-panel"
+  >
+    <div className="flex items-center justify-between gap-3">
+      <h3 id="run-stats-title" className={headingClass}>
+        {title}
+      </h3>
+      <span className={`${badgeClass} ${statusToneClass} bg-transparent normal-case`}>
+        {statusText}
+      </span>
+    </div>
+    <dl className="grid gap-4 sm:grid-cols-2">
+      {items.map((item) => (
+        <div key={item.label} className="space-y-2">
+          <dt className={`${labelClass} text-slate-400`}>{item.label}</dt>
+          <dd className="text-sm text-slate-200">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+    {errorMessage ? (
+      <p className="rounded-2xl border border-orange-500/50 bg-orange-500/10 px-4 py-3 text-sm text-orange-200">
+        {errorMessage}
+      </p>
+    ) : (
+      <p className={`${subtleTextClass} text-xs`}>{noticeText}</p>
+    )}
+  </section>
+);
+
+const RawResponseSection: FC<RawResponseProps> = ({
+  title,
+  isOpen,
+  onToggle,
+  collapseLabel,
+  expandLabel,
+  content,
+  summary,
+}) => (
+  <section
+    aria-labelledby="raw-response-title"
+    className={`${panelSurfaceClass} space-y-4 p-6 sm:p-7`}
+    data-testid="raw-response-panel"
+  >
+    <div className="flex items-center justify-between gap-3">
+      <h3 id="raw-response-title" className={headingClass}>
+        {title}
+      </h3>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`${outlineButtonClass} px-3 py-1 text-xs`}
+      >
+        {isOpen ? collapseLabel : expandLabel}
+      </button>
+    </div>
+    {isOpen ? (
+      <pre className="max-h-[28rem] overflow-auto rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-xs leading-relaxed text-slate-200">
+        {content}
+      </pre>
+    ) : (
+      <p className={`${subtleTextClass} text-xs`}>{summary}</p>
+    )}
+  </section>
+);
+
+const InsightsPanel: FC<InsightsPanelProps> = ({
+  guardianPanel,
+  runStats,
+  rawResponse,
+  planTimeline,
+  skillPanel,
+}) => (
+  <aside className="space-y-6" data-testid="chat-insights">
+    <GuardianPanel {...guardianPanel} />
+    <RunStatsSection {...runStats} />
+    <RawResponseSection {...rawResponse} />
+    <section className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`} data-testid="plan-panel">
+      <PlanTimeline {...planTimeline} />
+    </section>
+    <section
+      className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
+      data-testid="skill-panel-wrapper"
+    >
+      <SkillPanel {...skillPanel} />
+    </section>
+  </aside>
+);
+
+export type {
+  GuardianAlertDisplay,
+  GuardianBudgetSummary,
+  GuardianPanelProps,
+  InsightsPanelProps,
+  RawResponseProps,
+  RunStatItem,
+  RunStatsProps,
+};
+
+export default InsightsPanel;

--- a/components/chat/Sidebar.tsx
+++ b/components/chat/Sidebar.tsx
@@ -1,0 +1,85 @@
+import type { FC } from "react";
+
+import {
+  badgeClass,
+  headingClass,
+  labelClass,
+  outlineButtonClass,
+  panelSurfaceClass,
+  primaryButtonClass,
+  subtleTextClass,
+} from "../../lib/theme";
+
+interface SidebarProps {
+  heading: string;
+  traceNotice: string;
+  traceId?: string | null;
+  episodesLabel: string;
+  downloadLabel: string;
+  onSave: () => void;
+  saveLabel: string;
+  disableSave?: boolean;
+  downloadHref?: string | null;
+  draftLabel: string;
+  draftInput?: string | null;
+}
+
+const Sidebar: FC<SidebarProps> = ({
+  heading,
+  traceNotice,
+  traceId,
+  episodesLabel,
+  downloadLabel,
+  onSave,
+  saveLabel,
+  disableSave,
+  downloadHref,
+  draftLabel,
+  draftInput,
+}) => {
+  return (
+    <aside className="space-y-6" data-testid="chat-sidebar">
+      <section className={`${panelSurfaceClass} space-y-4 p-5 sm:p-6`}>
+        <div className="space-y-1">
+          <h3 className={headingClass}>{heading}</h3>
+          <p className={`${subtleTextClass} text-xs sm:text-sm`}>{traceNotice}</p>
+        </div>
+        <div className="flex flex-col gap-3 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
+          {traceId ? (
+            <span className="flex items-center gap-2 truncate text-sky-200">
+              <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>{episodesLabel}</span>
+              <span className="truncate text-slate-200">episodes/{traceId}.jsonl</span>
+            </span>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            {traceId && downloadHref ? (
+              <a
+                className={`${outlineButtonClass} px-3 py-1 text-xs sm:text-sm`}
+                href={downloadHref}
+              >
+                {downloadLabel}
+              </a>
+            ) : null}
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={disableSave}
+              className={`${primaryButtonClass} px-3 py-1 text-xs sm:text-sm`}
+            >
+              {saveLabel}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {draftInput ? (
+        <section className={`${panelSurfaceClass} space-y-3 p-5 sm:p-6`}>
+          <div className={`${labelClass} text-slate-400`}>{draftLabel}</div>
+          <p className="whitespace-pre-wrap text-sm text-slate-200">{draftInput}</p>
+        </section>
+      ) : null}
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,13 @@
 import { FormEventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NextPage } from "next";
 
-import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
+import type { ChatHistoryMessage } from "../components/ChatMessageList";
+import ChatMain from "../components/chat/ChatMain";
+import InsightsPanel from "../components/chat/InsightsPanel";
+import Sidebar from "../components/chat/Sidebar";
 import LogFlowPanel from "../components/LogFlowPanel";
-import PlanTimeline, {
-  type PlanTimelineEvent,
-  type PlanTimelineStep,
-} from "../components/PlanTimeline";
-import SkillPanel, { type SkillEvent } from "../components/SkillPanel";
+import { type PlanTimelineEvent, type PlanTimelineStep } from "../components/PlanTimeline";
+import type { SkillEvent } from "../components/SkillPanel";
 import { useI18n } from "../lib/i18n/index";
 import {
   fetchGuardianBudget,
@@ -19,12 +19,9 @@ import {
   type GuardianBudgetStatus,
 } from "../lib/guardian/index";
 import {
-  badgeClass,
   headerSurfaceClass,
   headingClass,
   insetSurfaceClass,
-  inputSurfaceClass,
-  labelClass,
   modalBackdropClass,
   modalSurfaceClass,
   outlineButtonClass,
@@ -1258,6 +1255,206 @@ const HomePage: NextPage = () => {
     });
   }, [episodeFilter, episodes]);
 
+  const conversationTraceNotice = t("conversation.traceNotice", { traceId: traceId ?? "…" });
+  const conversationDownloadHref = traceId ? `/api/episodes/${traceId}` : undefined;
+  const submitLabel =
+    runStatus === "running"
+      ? t("chat.submit.running")
+      : runStatus === "awaiting-confirmation"
+        ? t("chat.submit.confirming")
+        : t("chat.submit.run");
+
+  const guardianBudgetSummary = {
+    limitLabel: t("guardian.budget.limit"),
+    limitValue: guardianBudget
+      ? formatCurrencyValue(guardianBudget.limit, guardianBudget.currency)
+      : "–",
+    usedLabel: t("guardian.budget.used"),
+    usedValue: guardianBudget
+      ? formatCurrencyValue(guardianBudget.used, guardianBudget.currency)
+      : "–",
+    remainingLabel: t("guardian.budget.remaining"),
+    remainingValue: guardianBudget
+      ? formatCurrencyValue(guardianBudget.remaining, guardianBudget.currency)
+      : "–",
+    updatedAtText: guardianBudget?.updatedAt
+      ? t("guardian.budget.updatedAt", { value: formatDateTime(guardianBudget.updatedAt) })
+      : undefined,
+  };
+
+  const guardianAlertsEmptyText = guardianLoading
+    ? t("guardian.alerts.loading")
+    : guardianError
+      ? t("guardian.alerts.streamError")
+      : t("guardian.alerts.empty");
+
+  const guardianAlertItems = guardianAlerts.map((alert) => {
+    const submissionState = guardianSubmissions[alert.id];
+    const isPending = submissionState === "pending";
+    const replayHref =
+      alert.replayUrl ?? alert.detailsUrl ?? (alert.traceId ? `/episodes/${alert.traceId}` : null);
+    const showApproval = alert.requireApproval && alert.status === "open";
+    return {
+      id: alert.id,
+      message: alert.message,
+      severityLabel: t(`guardian.alerts.severity.${alert.severity}`),
+      severityToneClass: GUARDIAN_SEVERITY_TONES[alert.severity],
+      statusLabel: t(`guardian.alerts.status.${alert.status}`),
+      statusToneClass: GUARDIAN_ALERT_STATUS_TONES[alert.status],
+      timestamp: formatDateTime(alert.updatedAt ?? alert.createdAt),
+      replayHref,
+      showApproval,
+      isPending,
+      onApprove: () => handleGuardianDecision(alert.id, "approve"),
+      onReject: () => handleGuardianDecision(alert.id, "reject"),
+      submittedText: submissionState === "success" ? t("guardian.alerts.submitted") : undefined,
+      errorText: submissionState === "error" ? t("guardian.alerts.error") : undefined,
+    };
+  });
+
+  const runStatsItems = [
+    { label: t("chat.metrics.traceId"), value: traceId ?? "–" },
+    {
+      label: t("chat.metrics.progress"),
+      value: typeof progressPct === "number" ? `${Math.round(progressPct * 100)}%` : "–",
+    },
+    {
+      label: t("chat.metrics.latency"),
+      value: metrics.latency > 0 ? `${metrics.latency.toFixed(0)} ms` : "–",
+    },
+    {
+      label: t("chat.metrics.cost"),
+      value: metrics.cost > 0 ? metrics.cost.toFixed(4) : "–",
+    },
+    {
+      label: t("chat.metrics.tokens"),
+      value: metrics.tokens > 0 ? metrics.tokens.toLocaleString() : "–",
+    },
+  ];
+
+  const rawResponseContent = lastEvent ? JSON.stringify(lastEvent, null, 2) : t("chat.noResponse");
+  const rawResponseSummary = lastEvent ? t("chat.metrics.streamingNotice") : t("chat.noResponse");
+
+  const toggleDebug = useCallback(() => {
+    setDebugOpen((value) => !value);
+  }, [setDebugOpen]);
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInput(value);
+    },
+    [setInput],
+  );
+
+  const handlePlanFilterChange = useCallback(
+    (value: string) => {
+      setPlanFilter(value);
+    },
+    [setPlanFilter],
+  );
+
+  const handlePlanToggleCollapse = useCallback(() => {
+    setPlanCollapsed((value) => !value);
+  }, [setPlanCollapsed]);
+
+  const handleSkillFilterChange = useCallback(
+    (value: string) => {
+      setSkillFilter(value);
+    },
+    [setSkillFilter],
+  );
+
+  const handleSkillToggleCollapse = useCallback(() => {
+    setSkillCollapsed((value) => !value);
+  }, [setSkillCollapsed]);
+
+  const sidebarProps = {
+    heading: t("conversation.heading"),
+    traceNotice: conversationTraceNotice,
+    traceId,
+    episodesLabel: "episodes",
+    downloadLabel: t("conversation.downloadJsonl"),
+    onSave: handleSaveConversation,
+    saveLabel: t("conversation.saveButton"),
+    disableSave,
+    downloadHref: conversationDownloadHref,
+    draftLabel: t("conversation.draftLabel"),
+    draftInput,
+  };
+
+  const chatMainProps = {
+    panelTitle: t("conversation.heading"),
+    statusToneClass: statusTone,
+    statusText,
+    traceId,
+    messages: chatHistory,
+    isRunning: runStatus === "running",
+    finalPreview,
+    finalPreviewLabel: t("conversation.finalOutputTitle"),
+    inputLabel: t("chat.inputLabel"),
+    inputPlaceholder: t("chat.placeholder"),
+    inputValue: input,
+    onInputChange: handleInputChange,
+    onSubmit: handleSubmit,
+    onRunShortcut: handleRun,
+    submitLabel,
+    submitDisabled: runStatus === "running" || runStatus === "awaiting-confirmation",
+    helperText: statusText,
+  };
+
+  const insightsPanelProps = {
+    guardianPanel: {
+      heading: t("guardian.heading"),
+      subtitle: t("guardian.subtitle"),
+      statusToneClass: guardianStatusTone,
+      statusLabel: guardianStatusLabel,
+      errorText: guardianError ? t("guardian.error.detail", { message: guardianError }) : undefined,
+      budget: guardianBudgetSummary,
+      alertsHeading: t("guardian.alerts.heading"),
+      alertsCount: guardianAlerts.length,
+      alertsEmptyText: guardianAlertsEmptyText,
+      alertsStreamErrorText: guardianStreamError ? t("guardian.alerts.streamError") : undefined,
+      alertsReplayLabel: t("guardian.alerts.replay"),
+      alertsApproveLabel: t("guardian.alerts.approve"),
+      alertsRejectLabel: t("guardian.alerts.reject"),
+      alertsSubmittedLabel: t("guardian.alerts.submitted"),
+      alerts: guardianAlertItems,
+    },
+    runStats: {
+      title: t("chat.metrics.heading"),
+      statusToneClass: statusTone,
+      statusText,
+      items: runStatsItems,
+      errorMessage: runError,
+      noticeText: t("chat.metrics.streamingNotice"),
+    },
+    rawResponse: {
+      title: t("chat.latestResponse"),
+      isOpen: debugOpen,
+      onToggle: toggleDebug,
+      collapseLabel: t("panels.plan.collapse"),
+      expandLabel: t("panels.plan.expand"),
+      content: rawResponseContent,
+      summary: rawResponseSummary,
+    },
+    planTimeline: {
+      events: planEvents,
+      filter: planFilter,
+      collapsed: planCollapsed,
+      onFilterChange: handlePlanFilterChange,
+      onToggleCollapse: handlePlanToggleCollapse,
+      labels: planLabels,
+    },
+    skillPanel: {
+      events: skillEvents,
+      filter: skillFilter,
+      collapsed: skillCollapsed,
+      onFilterChange: handleSkillFilterChange,
+      onToggleCollapse: handleSkillToggleCollapse,
+      labels: skillLabels,
+    },
+  };
+
   return (
     <div className={shellClass} data-testid="chat-shell">
       <header className={`${headerSurfaceClass} px-6 py-8 sm:px-8`} data-testid="chat-header">
@@ -1302,393 +1499,9 @@ const HomePage: NextPage = () => {
             className="mx-auto grid w-full max-w-6xl gap-6 xl:grid-cols-[260px_minmax(0,1fr)_320px]"
             data-testid="chat-layout"
           >
-            <aside className="space-y-6" data-testid="chat-sidebar">
-              <section className={`${panelSurfaceClass} space-y-4 p-5 sm:p-6`}>
-                <div className="space-y-1">
-                  <h3 className={headingClass}>{t("conversation.heading")}</h3>
-                  <p className={`${subtleTextClass} text-xs sm:text-sm`}>
-                    {traceId
-                      ? t("conversation.traceNotice", { traceId })
-                      : t("conversation.traceNotice", { traceId: "…" })}
-                  </p>
-                </div>
-                <div className="flex flex-col gap-3 text-xs sm:flex-row sm:items-center sm:justify-between sm:text-sm">
-                  {traceId ? (
-                    <span className="flex items-center gap-2 truncate text-sky-200">
-                      <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>episodes</span>
-                      <span className="truncate text-slate-200">episodes/{traceId}.jsonl</span>
-                    </span>
-                  ) : null}
-                  <div className="flex flex-wrap items-center gap-2">
-                    {traceId ? (
-                      <a
-                        className={`${outlineButtonClass} px-3 py-1 text-xs sm:text-sm`}
-                        href={`/api/episodes/${traceId}`}
-                      >
-                        {t("conversation.downloadJsonl")}
-                      </a>
-                    ) : null}
-                    <button
-                      type="button"
-                      onClick={handleSaveConversation}
-                      disabled={disableSave}
-                      className={`${primaryButtonClass} px-3 py-1 text-xs sm:text-sm`}
-                    >
-                      {t("conversation.saveButton")}
-                    </button>
-                  </div>
-                </div>
-              </section>
-
-              {draftInput ? (
-                <section className={`${panelSurfaceClass} space-y-3 p-5 sm:p-6`}>
-                  <div className={`${labelClass} text-slate-400`}>
-                    {t("conversation.draftLabel")}
-                  </div>
-                  <p className="whitespace-pre-wrap text-sm text-slate-200">{draftInput}</p>
-                </section>
-              ) : null}
-            </aside>
-
-            <section
-              aria-labelledby="conversation-title"
-              className={`${panelSurfaceClass} space-y-6 p-6 sm:p-8`}
-              data-testid="conversation-panel"
-            >
-              <h3 id="conversation-title" className="sr-only">
-                {t("conversation.heading")}
-              </h3>
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <span className={`${badgeClass} ${statusTone} bg-transparent normal-case`}>
-                  {statusText}
-                </span>
-                {traceId ? (
-                  <span className="font-mono text-xs text-slate-400 sm:text-sm">{traceId}</span>
-                ) : null}
-              </div>
-
-              <ChatMessageList messages={chatHistory} isRunning={runStatus === "running"} />
-
-              {finalPreview ? (
-                <div className={`${insetSurfaceClass} border border-sky-500/40 bg-sky-500/5 p-4`}>
-                  <div className={`${labelClass} text-sky-200`}>
-                    {t("conversation.finalOutputTitle")}
-                  </div>
-                  <p className="mt-2 whitespace-pre-wrap text-sm text-slate-100">{finalPreview}</p>
-                </div>
-              ) : null}
-
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <label htmlFor="prompt" className={`${labelClass} text-slate-300`}>
-                  {t("chat.inputLabel")}
-                </label>
-                <textarea
-                  id="prompt"
-                  value={input}
-                  onChange={(event) => setInput(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                      event.preventDefault();
-                      void handleRun();
-                    }
-                  }}
-                  placeholder={t("chat.placeholder")}
-                  className={`${inputSurfaceClass} min-h-[9rem] w-full resize-y`}
-                />
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <button
-                    type="submit"
-                    disabled={runStatus === "running" || runStatus === "awaiting-confirmation"}
-                    className={`${primaryButtonClass} w-full sm:w-auto`}
-                  >
-                    {runStatus === "running"
-                      ? t("chat.submit.running")
-                      : runStatus === "awaiting-confirmation"
-                        ? t("chat.submit.confirming")
-                        : t("chat.submit.run")}
-                  </button>
-                  <span className={`${subtleTextClass} text-sm`}>{statusText}</span>
-                </div>
-              </form>
-            </section>
-
-            <aside className="space-y-6" data-testid="chat-insights">
-              <section
-                aria-labelledby="guardian-panel-title"
-                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
-                data-testid="guardian-panel"
-              >
-                <div className="space-y-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <h3 id="guardian-panel-title" className={headingClass}>
-                        {t("guardian.heading")}
-                      </h3>
-                      <p className={`${subtleTextClass} text-xs`}>{t("guardian.subtitle")}</p>
-                    </div>
-                    <span className={`${badgeClass} ${guardianStatusTone} normal-case`}>
-                      {guardianStatusLabel}
-                    </span>
-                  </div>
-                  {guardianError ? (
-                    <p className="text-xs text-rose-200">
-                      {t("guardian.error.detail", { message: guardianError })}
-                    </p>
-                  ) : null}
-                  <dl className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <dt className={`${labelClass} text-slate-400`}>
-                        {t("guardian.budget.limit")}
-                      </dt>
-                      <dd className="text-sm text-slate-200">
-                        {guardianBudget
-                          ? formatCurrencyValue(guardianBudget.limit, guardianBudget.currency)
-                          : "–"}
-                      </dd>
-                    </div>
-                    <div className="space-y-2">
-                      <dt className={`${labelClass} text-slate-400`}>
-                        {t("guardian.budget.used")}
-                      </dt>
-                      <dd className="text-sm text-slate-200">
-                        {guardianBudget
-                          ? formatCurrencyValue(guardianBudget.used, guardianBudget.currency)
-                          : "–"}
-                      </dd>
-                    </div>
-                    <div className="space-y-2">
-                      <dt className={`${labelClass} text-slate-400`}>
-                        {t("guardian.budget.remaining")}
-                      </dt>
-                      <dd className="text-sm text-slate-200">
-                        {guardianBudget
-                          ? formatCurrencyValue(guardianBudget.remaining, guardianBudget.currency)
-                          : "–"}
-                      </dd>
-                    </div>
-                  </dl>
-                  {guardianBudget?.updatedAt ? (
-                    <p className={`${subtleTextClass} text-xs`}>
-                      {t("guardian.budget.updatedAt", {
-                        value: formatDateTime(guardianBudget.updatedAt),
-                      })}
-                    </p>
-                  ) : null}
-                </div>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <h4 className={`${labelClass} text-slate-300`}>
-                      {t("guardian.alerts.heading")}
-                    </h4>
-                    <span className={`${badgeClass} bg-slate-900/70 text-slate-300`}>
-                      {guardianAlerts.length}
-                    </span>
-                  </div>
-                  {guardianStreamError ? (
-                    <p className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-100">
-                      {t("guardian.alerts.streamError")}
-                    </p>
-                  ) : null}
-                  {guardianAlerts.length === 0 ? (
-                    <p className={`${subtleTextClass} text-sm`}>
-                      {guardianLoading
-                        ? t("guardian.alerts.loading")
-                        : guardianError
-                          ? t("guardian.alerts.streamError")
-                          : t("guardian.alerts.empty")}
-                    </p>
-                  ) : (
-                    <ul className="space-y-3">
-                      {guardianAlerts.map((alert) => {
-                        const submissionState = guardianSubmissions[alert.id];
-                        const isPending = submissionState === "pending";
-                        const replayHref =
-                          alert.replayUrl ??
-                          alert.detailsUrl ??
-                          (alert.traceId ? `/episodes/${alert.traceId}` : null);
-                        const showApproval = alert.requireApproval && alert.status === "open";
-                        return (
-                          <li
-                            key={alert.id}
-                            className={`${insetSurfaceClass} border border-slate-800/70 bg-slate-950/50 p-4`}
-                          >
-                            <div className="flex items-start justify-between gap-3">
-                              <div className="space-y-2">
-                                <p className="text-sm text-slate-100">{alert.message}</p>
-                                <div className="flex flex-wrap gap-2">
-                                  <span
-                                    className={`${badgeClass} ${GUARDIAN_SEVERITY_TONES[alert.severity]}`}
-                                  >
-                                    {t(`guardian.alerts.severity.${alert.severity}`)}
-                                  </span>
-                                  <span
-                                    className={`${badgeClass} ${GUARDIAN_ALERT_STATUS_TONES[alert.status]}`}
-                                  >
-                                    {t(`guardian.alerts.status.${alert.status}`)}
-                                  </span>
-                                </div>
-                                <p className={`${subtleTextClass} text-xs`}>
-                                  {formatDateTime(alert.updatedAt ?? alert.createdAt)}
-                                </p>
-                              </div>
-                              {replayHref ? (
-                                <a
-                                  href={replayHref}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
-                                >
-                                  {t("guardian.alerts.replay")}
-                                </a>
-                              ) : null}
-                            </div>
-                            {showApproval ? (
-                              <div className="flex flex-wrap gap-3 pt-3">
-                                <button
-                                  type="button"
-                                  onClick={() => handleGuardianDecision(alert.id, "approve")}
-                                  disabled={isPending}
-                                  className={`${primaryButtonClass} px-3 py-1.5 text-xs`}
-                                >
-                                  {t("guardian.alerts.approve")}
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => handleGuardianDecision(alert.id, "reject")}
-                                  disabled={isPending}
-                                  className={`${outlineButtonClass} px-3 py-1.5 text-xs`}
-                                >
-                                  {t("guardian.alerts.reject")}
-                                </button>
-                              </div>
-                            ) : null}
-                            {submissionState === "success" ? (
-                              <p className={`${subtleTextClass} pt-2 text-xs`}>
-                                {t("guardian.alerts.submitted")}
-                              </p>
-                            ) : null}
-                            {submissionState === "error" ? (
-                              <p className="pt-2 text-xs text-rose-200">
-                                {t("guardian.alerts.error")}
-                              </p>
-                            ) : null}
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </div>
-              </section>
-              <section
-                aria-labelledby="run-stats-title"
-                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
-                data-testid="run-stats-panel"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <h3 id="run-stats-title" className={headingClass}>
-                    {t("chat.metrics.heading")}
-                  </h3>
-                  <span className={`${badgeClass} ${statusTone} bg-transparent normal-case`}>
-                    {statusText}
-                  </span>
-                </div>
-                <dl className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.traceId")}</dt>
-                    <dd className="font-mono text-sm text-slate-200">{traceId ?? "–"}</dd>
-                  </div>
-                  <div className="space-y-2">
-                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.progress")}</dt>
-                    <dd className="text-sm text-slate-200">
-                      {typeof progressPct === "number" ? `${Math.round(progressPct * 100)}%` : "–"}
-                    </dd>
-                  </div>
-                  <div className="space-y-2">
-                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.latency")}</dt>
-                    <dd className="text-sm text-slate-200">
-                      {metrics.latency > 0 ? `${metrics.latency.toFixed(0)} ms` : "–"}
-                    </dd>
-                  </div>
-                  <div className="space-y-2">
-                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.cost")}</dt>
-                    <dd className="text-sm text-slate-200">
-                      {metrics.cost > 0 ? metrics.cost.toFixed(4) : "–"}
-                    </dd>
-                  </div>
-                  <div className="space-y-2">
-                    <dt className={`${labelClass} text-slate-400`}>{t("chat.metrics.tokens")}</dt>
-                    <dd className="text-sm text-slate-200">
-                      {metrics.tokens > 0 ? metrics.tokens.toLocaleString() : "–"}
-                    </dd>
-                  </div>
-                </dl>
-                {runError ? (
-                  <p className="rounded-2xl border border-orange-500/50 bg-orange-500/10 px-4 py-3 text-sm text-orange-200">
-                    {runError}
-                  </p>
-                ) : (
-                  <p className={`${subtleTextClass} text-xs`}>
-                    {t("chat.metrics.streamingNotice")}
-                  </p>
-                )}
-              </section>
-
-              <section
-                aria-labelledby="raw-response-title"
-                className={`${panelSurfaceClass} space-y-4 p-6 sm:p-7`}
-                data-testid="raw-response-panel"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <h3 id="raw-response-title" className={headingClass}>
-                    {t("chat.latestResponse")}
-                  </h3>
-                  <button
-                    type="button"
-                    onClick={() => setDebugOpen((value) => !value)}
-                    className={`${outlineButtonClass} px-3 py-1 text-xs`}
-                  >
-                    {debugOpen ? t("panels.plan.collapse") : t("panels.plan.expand")}
-                  </button>
-                </div>
-                {debugOpen ? (
-                  <pre className="max-h-[28rem] overflow-auto rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-xs leading-relaxed text-slate-200">
-                    {lastEvent ? JSON.stringify(lastEvent, null, 2) : t("chat.noResponse")}
-                  </pre>
-                ) : (
-                  <p className={`${subtleTextClass} text-xs`}>
-                    {lastEvent ? t("chat.metrics.streamingNotice") : t("chat.noResponse")}
-                  </p>
-                )}
-              </section>
-
-              <section
-                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
-                data-testid="plan-panel"
-              >
-                <PlanTimeline
-                  events={planEvents}
-                  filter={planFilter}
-                  collapsed={planCollapsed}
-                  onFilterChange={setPlanFilter}
-                  onToggleCollapse={() => setPlanCollapsed((value) => !value)}
-                  labels={planLabels}
-                />
-              </section>
-
-              <section
-                className={`${panelSurfaceClass} space-y-6 p-6 sm:p-7`}
-                data-testid="skill-panel-wrapper"
-              >
-                <SkillPanel
-                  events={skillEvents}
-                  filter={skillFilter}
-                  collapsed={skillCollapsed}
-                  onFilterChange={setSkillFilter}
-                  onToggleCollapse={() => setSkillCollapsed((value) => !value)}
-                  labels={skillLabels}
-                />
-              </section>
-            </aside>
+            <Sidebar {...sidebarProps} />
+            <ChatMain {...chatMainProps} />
+            <InsightsPanel {...insightsPanelProps} />
           </div>
         ) : (
           <section className={`${panelSurfaceClass} p-6 sm:p-8`}>

--- a/tests/chatComponents.test.tsx
+++ b/tests/chatComponents.test.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ChatMain from "../components/chat/ChatMain";
+import InsightsPanel from "../components/chat/InsightsPanel";
+import Sidebar from "../components/chat/Sidebar";
+import type { ChatHistoryMessage } from "../components/ChatMessageList";
+import type { PlanTimelineEvent } from "../components/PlanTimeline";
+import type { SkillEvent } from "../components/SkillPanel";
+import { I18nProvider } from "../lib/i18n";
+
+describe("Chat layout components", () => {
+  it("renders sidebar information and draft snippet", () => {
+    const html = renderToStaticMarkup(
+      <Sidebar
+        heading="对话"
+        traceNotice="当前会话 ID: trace-123"
+        traceId="trace-123"
+        episodesLabel="episodes"
+        downloadLabel="下载"
+        onSave={() => undefined}
+        saveLabel="保存"
+        disableSave={false}
+        downloadHref="/api/episodes/trace-123"
+        draftLabel="草稿"
+        draftInput="用户草稿"
+      />,
+    );
+
+    expect(html).toContain("episodes/trace-123.jsonl");
+    expect(html).toContain("保存");
+    expect(html).toContain("用户草稿");
+  });
+
+  it("renders chat main section with messages and final preview", () => {
+    const messages: ChatHistoryMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        content: "你好",
+        ts: new Date("2024-01-01T00:00:00Z").toISOString(),
+        status: "done",
+        msgId: "msg-u1",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "您好，有什么可以帮忙？",
+        ts: new Date("2024-01-01T00:00:01Z").toISOString(),
+        status: "done",
+        msgId: "msg-a1",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <I18nProvider locale="zh-CN">
+        <ChatMain
+          panelTitle="对话"
+          statusToneClass="bg-emerald-500/10"
+          statusText="完成"
+          traceId="trace-123"
+          messages={messages}
+          isRunning={false}
+          finalPreview="执行完成"
+          finalPreviewLabel="最终输出"
+          inputLabel="指令"
+          inputPlaceholder="请输入指令"
+          inputValue="测试"
+          onInputChange={() => undefined}
+          onSubmit={vi.fn()}
+          onRunShortcut={vi.fn()}
+          submitLabel="运行"
+          submitDisabled={false}
+          helperText="闲置"
+        />
+      </I18nProvider>,
+    );
+
+    expect(html).toContain("trace-123");
+    expect(html).toContain("最终输出");
+    expect(html).toContain("执行完成");
+    expect(html).toContain("运行");
+  });
+
+  it("renders insights panel sections", () => {
+    const planEvents: PlanTimelineEvent[] = [
+      {
+        id: "plan-1",
+        ts: new Date("2024-01-01T00:00:00Z").toISOString(),
+        steps: [{ id: "s1", title: "准备", summary: "初始化" }],
+      },
+    ];
+    const skillEvents: SkillEvent[] = [
+      {
+        id: "skill-1",
+        type: "tool",
+        ts: new Date("2024-01-01T00:00:05Z").toISOString(),
+        name: "search",
+        status: "succeeded",
+        argsSummary: "查询数据",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <InsightsPanel
+        guardianPanel={{
+          heading: "Guardian",
+          subtitle: "预算与告警",
+          statusToneClass: "bg-sky-500/10",
+          statusLabel: "正常",
+          errorText: undefined,
+          budget: {
+            limitLabel: "额度",
+            limitValue: "$10.00",
+            usedLabel: "已用",
+            usedValue: "$2.00",
+            remainingLabel: "剩余",
+            remainingValue: "$8.00",
+            updatedAtText: "更新时间 2024/01/01",
+          },
+          alertsHeading: "告警",
+          alertsCount: 1,
+          alertsEmptyText: "暂无告警",
+          alertsStreamErrorText: undefined,
+          alertsReplayLabel: "回放",
+          alertsApproveLabel: "通过",
+          alertsRejectLabel: "拒绝",
+          alertsSubmittedLabel: "已提交",
+          alerts: [
+            {
+              id: "alert-1",
+              message: "请确认预算",
+              severityLabel: "warning",
+              severityToneClass: "bg-amber-500/10",
+              statusLabel: "open",
+              statusToneClass: "bg-sky-500/10",
+              timestamp: "2024-01-01",
+              replayHref: "https://example.com",
+              showApproval: true,
+              isPending: false,
+              onApprove: vi.fn(),
+              onReject: vi.fn(),
+              submittedText: undefined,
+              errorText: undefined,
+            },
+          ],
+        }}
+        runStats={{
+          title: "运行指标",
+          statusToneClass: "bg-emerald-500/10",
+          statusText: "完成",
+          items: [
+            { label: "Trace", value: "trace-123" },
+            { label: "Latency", value: "1200 ms" },
+          ],
+          errorMessage: undefined,
+          noticeText: "流式传输",
+        }}
+        rawResponse={{
+          title: "最新响应",
+          isOpen: false,
+          onToggle: vi.fn(),
+          collapseLabel: "收起",
+          expandLabel: "展开",
+          content: "{}",
+          summary: "暂无响应",
+        }}
+        planTimeline={{
+          events: planEvents,
+          filter: "",
+          collapsed: false,
+          onFilterChange: vi.fn(),
+          onToggleCollapse: vi.fn(),
+          labels: {
+            heading: "计划",
+            filterPlaceholder: "筛选",
+            collapse: "收起",
+            expand: "展开",
+            empty: "暂无计划",
+            updatedAt: (value: string) => value,
+            revision: () => "rev",
+            reason: () => "原因",
+            stepCount: () => "1",
+          },
+        }}
+        skillPanel={{
+          events: skillEvents,
+          filter: "",
+          collapsed: false,
+          onFilterChange: vi.fn(),
+          onToggleCollapse: vi.fn(),
+          labels: {
+            heading: "技能",
+            filterPlaceholder: "搜索技能",
+            collapse: "收起",
+            expand: "展开",
+            empty: "暂无技能",
+            status: {
+              started: "开始",
+              succeeded: "成功",
+              failed: "失败",
+            },
+            metricLabels: {
+              latency: "延迟",
+              cost: "成本",
+              tokens: "Token",
+            },
+            metrics: {
+              cost: () => "--",
+              latency: () => "--",
+              tokens: () => "--",
+            },
+            noteLabel: () => "备注",
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Guardian");
+    expect(html).toContain("告警");
+    expect(html).toContain("运行指标");
+    expect(html).toContain("最新响应");
+    expect(html).toContain("计划");
+    expect(html).toContain("技能");
+  });
+});


### PR DESCRIPTION
## 变更摘要
- 拆分聊天页侧边栏、主会话区与洞察面板为独立展示组件，集中处理样式与交互入口
- 调整 `pages/index.tsx` 仅负责状态管理与三大组件装配
- 补充基础渲染测试，覆盖新拆分组件的结构输出

## 影响范围
- Web 聊天页布局与面板渲染

## 验证步骤
- `pnpm lint`
- `pnpm test`（受缺失 episodes.controller 影响未能通过）

## 或条件验收
- [ ] 搜索入口或命令面板（INP ≤ 200ms）
- [ ] 错误兜底或重试（可恢复率 ≥ 95%）
- [ ] 骨架屏或渐进占位（首屏 ≤ 1.0s）
- [ ] 三步直达关键操作；CLS ≤ 0.1

## PoP 链接
- UX：
- REP：
- API：
- OBS：
- ROLL：

## 回滚方案
- `git revert 5c9ab8a`


------
https://chatgpt.com/codex/tasks/task_e_68ce1d505ec8832ba5df522d104461ff