### PR TITLE
feat(app): 会话导航新增日志与设置

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,11 +1,13 @@
 {
   "layout": {
-    "title": "AgentOS · Chat + LogFlow",
+    "title": "AgentOS · Conversation, Logs, Settings",
     "subtitle": "Submit a prompt to run the local agent, inspect timeline events, and explore task branches.",
     "tabs": {
-      "chat": "Chat",
-      "logflow": "LogFlow"
-    }
+      "conversation": "Conversation",
+      "logs": "Logs",
+      "settings": "Settings"
+    },
+    "navigationLabel": "Primary workspace sections"
   },
   "toast": {
     "error": {
@@ -66,7 +68,7 @@
     }
   },
   "chat": {
-    "inputLabel": "Chat input",
+    "inputLabel": "Conversation input",
     "placeholder": "Ask the agent for a summary or instruction...",
     "metrics": {
       "heading": "Run metrics",
@@ -215,5 +217,10 @@
   },
   "errors": {
     "requestFailed": "Request failed ({status})"
+  },
+  "settings": {
+    "heading": "Settings",
+    "description": "Adjust workspace preferences and manage integrations.",
+    "empty": "Settings are coming soon."
   }
 }

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -1,11 +1,13 @@
 {
   "layout": {
-    "title": "AgentOS · 对话与日志流",
+    "title": "AgentOS · 会话、日志、设置",
     "subtitle": "提交提示以运行本地代理，查看时间线事件并探索任务分支。",
     "tabs": {
-      "chat": "聊天",
-      "logflow": "日志流"
-    }
+      "conversation": "会话",
+      "logs": "日志",
+      "settings": "设置"
+    },
+    "navigationLabel": "主工作区导航"
   },
   "toast": {
     "error": {
@@ -23,11 +25,11 @@
     }
   },
   "conversation": {
-    "heading": "对话",
-    "traceNotice": "此对话已写入 episodes/{traceId}.jsonl",
-    "newButton": "新建对话",
+    "heading": "会话",
+    "traceNotice": "此会话已写入 episodes/{traceId}.jsonl",
+    "newButton": "新建会话",
     "downloadJsonl": "下载 JSONL",
-    "saveButton": "保存对话",
+    "saveButton": "保存会话",
     "draftLabel": "草稿输入",
     "finalOutputTitle": "最新最终输出快照",
     "episodes": {
@@ -42,7 +44,7 @@
       "draftTitle": "本地草稿",
       "draftStatus": "草稿",
       "draftPlaceholder": "episodes/draft-local.jsonl",
-      "draftTraceNotice": "草稿对话尚未写入 Episode 文件。",
+      "draftTraceNotice": "草稿会话尚未写入 Episode 文件。",
       "loadErrorFallback": "加载 Episode 列表失败。",
       "loadSuccess": "已载入 Episode {traceId}。",
       "loadError": "载入 Episode {traceId} 失败。",
@@ -53,7 +55,7 @@
         "steps": "步骤数"
       },
       "actions": {
-        "resume": "载入回放/继续对话",
+        "resume": "载入回放并继续会话",
         "loading": "载入中…",
         "download": "导出 JSONL",
         "downloading": "导出中…"
@@ -66,7 +68,7 @@
     }
   },
   "chat": {
-    "inputLabel": "聊天输入",
+    "inputLabel": "会话输入",
     "placeholder": "请向代理提问或发送指令…",
     "metrics": {
       "heading": "运行指标",
@@ -97,7 +99,7 @@
     "generating": "正在生成回复…",
     "toast": {
       "noContent": "当前没有可保存的内容。",
-      "saveSuccess": "对话已保存为 JSON 文件。"
+      "saveSuccess": "会话已保存为 JSON 文件。"
     },
     "message": {
       "labels": {
@@ -215,5 +217,10 @@
   },
   "errors": {
     "requestFailed": "请求失败（{status}）"
+  },
+  "settings": {
+    "heading": "设置",
+    "description": "调整工作区偏好并管理外部集成。",
+    "empty": "设置面板即将上线。"
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,6 +77,8 @@ type RunStatus = "idle" | "running" | "awaiting-confirmation" | "completed" | "e
 
 type GuardianStatusKey = GuardianBudgetStatus | "loading" | "idle" | "error";
 
+type PrimaryTab = "conversation" | "logs" | "settings";
+
 const GUARDIAN_STATUS_TONES: Record<GuardianStatusKey, string> = {
   ok: "bg-emerald-500/10 text-emerald-200",
   warning: "bg-amber-500/10 text-amber-200",
@@ -256,7 +258,7 @@ const HomePage: NextPage = () => {
   const [traceId, setTraceId] = useState<string | undefined>(undefined);
   const [chatHistory, setChatHistory] = useState<ChatHistoryMessage[]>([]);
   const [runError, setRunError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
+  const [activeTab, setActiveTab] = useState<PrimaryTab>("conversation");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [insightsOpen, setInsightsOpen] = useState(false);
   const sidebarSheetRef = useRef<HTMLDivElement | null>(null);
@@ -1314,10 +1316,12 @@ const HomePage: NextPage = () => {
   );
 
   const tabItems = useMemo(
-    () => [
-      { id: "chat" as const, label: t("layout.tabs.chat") },
-      { id: "logflow" as const, label: t("layout.tabs.logflow") },
-    ],
+    () =>
+      [
+        { id: "conversation", label: t("layout.tabs.conversation"), panelId: "conversation-panel" },
+        { id: "logs", label: t("layout.tabs.logs"), panelId: "logflow-panel" },
+        { id: "settings", label: t("layout.tabs.settings"), panelId: "settings-panel" },
+      ] satisfies Array<{ id: PrimaryTab; label: string; panelId: string }>,
     [t],
   );
 
@@ -1816,12 +1820,12 @@ const HomePage: NextPage = () => {
     </>
   );
 
-  const chatPanel = (
+  const conversationPanel = (
     <section
-      aria-labelledby="tab-chat conversation-title"
+      aria-labelledby="tab-conversation conversation-title"
       className={`${panelSurfaceClass} space-y-6 p-6 sm:p-8`}
       data-testid="conversation-panel"
-      id="chat-panel"
+      id="conversation-panel"
       role="tabpanel"
     >
       <h3 id="conversation-title" className="sr-only">
@@ -1880,21 +1884,66 @@ const HomePage: NextPage = () => {
     </section>
   );
 
-  const logflowPanel = (
+  const logsPanel = (
     <section
       className={`${panelSurfaceClass} p-6 sm:p-8`}
       data-testid="logflow-panel"
       id="logflow-panel"
       role="tabpanel"
-      aria-labelledby="tab-logflow"
+      aria-labelledby="tab-logs"
     >
       <LogFlowPanel traceId={traceId} />
     </section>
   );
 
+  const settingsPanel = (
+    <section
+      aria-labelledby="tab-settings settings-title"
+      className={`${panelSurfaceClass} space-y-6 p-6 sm:p-8`}
+      data-testid="settings-panel"
+      id="settings-panel"
+      role="tabpanel"
+    >
+      <div className="space-y-3">
+        <h3 id="settings-title" className={headingClass}>
+          {t("settings.heading")}
+        </h3>
+        <p className={`${subtleTextClass} text-sm`}>{t("settings.description")}</p>
+      </div>
+      <div
+        className={`${insetSurfaceClass} border border-slate-800/70 bg-slate-950/50 p-6 text-center`}
+        role="status"
+        aria-live="polite"
+      >
+        <p className={`${subtleTextClass} text-sm`}>{t("settings.empty")}</p>
+      </div>
+    </section>
+  );
+
+  const renderSettingsAside = () => (
+    <section
+      aria-labelledby="settings-aside-title"
+      className={`${panelSurfaceClass} space-y-4 p-6 sm:p-7`}
+      data-testid="settings-aside"
+    >
+      <h3 id="settings-aside-title" className={headingClass}>
+        {t("settings.heading")}
+      </h3>
+      <p className={`${subtleTextClass} text-sm`}>{t("settings.empty")}</p>
+    </section>
+  );
+
   const sidebarDrawerId = "mobile-sidebar-drawer";
   const insightsDrawerId = "mobile-insights-drawer";
-  const activePanel = activeTab === "chat" ? chatPanel : logflowPanel;
+  const activePanel =
+    activeTab === "conversation"
+      ? conversationPanel
+      : activeTab === "logs"
+        ? logsPanel
+        : settingsPanel;
+  const renderActiveAside = () =>
+    activeTab === "settings" ? renderSettingsAside() : renderInsights();
+  const asideAriaLabel = activeTab === "settings" ? t("settings.heading") : t("guardian.heading");
 
   return (
     <div className={shellClass} data-testid="chat-shell">
@@ -1911,7 +1960,7 @@ const HomePage: NextPage = () => {
 
       <main className={`${pageContainerClass} space-y-8`} data-testid="chat-main">
         <nav
-          aria-label={`${t("layout.tabs.chat")} / ${t("layout.tabs.logflow")}`}
+          aria-label={t("layout.navigationLabel")}
           className={`${pillGroupClass} mx-auto max-w-md`}
           data-testid="chat-nav"
           role="tablist"
@@ -1919,7 +1968,6 @@ const HomePage: NextPage = () => {
           {tabItems.map((tab) => {
             const selected = activeTab === tab.id;
             const tabId = `tab-${tab.id}`;
-            const panelId = tab.id === "chat" ? "chat-panel" : "logflow-panel";
             return (
               <button
                 key={tab.id}
@@ -1927,7 +1975,7 @@ const HomePage: NextPage = () => {
                 onClick={() => setActiveTab(tab.id)}
                 role="tab"
                 id={tabId}
-                aria-controls={panelId}
+                aria-controls={tab.panelId}
                 aria-selected={selected}
                 tabIndex={selected ? 0 : -1}
                 className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 ${
@@ -1973,7 +2021,7 @@ const HomePage: NextPage = () => {
             aria-haspopup="dialog"
             data-testid="chat-insights-toggle"
           >
-            {t("guardian.heading")}
+            {asideAriaLabel}
           </button>
         </div>
 
@@ -1994,9 +2042,9 @@ const HomePage: NextPage = () => {
           <aside
             className="hidden xl:flex xl:flex-col xl:space-y-6"
             data-testid="chat-insights"
-            aria-label={t("guardian.heading")}
+            aria-label={asideAriaLabel}
           >
-            {renderInsights()}
+            {renderActiveAside()}
           </aside>
         </div>
 
@@ -2052,7 +2100,7 @@ const HomePage: NextPage = () => {
               className="relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-slate-950 p-6 shadow-xl outline-none sm:max-w-sm"
               role="dialog"
               aria-modal="true"
-              aria-label={t("guardian.heading")}
+              aria-label={asideAriaLabel}
               id={insightsDrawerId}
               tabIndex={-1}
               data-testid="chat-insights-sheet"
@@ -2062,12 +2110,12 @@ const HomePage: NextPage = () => {
                   type="button"
                   onClick={() => setInsightsOpen(false)}
                   className={`${outlineButtonClass} px-3 py-1 text-xs`}
-                  aria-label={`${t("guardian.heading")} ${t("panels.plan.collapse")}`}
+                  aria-label={`${asideAriaLabel} ${t("panels.plan.collapse")}`}
                 >
                   {t("panels.plan.collapse")}
                 </button>
               </div>
-              <div className="space-y-6">{renderInsights()}</div>
+              <div className="space-y-6">{renderActiveAside()}</div>
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
## 变更摘要
- 更新中英双语文案，将会话相关标签统一为“会话/日志/设置”，同步输入框等细节文案
- 重构首页导航为三项布局，新增设置面板占位并保持左侧会话列稳定
- 为移动端抽屉与主布局补足 ARIA/键盘辅助属性，设置页提供占位内容

## 影响范围
- 首页导航与右侧信息面板
- 国际化文案（en、zh-CN）

## 验证步骤
- `pnpm lint`（存在既有 prettier 警告，未改动相关文件）

## 或条件验收
- [ ] 搜索入口或命令面板（INP ≤ 200ms）
- [ ] 错误兜底或重试（可恢复率 ≥ 95%）
- [ ] 骨架屏或渐进占位（首屏 ≤ 1.0s）
- [ ] 三步直达关键操作；CLS ≤ 0.1

## PoP 链接
- UX：N/A
- REP：N/A
- API：N/A
- OBS：N/A
- ROLL：N/A

## 回滚方案
- `git revert HEAD` 或回退本次提交

------
https://chatgpt.com/codex/tasks/task_e_68ce3c823400832b9a35c5c8e0d611a9