### PR TITLE
feat(ui): 调整聊天页栅格与抽屉动画

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -18,6 +18,7 @@
 - dev/build/test：`pnpm dev` / `pnpm build` / `pnpm test`
 
 ## 变更摘要
+- 栅格与抽屉：`tailwind.config.cjs` 新增 `gridTemplateColumns.shell` 与 `transitionDuration.16`，聊天页主容器切换为 `xl:grid-cols-shell`；移动端抽屉维持 `aria`/`tabIndex` 的同时加入 16ms 过渡、遮罩透明度渐变与指针穿透管理。
 - 后端：`servers/api/src/episodes/episodes.service.ts` 实现 Episode 列表/详情/回放、文件读取与评分计算；`servers/api/src/episodes/episodes.controller.ts` + `episodes.module.ts` 注册模块；`servers/api/src/runs/runs.service.ts` 新增 `listRecentRuns`、`awaitRunCompletion`；`servers/api/src/database/database.service.ts` 新增内存模式 `listRuns`；`servers/api/src/app.module.ts` 引入 `EpisodesModule`。
 - Next API & 脚本：`pages/api/episodes/index.ts`、`[traceId]/index.ts`、`[traceId]/replay.ts` 代理远端/本地服务；`scripts/replay.mjs` 读取 JSONL 生成差值报告；`reproduce.sh` 提供最小复现（安装→测试→回放）。
 - 前端 Toast：`components/useLocalToast.tsx` 提供复用的 Toast 状态容器；`pages/index.tsx` 接入错误/成功提示并在 `handleRun`、`handleGuardianDecision`、`refreshEpisodes` 与保存对话路径触发；`pages/episodes.tsx` 复用该容器并接入国际化；`locales/*/common.json` 补充 Toast 文案。

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -101,6 +101,30 @@ const GUARDIAN_ALERT_STATUS_TONES: Record<GuardianAlert["status"], string> = {
 
 const EPISODE_SKELETON_ITEMS = new Array(6).fill(null);
 
+const DRAWER_TRANSITION_MS = 16;
+
+const useDrawerMount = (open: boolean, durationMs: number): boolean => {
+  const [mounted, setMounted] = useState(open);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    if (open) {
+      setMounted(true);
+    } else if (mounted) {
+      timeout = setTimeout(() => {
+        setMounted(false);
+      }, durationMs);
+    }
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [open, mounted, durationMs]);
+
+  return mounted;
+};
+
 const generateLocalId = (): string => {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
@@ -259,6 +283,8 @@ const HomePage: NextPage = () => {
   const [activeTab, setActiveTab] = useState<"chat" | "logflow">("chat");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [insightsOpen, setInsightsOpen] = useState(false);
+  const sidebarSheetMounted = useDrawerMount(sidebarOpen, DRAWER_TRANSITION_MS);
+  const insightsSheetMounted = useDrawerMount(insightsOpen, DRAWER_TRANSITION_MS);
   const sidebarSheetRef = useRef<HTMLDivElement | null>(null);
   const insightsSheetRef = useRef<HTMLDivElement | null>(null);
   const [finalOutput, setFinalOutput] = useState<unknown>(null);
@@ -1978,7 +2004,7 @@ const HomePage: NextPage = () => {
         </div>
 
         <div
-          className="mx-auto grid w-full max-w-6xl gap-6 xl:grid-cols-[280px_minmax(360px,1fr)_320px]"
+          className="mx-auto grid w-full max-w-6xl gap-6 xl:grid-cols-shell"
           data-testid="chat-layout"
         >
           <aside
@@ -2000,22 +2026,29 @@ const HomePage: NextPage = () => {
           </aside>
         </div>
 
-        {sidebarOpen ? (
+        {sidebarSheetMounted ? (
           <div
-            className="fixed inset-0 z-40 flex xl:hidden"
+            className={`fixed inset-0 z-40 flex xl:hidden transition-opacity duration-16 ${
+              sidebarOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+            }`}
             role="presentation"
+            aria-hidden={!sidebarOpen}
             data-testid="chat-sidebar-sheet-backdrop"
           >
             <div
-              className="absolute inset-0 bg-slate-950/80"
+              className={`absolute inset-0 bg-slate-950/80 transition-opacity duration-16 ${
+                sidebarOpen ? "opacity-100" : "opacity-0"
+              }`}
               aria-hidden="true"
               onClick={() => setSidebarOpen(false)}
             />
             <div
               ref={sidebarSheetRef}
-              className="relative flex h-full w-full max-w-xs flex-col overflow-y-auto bg-slate-950 p-6 shadow-xl outline-none sm:max-w-sm"
+              className={`relative flex h-full w-full max-w-xs flex-col overflow-y-auto bg-slate-950 p-6 shadow-xl outline-none transition-transform duration-16 ease-out sm:max-w-sm ${
+                sidebarOpen ? "translate-x-0" : "-translate-x-full"
+              }`}
               role="dialog"
-              aria-modal="true"
+              aria-modal={sidebarOpen}
               aria-label={t("conversation.heading")}
               id={sidebarDrawerId}
               tabIndex={-1}
@@ -2036,22 +2069,29 @@ const HomePage: NextPage = () => {
           </div>
         ) : null}
 
-        {insightsOpen ? (
+        {insightsSheetMounted ? (
           <div
-            className="fixed inset-0 z-40 flex xl:hidden"
+            className={`fixed inset-0 z-40 flex xl:hidden transition-opacity duration-16 ${
+              insightsOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+            }`}
             role="presentation"
+            aria-hidden={!insightsOpen}
             data-testid="chat-insights-sheet-backdrop"
           >
             <div
-              className="absolute inset-0 bg-slate-950/80"
+              className={`absolute inset-0 bg-slate-950/80 transition-opacity duration-16 ${
+                insightsOpen ? "opacity-100" : "opacity-0"
+              }`}
               aria-hidden="true"
               onClick={() => setInsightsOpen(false)}
             />
             <div
               ref={insightsSheetRef}
-              className="relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-slate-950 p-6 shadow-xl outline-none sm:max-w-sm"
+              className={`relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-slate-950 p-6 shadow-xl outline-none transition-transform duration-16 ease-out sm:max-w-sm ${
+                insightsOpen ? "translate-x-0" : "translate-x-full"
+              }`}
               role="dialog"
-              aria-modal="true"
+              aria-modal={insightsOpen}
               aria-label={t("guardian.heading")}
               id={insightsDrawerId}
               tabIndex={-1}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
-}
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,19 +1,23 @@
-/** @type {import('tailwindcss').Config} */
+/** @type {import("tailwindcss").Config} */
 module.exports = {
   content: [
-    './pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './lib/**/*.{js,ts,jsx,tsx,mdx}',
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  darkMode: 'class',
+  darkMode: "class",
   theme: {
     extend: {
+      gridTemplateColumns: {
+        shell: "270px minmax(520px,1fr) 340px",
+      },
+      transitionDuration: {
+        16: "16ms",
+      },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ["Inter", "system-ui", "sans-serif"],
       },
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
-}
+  plugins: [require("@tailwindcss/typography")],
+};


### PR DESCRIPTION
## 变更摘要
- 新增 `gridTemplateColumns.shell` 与 `transitionDuration.16`，让聊天页主容器使用统一的三栏栅格。
- 移动端抽屉维持 `aria`、`tabIndex` 的同时加入 16ms 级别的遮罩与面板过渡动画，防止误触。

## 影响范围
- 聊天页桌面端三栏布局的列宽与最大宽度。
- 聊天页在 ≤1280px 视口下的侧栏/指标抽屉开合体验。

## 验证步骤
- `pnpm lint`

## 或条件验收
- 沿用上一阶段已满足的错误兜底/骨架屏要求，新增动画不会破坏 Toast 与骨架逻辑。

## PoP 链接
- UX：后续补充（本次只涉及过渡动画与栅格，待与既有录屏合并）。
- 其余沿用上一阶段已有记录。

## 回滚方案
- `git revert 47c0515`，或手动恢复本次涉及的配置与 `pages/index.tsx`。

------
https://chatgpt.com/codex/tasks/task_e_68ce3c83c4b0832badf581dc0ca0c3df