### PR TITLE
feat(chat): 折叠消息元信息并优化可访问性

### DIFF
--- a/components/ChatMessageList.tsx
+++ b/components/ChatMessageList.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
 
+import { formatShortId } from "../lib/id";
+import { formatFullTimestamp, formatRelativeTimestamp } from "../lib/datetime";
 import { useI18n } from "../lib/i18n/index";
 import { badgeClass, chatBubbleVariants, insetSurfaceClass, subtleTextClass } from "../lib/theme";
 
@@ -36,23 +38,6 @@ const groupMessagesByRole = (messages: ChatHistoryMessage[]) => {
   return groups;
 };
 
-const formatTimestamp = (ts: string, locale: string): string => {
-  if (!ts) return "";
-  try {
-    const date = new Date(ts);
-    if (Number.isNaN(date.getTime())) {
-      return ts;
-    }
-    return date.toLocaleTimeString(locale, {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    return ts;
-  }
-};
-
 const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false }) => {
   const { locale, t } = useI18n();
   const groups = groupMessagesByRole(messages);
@@ -79,42 +64,94 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
               {group.items.map((message) => {
                 const statusLabel =
                   message.status === "error"
-                    ? (message.error ?? t("chat.message.status.error"))
+                    ? message.error ?? t("chat.message.status.error")
                     : message.status === "pending"
                       ? t("chat.message.status.pending")
                       : message.status === "done"
                         ? t("chat.message.status.done")
                         : t("chat.message.status.sent");
 
-                const metadata: string[] = [
-                  message.msgId
-                    ? `${t("chat.message.labels.msgId")}: ${message.msgId}`
-                    : `${t("chat.message.labels.localId")}: ${message.id}`,
-                  formatTimestamp(message.ts, locale),
-                  statusLabel,
-                ];
+                const identifier = message.msgId ?? message.id;
+                const identifierLabel = message.msgId
+                  ? t("chat.message.labels.msgId")
+                  : t("chat.message.labels.localId");
+                const relativeTime = formatRelativeTimestamp(message.ts, locale);
+                const exactTime = formatFullTimestamp(message.ts, locale);
+                const metadataEntries: Array<{
+                  key: string;
+                  label: string;
+                  value: string;
+                  title?: string;
+                }> = [];
+
+                if (identifier) {
+                  metadataEntries.push({
+                    key: "identifier",
+                    label: identifierLabel,
+                    value: formatShortId(identifier),
+                    title: identifier,
+                  });
+                }
+
+                if (relativeTime) {
+                  metadataEntries.push({
+                    key: "timestamp",
+                    label: t("chat.message.labels.timestamp"),
+                    value: relativeTime,
+                    title: exactTime,
+                  });
+                }
+
+                metadataEntries.push({
+                  key: "status",
+                  label: t("chat.message.labels.status"),
+                  value: statusLabel,
+                });
 
                 if (message.traceId) {
-                  metadata.push(`${t("chat.message.labels.traceId")}: ${message.traceId}`);
+                  metadataEntries.push({
+                    key: "traceId",
+                    label: t("chat.message.labels.traceId"),
+                    value: formatShortId(message.traceId),
+                    title: message.traceId,
+                  });
                 }
-                if (message.failureReason) {
-                  metadata.push(`${t("chat.message.labels.reason")}: ${message.failureReason}`);
-                }
-                if (message.reviewNotes && message.reviewNotes.length > 0) {
-                  const noteSummary = message.reviewNotes.filter(Boolean).join(" · ");
-                  metadata.push(`${t("chat.message.labels.reviewNotes")}: ${noteSummary}`);
-                }
+
                 if (typeof message.latencyMs === "number") {
-                  metadata.push(
-                    `${t("chat.message.labels.latency")}: ${message.latencyMs.toFixed(0)} ms`,
-                  );
+                  metadataEntries.push({
+                    key: "latency",
+                    label: t("chat.message.labels.latency"),
+                    value: `${message.latencyMs.toFixed(0)} ms`,
+                  });
                 }
+
                 if (typeof message.cost === "number") {
-                  metadata.push(`${t("chat.message.labels.cost")}: ${message.cost.toFixed(4)}`);
+                  metadataEntries.push({
+                    key: "cost",
+                    label: t("chat.message.labels.cost"),
+                    value: message.cost.toFixed(4),
+                  });
+                }
+
+                if (message.failureReason) {
+                  metadataEntries.push({
+                    key: "reason",
+                    label: t("chat.message.labels.reason"),
+                    value: message.failureReason,
+                  });
+                }
+
+                if (message.reviewNotes && message.reviewNotes.length > 0) {
+                  metadataEntries.push({
+                    key: "reviewNotes",
+                    label: t("chat.message.labels.reviewNotes"),
+                    value: message.reviewNotes.filter(Boolean).join("\n"),
+                  });
                 }
 
                 const ringClass =
                   message.status === "error" ? "ring-orange-400/80" : "ring-offset-transparent";
+                const metadataId = `chat-message-${message.id}-metadata`;
 
                 return (
                   <article
@@ -127,18 +164,38 @@ const ChatMessageList: FC<ChatMessageListProps> = ({ messages, isRunning = false
                     <div className="whitespace-pre-wrap break-words text-left">
                       {message.content}
                     </div>
-                    <footer
-                      className={`mt-3 flex flex-wrap items-center gap-2 text-[0.7rem] font-medium uppercase tracking-[0.14em] ${tone.meta}`}
-                    >
-                      {metadata.map((item, index) => (
-                        <span
-                          key={`${message.id}-meta-${index}`}
-                          className={`${badgeClass} ${tone.meta} bg-transparent px-2 py-0 normal-case`}
+                    {metadataEntries.length > 0 ? (
+                      <details
+                        className="mt-3 text-[0.7rem]"
+                        aria-label={t("chat.message.metadata.summary")}
+                      >
+                        <summary
+                          className="flex cursor-pointer select-none items-center gap-2 font-semibold uppercase tracking-[0.14em] text-slate-500 outline-none transition hover:text-slate-700 focus-visible:text-slate-700"
+                          aria-controls={metadataId}
                         >
-                          {item}
-                        </span>
-                      ))}
-                    </footer>
+                          <span>{t("chat.message.metadata.summary")}</span>
+                        </summary>
+                        <dl
+                          id={metadataId}
+                          className="mt-2 space-y-2 text-left text-[0.7rem]"
+                        >
+                          {metadataEntries.map((item) => (
+                            <div key={`${message.id}-${item.key}`} className="flex flex-col gap-0.5">
+                              <dt className="font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                {item.label}
+                              </dt>
+                              <dd
+                                className="whitespace-pre-line break-words font-mono text-slate-700"
+                                title={item.title}
+                                aria-label={item.title ? `${item.label}: ${item.title}` : undefined}
+                              >
+                                {item.value}
+                              </dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </details>
+                    ) : null}
                   </article>
                 );
               })}

--- a/lib/datetime.ts
+++ b/lib/datetime.ts
@@ -1,0 +1,53 @@
+const RELATIVE_DIVISIONS: Array<{ amount: number; unit: Intl.RelativeTimeFormatUnit }> = [
+  { amount: 60, unit: "second" },
+  { amount: 60, unit: "minute" },
+  { amount: 24, unit: "hour" },
+  { amount: 7, unit: "day" },
+  { amount: 4.34524, unit: "week" },
+  { amount: 12, unit: "month" },
+  { amount: Number.POSITIVE_INFINITY, unit: "year" },
+];
+
+export function formatRelativeTimestamp(isoString: string, locale: string): string {
+  if (!isoString) {
+    return "";
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return isoString;
+  }
+
+  const now = Date.now();
+  let diffInSeconds = (date.getTime() - now) / 1000;
+  let unit: Intl.RelativeTimeFormatUnit = "second";
+
+  for (const division of RELATIVE_DIVISIONS) {
+    if (Math.abs(diffInSeconds) < division.amount) {
+      unit = division.unit;
+      break;
+    }
+    diffInSeconds /= division.amount;
+  }
+
+  const formatter = new Intl.RelativeTimeFormat(locale || "en", { numeric: "auto" });
+  return formatter.format(Math.round(diffInSeconds), unit);
+}
+
+export function formatFullTimestamp(isoString: string, locale: string): string {
+  if (!isoString) {
+    return "";
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return isoString;
+  }
+
+  try {
+    return date.toLocaleString(locale, {
+      dateStyle: "medium",
+      timeStyle: "medium",
+    });
+  } catch {
+    return date.toISOString();
+  }
+}

--- a/lib/id.ts
+++ b/lib/id.ts
@@ -1,0 +1,21 @@
+const DEFAULT_LENGTH = 8;
+
+export function generateShortId(length = DEFAULT_LENGTH): string {
+  const target = Math.max(4, Math.floor(length));
+  let result = "";
+  while (result.length < target) {
+    result += Math.random().toString(36).slice(2);
+  }
+  return result.slice(0, target);
+}
+
+export function formatShortId(value: string, length = DEFAULT_LENGTH): string {
+  if (!value) {
+    return "";
+  }
+  const safeLength = Math.max(4, Math.floor(length));
+  if (value.length <= safeLength) {
+    return value;
+  }
+  return `${value.slice(0, safeLength - 1)}…`;
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -107,13 +107,18 @@
         "latency": "latency",
         "cost": "cost",
         "reason": "reason",
-        "reviewNotes": "review notes"
+        "reviewNotes": "review notes",
+        "timestamp": "time",
+        "status": "status"
       },
       "status": {
         "error": "Delivery failed",
         "pending": "Pending",
         "done": "Delivered",
         "sent": "Sent"
+      },
+      "metadata": {
+        "summary": "View message details"
       }
     }
   },

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -107,13 +107,18 @@
         "latency": "延迟",
         "cost": "成本",
         "reason": "原因",
-        "reviewNotes": "评审备注"
+        "reviewNotes": "评审备注",
+        "timestamp": "时间",
+        "status": "状态"
       },
       "status": {
         "error": "发送失败",
         "pending": "等待中",
         "done": "已送达",
         "sent": "已发送"
+      },
+      "metadata": {
+        "summary": "查看消息详情"
       }
     }
   },

--- a/tests/chatMessageList.test.tsx
+++ b/tests/chatMessageList.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 import { I18nProvider } from "../lib/i18n/index";
 
 describe("ChatMessageList", () => {
   it("renders multi-turn conversation bubbles with status", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2023-06-01T00:00:05Z"));
     const messages: ChatHistoryMessage[] = [
       {
         id: "u-1",
@@ -48,13 +50,24 @@ describe("ChatMessageList", () => {
     expect(html.includes("Hello")).toBe(true);
     expect(html.includes("Hi, how can I help?")).toBe(true);
     expect(html.includes("Tell me a joke.")).toBe(true);
-    expect(html.includes("延迟: 1200 ms")).toBe(true);
-    expect(html.includes("成本: 0.0042")).toBe(true);
+    expect(html.includes("<details")).toBe(true);
+    expect(html.includes("<details open")).toBe(false);
+    expect(html.includes("查看消息详情")).toBe(true);
+    expect(html.includes("延迟")).toBe(true);
+    expect(html.includes("1200 ms")).toBe(true);
+    expect(html.includes("成本")).toBe(true);
+    expect(html.includes("0.0042")).toBe(true);
+    expect(html.includes("msg-user…")).toBe(true);
+    expect(html.includes("msg-assistant…")).toBe(true);
+    expect(html.includes("秒前")).toBe(true);
     expect(html.includes('data-role="status"')).toBe(true);
     expect(html.includes("正在生成回复…")).toBe(true);
+    vi.useRealTimers();
   });
 
   it("renders english labels when locale is en", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2023-06-01T00:00:05Z"));
     const messages: ChatHistoryMessage[] = [
       {
         id: "u-1",
@@ -72,12 +85,17 @@ describe("ChatMessageList", () => {
       </I18nProvider>,
     );
 
-    expect(html.includes("msg_id: msg-user-1")).toBe(true);
+    expect(html.includes("View message details")).toBe(true);
+    expect(html.includes("msg_id")).toBe(true);
+    expect(html.includes("msg-user…")).toBe(true);
     expect(html.includes("Delivered")).toBe(true);
     expect(html.includes("No messages yet.")).toBe(false);
+    vi.useRealTimers();
   });
 
   it("highlights failed assistant messages with review metadata", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2023-06-01T00:00:05Z"));
     const messages: ChatHistoryMessage[] = [
       {
         id: "u-1",
@@ -108,7 +126,9 @@ describe("ChatMessageList", () => {
 
     expect(html.includes('data-status="error"')).toBe(true);
     expect(html.includes("tool invocation failed")).toBe(true);
-    expect(html.includes("reason: max-iterations")).toBe(true);
-    expect(html.includes("review notes: tool invocation failed")).toBe(true);
+    expect(html.includes("reason")).toBe(true);
+    expect(html.includes("max-iterations")).toBe(true);
+    expect(html.includes("review notes")).toBe(true);
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## 变更摘要
- 重构 `ChatMessageList` 仅默认呈现正文，新增详情折叠区展示短 ID、相对时间与状态等元信息，并补充 ARIA 属性。
- 新增 `lib/id.ts` 与 `lib/datetime.ts` 提供短 ID 生成/格式化与相对时间格式化能力，更新中英文文案。
- 扩充 `chatMessageList` 单测覆盖折叠逻辑与相对时间展示。

## 影响范围
- 聊天消息列表的展示与可访问性
- i18n 文案
- 聊天组件单元测试

## 验证步骤
- `pnpm test --filter chatMessageList`（运行失败，缺少 `servers/api/src/episodes/episodes.controller`，需在本地补齐依赖后重试）

## 或条件验收
- [ ] 搜索入口或命令面板（INP ≤ 200ms）
- [ ] 错误兜底或重试（可恢复率 ≥ 95%）
- [ ] 骨架屏或渐进占位（首屏 ≤ 1.0s）
- [ ] 三步直达关键操作；CLS ≤ 0.1

## PoP 链接
- （暂无，当前变更仅限组件与单测）

## 回滚方案
- `git revert 552cdf6 1c5f460`

------
https://chatgpt.com/codex/tasks/task_e_68ce3c895ba8832b98ad81d80c0b8cbc