### PR TITLE
feat(ui): 重组运行页与错误态

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,10 +1,12 @@
 # RESULT
-- 改了什么：本轮重构聊天主工作区为三栏骨架：左侧常驻会话/Episode 列表（含搜索、刷新、下载、草稿预览），中栏固定最终答复条 + 对话流 + 右置运行按钮，右侧 Inspector 汇集 Guardian、运行指标、原始响应、Plan/Skills 与 LogFlow；移动端维持抽屉折叠；同时将最终答复卡片外提置顶、Composer 主 CTA 与输入框同排右置，并补充 Inspector/会话列表相关本地化文案；最新补充 Episodes 服务在测试环境下等待运行完成以生成 JSONL、恢复回放契约，聊天消息列表补齐截断与相对时间展示并恢复主页文案断言。
-- 为何改：对齐 UX 差距矩阵对「三栏骨架 / Inspector / 主 CTA 显著性」的 P0 要求，降低 Tabs 切换造成的路径断裂，让操作者在宽屏场景下无需跳页即可查看最终答复、运行轨迹与日志；同时让运行按钮默认可见，减少空态下的隐性失败。
-- 如何验证：执行 `pnpm lint` ✅（保留 Next.js 测试桩警告与 TS 版本提示）、`pnpm typecheck` ✅、`pnpm test` ✅（Episodes 契约与聊天组件断言现已通过）。
-- 如何回滚：若仅撤销本轮三栏骨架，可 `git checkout pages/index.tsx locales/en/common.json locales/zh-CN/common.json` 复原布局与文案；如需回退更早的页头/主题改动，参考 `artifacts/roll/episodes-rollback.md` 并逐文件执行 `git checkout -- <path>`。
+
+- 改了什么：完成 P0 信息架构收敛——主页去除 LogFlow / 运行入口，只保留会话与最终答复；新增 `/run` 三栏观察页（左列运行列表 + 中列事件时间轴 + 右列 Inspector & LogFlow）；引入 `ErrorCard` 统一错误态并补齐中英文文案；调整 I18n 类型以适配新增键值。
+- 为何改：落实 UX 复盘的“路由去重 + 状态兜底”要求，消除对话与运行功能重叠、避免裸露 404 JSON，确保运行回放集中在 `/run`。
+- 如何验证：执行 `pnpm lint`（保留 Next.js 测试桩与 TypeScript 版本 warning）、`pnpm typecheck`、`pnpm test`，三者均通过。
+- 如何回滚：执行 `git checkout -- components/ErrorCard.tsx lib/i18n/I18nProvider.tsx locales/en/common.json locales/zh-CN/common.json pages/index.tsx pages/run.tsx` 复原此次调整；若需彻底撤销，可对本次提交使用 `git revert`。
 
 ## 需求澄清（中文）
+
 - 业务目标：
   - 新增：让聊天页头提供可感的导航、运行态与帮助入口，并引入主题切换以对齐产品体验；
   - 既有：推进“阶段三（Episode 回放）”，让 `/api/episodes`、`/api/episodes/{id}`、`/api/episodes/{id}/replay` 与新 UI/脚本完成回放闭环，提供评分 diff 证据；统一聊天页与 Episodes 页的错误 Toast，使运行失败/审批失败等异常具备即时反馈。
@@ -15,25 +17,46 @@
 - 假设：#ASSUMPTION: 主题切换主要服务聊天页，可接受其它页面在浅色主题下继续使用深色面板（需后续逐页调优）。
 
 ### 本轮补充（最终答复卡片）
+
 - 业务目标：让运行完成后的最终答复在聊天中栏保持可见，支持复制、定位及历史回溯，提升主路径复核效率。
 - 范围：仅改动聊天页中栏与相关组件/i18n/测试，不触及后端 API 与 Guardian 面板逻辑。
 - 使用场景：主路径——操作者滚动查看长对话时，仍可从顶部卡片快速复制/定位最终答复；异常路径——历史面板为空时提示无版本，或目标气泡缺失时给出 Toast。
 - UI 验收要点：1) 最终答复卡片在滚动聊天记录时持续固定在中栏顶部；2) 点击定位按钮会滚动并高亮答复气泡；3) 版本回溯面板展示按时间倒序的历史；#ASSUMPTION：复制按钮成功写入系统剪贴板（以浏览器开发者工具验证）。
 - 依赖：复用 `useLocalToast` 与现有聊天消息结构；假设浏览器环境支持 `navigator.clipboard`，并在缺失时退回 `document.execCommand`。
 
-### 本轮补充（三栏骨架与 Inspector）
-- 业务目标：按 UX 评审要求，提供左侧会话列表、中部对话结论、右侧 Inspector（三栏骨架），并把运行指标/Guardian 统一收纳至 Inspector，消除标签页跳转中的主路径断裂。
-- 范围：重构 `pages/index.tsx` 布局（移除中部标签页、让会话列表与 Inspector 常驻）、Composer 主按钮排布、Final Answer 置顶；不改动后端 API 契约与 episodes/guardian 数据结构。
-- 使用场景：主路径——操作者在桌面宽屏直接浏览会话、指标与日志，无需切换标签即可定位问题；异常路径——在 ≤1280px 宽度下可通过抽屉访问会话列表与 Inspector。
-- UI 验收要点：1) ≥1280px 时左/中/右三栏同屏可见，≤1280px 自动折叠为抽屉；2) 中栏顶部常驻「最终答复」卡片，包含复制/定位/历史操作；3) 运行按钮与输入框同排且默认可见；#ASSUMPTION：Inspector 内含 Plan/Skills/LogFlow/Guardian 信息即可满足评审对进度可见性的要求。
-- 依赖：沿用 episodes/guardian 获取函数与 `LogFlowPanel` 等现有组件；假设 Tailwind 自定义 `grid-cols-shell` 满足布局宽度需求。
+### 本轮计划（信息架构收敛 P0）
+
+- 业务目标：
+  - 首页专注“会话创建与复核”，剥离运行时间轴与 LogFlow；
+  - `/run` 专注“运行观察/回放”，以三栏骨架呈现运行列表、事件时间轴与 Inspector；
+  - 空态/错误态统一为 ErrorCard + 行动引导，避免直接暴露 404/JSON。
+- 范围（包含/不包含）：
+  - 包含：路由内容去重、会话页 Final Answer 单一来源、运行页静态骨架（含假数据）、ErrorCard 组件与相关文案；
+  - 不包含：真实运行时间轴虚拟化、成本统计/过滤器、命令面板与响应式抽屉记忆（待 P1）。
+- 使用场景：
+  - 主路径：操作者在首页发起运行并查看最终答复 → 切换到 `/run` 浏览最近一次运行的事件时间轴；
+  - 异常路径：访问不存在的 Episode/Run 时以 ErrorCard 呈现“为何不可用 + 如何修复”。
+- UI 验收要点：
+  1. 首页不再出现运行列表/LogFlow，Final Answer 卡片内容与聊天记录一致；
+  2. `/run` 渲染左侧运行列表、中部事件时间轴、右侧 Inspector（三栏可拉伸壳体即可）；
+  3. 错误态以 ErrorCard 呈现并包含可执行按钮（如“返回会话”“重试”）。
+- 依赖与契约：沿用 episodes/guardian API 与本地存储；新增 ErrorCard 组件国际化文案。
+- 假设：
+  - #ASSUMPTION: 运行列表暂以最近触发的 Episode mock 数据占位，可在 P1 替换为真实 API；
+  - #ASSUMPTION: ErrorCard 行为（按钮跳转/刷新）即可满足 UX 对“可恢复率 ≥95%”的要求，暂不引入服务端兜底页。
 
 ## 栈与命令
+
 - 包管理器：pnpm（依据 pnpm-lock.yaml）
 - 目标应用：根目录 Next.js + NestJS 单仓
 - dev/build/test：`pnpm dev` / `pnpm build` / `pnpm test`
 
 ## 变更摘要
+
+- 信息架构：`pages/index.tsx` 移除 Inspector 内的 LogFlow 区块、导航新增 “运行”，保证主页仅承担会话职责；`pages/run.tsx` 重写为运行观察页，整合运行列表、事件时间轴与 Inspector。
+- 错误兜底：新增 `components/ErrorCard.tsx` 并在运行页落地 ErrorCard 行动按钮策略，后续可在其他页面复用。
+- 国际化：`locales/en/common.json`、`locales/zh-CN/common.json` 新增 runs / errors 文案，维持 `requestFailed` 等既有键。
+- I18n 类型：`lib/i18n/I18nProvider.tsx` 以英文文案为基线校验消息结构，确保各语言键值一致。
 - Episodes 契约补强：`servers/api/src/config/api-config.service.ts` 解析 `AOS_WAIT_FOR_RUN_COMPLETION` 并驱动 `AgentController` 等待运行结束，`servers/api/src/runs/runs.service.ts` 新增 `awaitRunCompletion` 轮询逻辑；`scripts/ts-loader.mjs`、`scripts/vitest-runner.mjs` 显式映射 Vitest stub 并改用动态导入，`tests/api/support/testApp.ts` 注入测试所需环境变量，确保 Episode 列表/详情/回放契约稳定生成 JSONL。
 - 聊天与 i18n：`components/chat/FinalReplyCard.tsx` 始终展示历史按钮并在缺少回调时禁用；`lib/id.ts` 依据短横线保留 ID 前缀、`lib/datetime.ts` 调整中文相对时间为“秒前”，`locales/en/common.json`、`locales/zh-CN/common.json` 恢复旧版文案，配合 `ChatMessageList` 截断逻辑满足聊天组件与首页国际化断言。
 - 三栏布局与 Inspector：`pages/index.tsx` 移除中部标签页，统一渲染会话列表、最终答复卡片、对话流与 Inspector；会话列表新增搜索/刷新/下载操作及草稿预览，Inspector 合并 Guardian、运行指标、原始响应、Plan、Skills、LogFlow，移动端抽屉沿用无障碍焦点管理；`locales/en/common.json`、`locales/zh-CN/common.json` 新增 Inspector 文案。
@@ -48,17 +71,20 @@
 - 测试辅助：`tests/api/support/testApp.ts` 在测试容器中兜底提供 EpisodesController；`tests/api/episodesController.test.ts` 去除无效 expect；`tests/api/guardianRoutes.test.ts` 新增预算/审批/SSE 契约测试；`tests/useLocalToast.test.tsx` 覆盖 Toast 容器渲染。
 
 ## 或条件验收（选择已达成项并附证据链接）
+
 - [ ] 搜索入口或命令面板（INP ≤ 200ms）
 - [x] 错误兜底或重试（可恢复率 ≥ 95%）— `pages/episodes.tsx` Toast + `artifacts/ux/episodes-smoke.md`
 - [x] 骨架屏或渐进占位（首屏 ≤ 1.0s）— `pages/episodes.tsx` 列表/详情骨架 + 手动测量记录
 - [ ] 三步直达关键操作；CLS ≤ 0.1
 
 ## 质量门（DoD‑Deep）
+
 - `pnpm lint` ✅（保留 Next.js 测试桩与 TS 版本提示）、`pnpm typecheck` ✅、`pnpm test` ✅（详见本轮日志）。
 - `pnpm replay` 生成回放报告（`reports/0a1341b9-5f04-4451-8b24-6f3eec242eaa-replay.json`）。
 - UI 走查记录：`artifacts/ux/episodes-smoke.md`（含 Toast/骨架验证步骤）。
 
 ## PoP 链接
+
 - UX：`artifacts/ux/episodes-smoke.md`
 - REP：`reproduce.sh`
 - API：`artifacts/api/pnpm-test.log`
@@ -66,5 +92,6 @@
 - ROLL：`artifacts/roll/episodes-rollback.md`
 
 ## 回滚
+
 - 命令：参考 `artifacts/roll/episodes-rollback.md`；若具备 git 权限，可逐文件执行 `git checkout -- <path>`。
 - 验证步骤：`pnpm lint && pnpm typecheck && pnpm test && pnpm replay`，确认 Episodes API 与 UI 不再暴露。

--- a/components/ErrorCard.tsx
+++ b/components/ErrorCard.tsx
@@ -1,0 +1,59 @@
+import type { FC, ReactNode } from "react";
+
+import { headingClass, insetSurfaceClass, subtleTextClass } from "../lib/theme";
+
+interface ErrorCardAction {
+  label: string;
+  onClick: () => void;
+  icon?: ReactNode;
+}
+
+interface ErrorCardProps {
+  title: string;
+  description?: string;
+  actions?: ErrorCardAction[];
+  className?: string;
+  "data-testid"?: string;
+}
+
+const ErrorCard: FC<ErrorCardProps> = ({
+  title,
+  description,
+  actions = [],
+  className,
+  "data-testid": dataTestId,
+}) => {
+  return (
+    <section
+      className={`${insetSurfaceClass} space-y-3 border border-rose-500/30 bg-rose-500/5 p-4 text-left ${className ?? ""}`}
+      data-testid={dataTestId}
+      role="alert"
+    >
+      <h3 className={`${headingClass} text-base text-rose-100`}>{title}</h3>
+      {description ? (
+        <p className={`${subtleTextClass} text-sm text-rose-200/90`}>{description}</p>
+      ) : null}
+      {actions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {actions.map((action, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={action.onClick}
+              className="inline-flex items-center gap-2 rounded-full border border-rose-300/60 px-4 py-1.5 text-sm font-semibold text-rose-100 transition hover:border-rose-200 hover:text-rose-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-200"
+            >
+              {action.icon ? <span aria-hidden>{action.icon}</span> : null}
+              {action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export interface ErrorCardHandle {
+  focus: () => void;
+}
+
+export default ErrorCard;

--- a/lib/i18n/I18nProvider.tsx
+++ b/lib/i18n/I18nProvider.tsx
@@ -5,7 +5,7 @@ import { FALLBACK_LOCALE, type SupportedLocale } from "./config";
 import enMessages from "../../locales/en/common.json" with { type: "json" };
 import zhCNMessages from "../../locales/zh-CN/common.json" with { type: "json" };
 
-type MessageDictionary = typeof zhCNMessages;
+type MessageDictionary = typeof enMessages;
 
 type MessageRecord = Record<SupportedLocale, MessageDictionary>;
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -17,6 +17,7 @@
     },
     "nav": {
       "chat": "Chat",
+      "runs": "Runs",
       "episodes": "Episodes",
       "skills": "Skills"
     },
@@ -229,6 +230,52 @@
     },
     "error": {
       "detail": "Guardian error: {message}"
+    }
+  },
+  "runs": {
+    "heading": "Runs",
+    "subtitle": "Monitor active and past runs, then inspect their timelines.",
+    "list": {
+      "heading": "Recent runs",
+      "empty": "No runs yet. Trigger a conversation to generate the first run.",
+      "error": "Failed to load runs.",
+      "retry": "Retry",
+      "refresh": "Refresh",
+      "loading": "Loading…",
+      "updated": "Updated",
+      "searchPlaceholder": "Filter by goal, trace ID, or status…"
+    },
+    "timeline": {
+      "heading": "Event timeline",
+      "empty": "No events captured for this run yet.",
+      "error": "Failed to load timeline.",
+      "retry": "Retry",
+      "meta": {
+        "startedAt": "Started",
+        "finishedAt": "Finished",
+        "status": "Status"
+      }
+    },
+    "inspector": {
+      "heading": "Inspector",
+      "planHeading": "Plan snapshot",
+      "skillsHeading": "Skills involved",
+      "logHeading": "LogFlow trace"
+    }
+  },
+  "errors": {
+    "requestFailed": "Request failed ({status})",
+    "generic": {
+      "title": "Something went wrong",
+      "description": "We couldn’t complete this action. Try again or return to conversations.",
+      "primary": "Retry",
+      "secondary": "Back to conversations"
+    },
+    "runNotFound": {
+      "title": "Run not found",
+      "description": "This run no longer exists or has been archived. Choose another run or return to conversations.",
+      "primary": "View conversations",
+      "secondary": "Reload list"
     }
   },
   "panels": {

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -17,6 +17,7 @@
     },
     "nav": {
       "chat": "对话",
+      "runs": "运行",
       "episodes": "历史回放",
       "skills": "工具看板"
     },
@@ -127,6 +128,37 @@
         "errorTitle": "出现问题",
         "close": "关闭"
       }
+    }
+  },
+  "runs": {
+    "heading": "运行",
+    "subtitle": "集中查看正在进行和历史运行，并检视事件时间轴。",
+    "list": {
+      "heading": "最近运行",
+      "empty": "暂无运行记录，请先在会话页触发一次运行。",
+      "error": "加载运行列表失败。",
+      "retry": "重试",
+      "refresh": "刷新",
+      "loading": "加载中…",
+      "updated": "已更新",
+      "searchPlaceholder": "按目标、追踪 ID 或状态筛选…"
+    },
+    "timeline": {
+      "heading": "事件时间轴",
+      "empty": "当前运行尚未产生任何事件。",
+      "error": "加载时间轴失败。",
+      "retry": "重试",
+      "meta": {
+        "startedAt": "开始于",
+        "finishedAt": "结束于",
+        "status": "状态"
+      }
+    },
+    "inspector": {
+      "heading": "Inspector",
+      "planHeading": "计划快照",
+      "skillsHeading": "涉及技能",
+      "logHeading": "LogFlow 追踪"
     }
   },
   "chat": {
@@ -285,7 +317,19 @@
     "system": "系统"
   },
   "errors": {
-    "requestFailed": "请求失败（{status}）"
+    "requestFailed": "请求失败（{status}）",
+    "generic": {
+      "title": "发生错误",
+      "description": "未能完成此操作，请重试或返回会话页。",
+      "primary": "重试",
+      "secondary": "返回会话"
+    },
+    "runNotFound": {
+      "title": "未找到运行",
+      "description": "该运行可能已被移除或归档，请选择其他运行或返回会话页。",
+      "primary": "查看会话",
+      "secondary": "重新载入列表"
+    }
   },
   "settings": {
     "heading": "设置",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/router";
 import ChatMessageList, { type ChatHistoryMessage } from "../components/ChatMessageList";
 import FinalReplyCard from "../components/chat/FinalReplyCard";
 import HeaderPrimaryNav, { type HeaderPrimaryNavItem } from "../components/HeaderPrimaryNav";
-import LogFlowPanel from "../components/LogFlowPanel";
 import PlanTimeline, {
   type PlanTimelineEvent,
   type PlanTimelineStep,
@@ -1475,6 +1474,7 @@ const HomePage: NextPage = () => {
     () =>
       [
         { href: "/", label: t("layout.nav.chat") },
+        { href: "/run", label: t("layout.nav.runs") },
         { href: "/episodes", label: t("layout.nav.episodes") },
         { href: "/skills", label: t("layout.nav.skills") },
       ].map((item) => ({
@@ -2336,22 +2336,6 @@ const HomePage: NextPage = () => {
           onToggleCollapse={() => setSkillCollapsed((value) => !value)}
           labels={skillLabels}
         />
-      </section>
-
-      <section
-        className={`${panelSurfaceClass} space-y-4 p-6 sm:p-7`}
-        data-testid="logflow-panel"
-        aria-labelledby="inspector-logflow-title"
-      >
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 id="inspector-logflow-title" className={headingClass}>
-            {t("layout.tabs.logs")}
-          </h3>
-          <span className={`${badgeClass} bg-slate-900/70 text-slate-200`}>
-            {t("chat.metrics.traceId")}: {traceId ?? "–"}
-          </span>
-        </div>
-        <LogFlowPanel traceId={traceId} />
       </section>
     </div>
   );

--- a/pages/run.tsx
+++ b/pages/run.tsx
@@ -1,251 +1,447 @@
-import { NextPage } from "next";
 import Head from "next/head";
-import type { FC, FormEvent } from "react";
-import { useCallback, useState } from "react";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-interface ChatSendResponse {
-  trace_id: string;
-  msg_id: string;
-  result?: unknown;
-}
+import ErrorCard from "../components/ErrorCard";
+import HeaderPrimaryNav, { type HeaderPrimaryNavItem } from "../components/HeaderPrimaryNav";
+import LogFlowPanel from "../components/LogFlowPanel";
+import {
+  fetchEpisodeDetail,
+  fetchEpisodes,
+  type EpisodeDetailResponse,
+  type EpisodeEvent,
+  type EpisodeListItem,
+} from "../lib/episodes";
+import { useI18n } from "../lib/i18n";
+import {
+  badgeClass,
+  headerSurfaceClass,
+  headingClass,
+  inputSurfaceClass,
+  insetSurfaceClass,
+  labelClass,
+  outlineButtonClass,
+  pageContainerClass,
+  panelSurfaceClass,
+  shellClass,
+  subtleTextClass,
+} from "../lib/theme";
 
-interface ChatPanelProps {
-  message: string;
-  onMessageChange: (value: string) => void;
-  onRun: () => void;
-  isRunning: boolean;
-  status: string;
-  finalOutput: string;
-}
-
-interface LogFlowPanelProps {
-  traceId: string | null;
-  log: string;
+interface RunListState {
   isLoading: boolean;
+  error: string | null;
+  items: EpisodeListItem[];
 }
 
-const formatResult = (result: unknown): string => {
-  if (result === null || result === undefined) {
-    return "Result is empty.";
-  }
+interface RunDetailState {
+  isLoading: boolean;
+  error: string | null;
+  detail: EpisodeDetailResponse["data"] | null;
+}
 
-  if (typeof result === "string") {
-    return result;
-  }
+const skeletonItems = new Array(6).fill(null);
 
-  try {
-    return JSON.stringify(result, null, 2);
-  } catch (error) {
-    return String(result);
+const formatTimestamp = (value: string | null | undefined): string => {
+  if (!value) return "–";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
   }
+  return date.toLocaleString();
 };
 
-const ChatPanel: FC<ChatPanelProps> = ({
-  message,
-  onMessageChange,
-  onRun,
-  isRunning,
-  status,
-  finalOutput,
-}) => {
-  const handleSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      onRun();
-    },
-    [onRun],
-  );
-
-  return (
-    <section className="flex flex-col gap-6 rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-lg">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-xl font-semibold text-slate-100">Chat</h2>
-        <p className="text-xs text-slate-400 sm:text-sm">
-          Press{" "}
-          <kbd className="rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem]">
-            Ctrl
-          </kbd>{" "}
-          /
-          <kbd className="rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem]">
-            ⌘
-          </kbd>
-          <span className="px-1">+</span>
-          <kbd className="rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem]">
-            Enter
-          </kbd>
-        </p>
-      </div>
-      <form className="flex flex-1 flex-col gap-4" onSubmit={handleSubmit}>
-        <label className="flex flex-col gap-2 text-sm font-medium text-slate-300" htmlFor="message">
-          Message
-          <textarea
-            id="message"
-            placeholder="Ask the agent for a summary or instruction..."
-            value={message}
-            onChange={(event) => onMessageChange(event.target.value)}
-            onKeyDown={(event) => {
-              if (!isRunning && event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                event.preventDefault();
-                onRun();
-              }
-            }}
-            className="min-h-[12rem] w-full resize-y rounded-xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-base text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
-          />
-        </label>
-        <div className="flex flex-wrap items-center gap-3">
-          <button
-            type="submit"
-            disabled={isRunning}
-            className="inline-flex items-center justify-center rounded-full bg-cyan-400 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-200 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isRunning ? "Running..." : "Run"}
-          </button>
-          <span className="text-sm text-slate-400">{status}</span>
-        </div>
-        <div className="flex flex-col gap-2">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">
-            Final Output
-          </h3>
-          <pre className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-100">
-            {finalOutput || "Results will appear here once the run completes."}
-          </pre>
-        </div>
-      </form>
-    </section>
-  );
-};
-
-const LogFlowPanel: FC<LogFlowPanelProps> = ({ traceId, log, isLoading }) => {
-  return (
-    <section className="flex h-full flex-col gap-4 rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-lg">
-      <div className="flex flex-col gap-2">
-        <h2 className="text-xl font-semibold text-slate-100">LogFlow</h2>
-        <p className="text-xs text-slate-400 sm:text-sm">
-          {traceId ? (
-            <span>
-              trace_id: <code className="break-all text-cyan-300">{traceId}</code>
-            </span>
-          ) : (
-            "Run the agent to generate a trace."
-          )}
-        </p>
-      </div>
-      <pre className="max-h-[28rem] flex-1 overflow-y-auto whitespace-pre-wrap rounded-xl border border-slate-800 bg-slate-950/70 p-4 text-sm text-slate-100">
-        {isLoading ? "Loading episode log..." : log || "Logs will appear here when available."}
-      </pre>
-    </section>
-  );
+const summariseEvent = (event: EpisodeEvent): string | null => {
+  if (!event?.data) return null;
+  if (typeof event.data === "string") {
+    return event.data;
+  }
+  if (typeof event.data === "object") {
+    const message = (event.data as any)?.message ?? (event.data as any)?.text;
+    if (typeof message === "string") {
+      return message;
+    }
+    try {
+      return JSON.stringify(event.data);
+    } catch {
+      return String(event.data);
+    }
+  }
+  return String(event.data);
 };
 
 const RunPage: NextPage = () => {
-  const [message, setMessage] = useState("");
-  const [isRunning, setIsRunning] = useState(false);
-  const [status, setStatus] = useState("");
-  const [finalOutput, setFinalOutput] = useState("");
-  const [traceId, setTraceId] = useState<string | null>(null);
-  const [log, setLog] = useState("");
-  const [isLogLoading, setIsLogLoading] = useState(false);
+  const router = useRouter();
+  const { t } = useI18n();
+  const [listState, setListState] = useState<RunListState>({
+    isLoading: true,
+    error: null,
+    items: [],
+  });
+  const [detailState, setDetailState] = useState<RunDetailState>({
+    isLoading: false,
+    error: null,
+    detail: null,
+  });
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
 
-  const handleRun = useCallback(async () => {
-    if (isRunning) {
-      return;
-    }
-    const prompt = message.trim();
-    setIsRunning(true);
-    setStatus("Running...");
-    setFinalOutput("");
-    setTraceId(null);
-    setLog("");
-    setIsLogLoading(false);
+  const navItems = useMemo<HeaderPrimaryNavItem[]>(
+    () =>
+      [
+        { href: "/", label: t("layout.nav.chat") },
+        { href: "/run", label: t("layout.nav.runs") },
+        { href: "/episodes", label: t("layout.nav.episodes") },
+        { href: "/skills", label: t("layout.nav.skills") },
+      ].map((item) => ({
+        ...item,
+        isActive: router.pathname === item.href,
+      })),
+    [router.pathname, t],
+  );
 
+  const loadRuns = useCallback(async () => {
+    setListState((prev) => ({ ...prev, isLoading: true, error: null }));
     try {
-      const response = await fetch("/api/chat/send", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: prompt }),
-      });
-
-      const payload = (await response.json().catch(() => null)) as
-        | ChatSendResponse
-        | { message?: string }
-        | null;
-
-      if (!response.ok || !payload) {
-        const message =
-          typeof (payload as any)?.message === "string"
-            ? (payload as any).message
-            : "Request failed";
-        throw new Error(message);
-      }
-
-      const data = payload as ChatSendResponse;
-      setStatus("Completed");
-      setTraceId(data.trace_id);
-      setFinalOutput(formatResult(data.result));
-
-      if (data.trace_id) {
-        setIsLogLoading(true);
-        try {
-          const episodeResponse = await fetch(`/api/episodes/${data.trace_id}`);
-          if (episodeResponse.ok) {
-            const episodeText = await episodeResponse.text();
-            const trimmedText = episodeText.trim();
-            setLog(trimmedText.length > 0 ? trimmedText : "Episode available but empty.");
-          } else {
-            setLog("Episode not available yet.");
-          }
-        } catch {
-          setLog("Failed to load episode log.");
-        } finally {
-          setIsLogLoading(false);
+      const response = await fetchEpisodes();
+      const items = response.data.items;
+      setListState({ isLoading: false, error: null, items });
+      setSelectedTraceId((current) => {
+        if (current && items.some((item) => item.trace_id === current)) {
+          return current;
         }
-      } else {
-        setLog("Trace id was not provided for this run.");
-      }
+        return items[0]?.trace_id ?? null;
+      });
     } catch (error) {
-      setStatus("Failed");
-      const message = error instanceof Error ? error.message : "Request failed";
-      setFinalOutput(message);
-      setLog("Run failed before episode log could be retrieved.");
-      setIsLogLoading(false);
-    } finally {
-      setIsRunning(false);
+      const message = error instanceof Error ? error.message : t("runs.list.error");
+      setListState({ isLoading: false, error: message, items: [] });
+      setSelectedTraceId(null);
     }
-  }, [isRunning, message]);
+  }, [t]);
+
+  const loadDetail = useCallback(
+    async (traceId: string) => {
+      setDetailState({ isLoading: true, error: null, detail: null });
+      try {
+        const response = await fetchEpisodeDetail(traceId);
+        setDetailState({ isLoading: false, error: null, detail: response.data });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : t("runs.timeline.error");
+        setDetailState({ isLoading: false, error: message, detail: null });
+      }
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  useEffect(() => {
+    if (selectedTraceId) {
+      loadDetail(selectedTraceId);
+    }
+  }, [selectedTraceId, loadDetail]);
+
+  const filteredItems = useMemo(() => {
+    const normalised = searchTerm.trim().toLowerCase();
+    if (!normalised) {
+      return listState.items;
+    }
+    return listState.items.filter((item) => {
+      const tokens = [item.goal, item.trace_id, item.status]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return tokens.includes(normalised);
+    });
+  }, [listState.items, searchTerm]);
+
+  const pageTitle = `${t("runs.heading")} · Agent OS`;
+  const subtitle = t("runs.subtitle");
+  const listHeading = t("runs.list.heading");
+  const listEmpty = t("runs.list.empty");
+  const listError = listState.error ?? t("runs.list.error");
+  const listRetry = t("runs.list.retry");
+  const listRefresh = t("runs.list.refresh");
+  const searchPlaceholder = t("runs.list.searchPlaceholder");
+  const timelineHeading = t("runs.timeline.heading");
+  const timelineEmpty = t("runs.timeline.empty");
+  const metaStartedLabel = t("runs.timeline.meta.startedAt");
+  const metaFinishedLabel = t("runs.timeline.meta.finishedAt");
+  const metaStatusLabel = t("runs.timeline.meta.status");
+  const errorBack = t("errors.generic.secondary");
+  const runNotFoundTitle = t("errors.runNotFound.title");
+  const runNotFoundDescription = t("errors.runNotFound.description");
+  const runNotFoundPrimary = t("errors.runNotFound.primary");
+  const runNotFoundSecondary = t("errors.runNotFound.secondary");
+
+  const selectedDetail = detailState.detail;
+  const selectedEvents = selectedDetail?.events ?? [];
 
   return (
-    <>
+    <div className={shellClass}>
       <Head>
-        <title>AgentOS · Run</title>
-        <meta
-          name="description"
-          content="Execute the AgentOS run loop, inspect the final output, and browse the LogFlow episode events."
-        />
+        <title>{pageTitle}</title>
       </Head>
-      <div className="min-h-screen bg-slate-950/95 text-slate-100">
-        <header className="border-b border-slate-800/80 bg-slate-950/60 backdrop-blur">
-          <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-8 lg:flex-row lg:items-baseline lg:justify-between">
+      <main className={`${pageContainerClass} space-y-6`}>
+        <header className={`${headerSurfaceClass} space-y-4 p-6 sm:p-8`}>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-2">
-              <h1 className="text-3xl font-semibold">AgentOS · Chat + LogFlow</h1>
-              <p className="text-sm text-slate-400">
-                Submit a prompt to generate a response, inspect events, and replay episodes.
-              </p>
+              <h1 className={`${headingClass} text-2xl`}>{t("runs.heading")}</h1>
+              <p className={`${subtleTextClass} text-sm`}>{subtitle}</p>
             </div>
+            <button
+              type="button"
+              onClick={() => loadRuns()}
+              className={`${outlineButtonClass} w-full sm:w-auto`}
+              disabled={listState.isLoading}
+            >
+              {listState.isLoading ? t("runs.list.loading") : listRefresh}
+            </button>
           </div>
-        </header>
-        <main className="mx-auto grid w-full max-w-6xl flex-1 grid-cols-1 gap-6 px-6 py-8 lg:grid-cols-2">
-          <ChatPanel
-            message={message}
-            onMessageChange={setMessage}
-            onRun={handleRun}
-            isRunning={isRunning}
-            status={status}
-            finalOutput={finalOutput}
+          <HeaderPrimaryNav
+            items={navItems}
+            ariaLabel={t("layout.primaryNavLabel")}
+            className="justify-center"
           />
-          <LogFlowPanel traceId={traceId} log={log} isLoading={isLogLoading} />
-        </main>
-      </div>
-    </>
+        </header>
+
+        <section className="grid gap-6 xl:grid-cols-shell">
+          <aside className={`${panelSurfaceClass} flex flex-col gap-4 p-6`}>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <h2 className={`${headingClass} text-base`}>{listHeading}</h2>
+                <span className={`${labelClass} text-xs text-slate-300/70`}>
+                  {listState.items.length}
+                </span>
+              </div>
+              <label className="flex flex-col gap-2 text-sm">
+                <span className={`${labelClass} text-slate-400`}>{searchPlaceholder}</span>
+                <input
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  placeholder={searchPlaceholder}
+                  className={`${inputSurfaceClass} w-full`}
+                  data-testid="run-search"
+                />
+              </label>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {listState.isLoading ? (
+                <ul className="flex flex-col gap-3" data-testid="run-list-skeleton">
+                  {skeletonItems.map((_, index) => (
+                    <li
+                      key={index}
+                      className="animate-pulse rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4"
+                    >
+                      <div className="h-4 w-3/5 rounded bg-slate-800/70" />
+                      <div className="mt-3 h-3 w-1/2 rounded bg-slate-800/50" />
+                    </li>
+                  ))}
+                </ul>
+              ) : listState.error ? (
+                <ErrorCard
+                  title={listError}
+                  description={subtitle}
+                  actions={[
+                    {
+                      label: listRetry,
+                      onClick: () => loadRuns(),
+                    },
+                    {
+                      label: errorBack,
+                      onClick: () => {
+                        void router.push("/");
+                      },
+                    },
+                  ]}
+                />
+              ) : filteredItems.length === 0 ? (
+                <div className={`${insetSurfaceClass} p-4 text-sm text-slate-300/80`}>
+                  {listEmpty}
+                </div>
+              ) : (
+                <ul className="flex flex-col gap-3" data-testid="run-list">
+                  {filteredItems.map((item) => {
+                    const isSelected = item.trace_id === selectedTraceId;
+                    return (
+                      <li key={item.trace_id}>
+                        <button
+                          type="button"
+                          onClick={() => setSelectedTraceId(item.trace_id)}
+                          className={`${
+                            isSelected
+                              ? "border-sky-500/70 bg-sky-500/10 text-sky-100"
+                              : "border-transparent bg-slate-900/60 text-slate-200 hover:bg-slate-900/80"
+                          } flex w-full flex-col gap-2 rounded-2xl border px-4 py-3 text-left transition`}
+                          data-testid="run-list-item"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span className="font-semibold">
+                              {item.goal ?? t("conversation.episodes.untitled")}
+                            </span>
+                            <span className={`${badgeClass} text-xs uppercase tracking-[0.18em]`}>
+                              {item.status}
+                            </span>
+                          </div>
+                          <p className={`${subtleTextClass} text-xs font-mono`}>{item.trace_id}</p>
+                          <p className={`${subtleTextClass} text-xs`}>
+                            {metaStartedLabel}: {formatTimestamp(item.started_at)}
+                          </p>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </aside>
+
+          <section className={`${panelSurfaceClass} flex flex-col gap-6 p-6`}>
+            <header className="space-y-2">
+              <h2 className={`${headingClass} text-xl`}>{timelineHeading}</h2>
+              {selectedDetail ? (
+                <dl className="grid gap-1 text-xs uppercase tracking-[0.18em] text-slate-300">
+                  <div className="flex items-center gap-2">
+                    <dt className={`${badgeClass} bg-transparent px-2 py-0`}>{metaStatusLabel}</dt>
+                    <dd>{selectedDetail.status ?? "–"}</dd>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <dt className={`${badgeClass} bg-transparent px-2 py-0`}>{metaStartedLabel}</dt>
+                    <dd>{formatTimestamp(selectedDetail.started_at)}</dd>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <dt className={`${badgeClass} bg-transparent px-2 py-0`}>
+                      {metaFinishedLabel}
+                    </dt>
+                    <dd>{formatTimestamp(selectedDetail.finished_at ?? null)}</dd>
+                  </div>
+                </dl>
+              ) : null}
+            </header>
+
+            {detailState.isLoading ? (
+              <div className="space-y-3" data-testid="run-timeline-skeleton">
+                {skeletonItems.slice(0, 4).map((_, index) => (
+                  <div
+                    key={index}
+                    className="animate-pulse rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4"
+                  >
+                    <div className="h-4 w-1/4 rounded bg-slate-800/70" />
+                    <div className="mt-2 h-3 w-2/3 rounded bg-slate-800/50" />
+                    <div className="mt-2 h-3 w-full rounded bg-slate-800/40" />
+                  </div>
+                ))}
+              </div>
+            ) : detailState.error ? (
+              <ErrorCard
+                title={runNotFoundTitle}
+                description={runNotFoundDescription}
+                actions={[
+                  {
+                    label: runNotFoundPrimary,
+                    onClick: () => {
+                      void router.push("/");
+                    },
+                  },
+                  {
+                    label: runNotFoundSecondary,
+                    onClick: () => loadRuns(),
+                  },
+                ]}
+              />
+            ) : selectedEvents.length === 0 ? (
+              <div className={`${insetSurfaceClass} p-6 text-center text-sm text-slate-300/80`}>
+                {timelineEmpty}
+              </div>
+            ) : (
+              <ol className="space-y-4" data-testid="run-timeline">
+                {selectedEvents.map((event) => (
+                  <li
+                    key={event.id}
+                    className={`${insetSurfaceClass} space-y-3 border-slate-800/60 p-4`}
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em]">
+                      <span className={`${badgeClass} bg-sky-500/10 text-sky-100`}>
+                        {event.type}
+                      </span>
+                      {event.level ? (
+                        <span className={`${badgeClass} text-amber-200/90`}>{event.level}</span>
+                      ) : null}
+                      <span className={`${badgeClass} text-slate-300`}>
+                        {new Date(event.ts).toLocaleString()}
+                      </span>
+                    </div>
+                    {event.topic ? (
+                      <p className={`${subtleTextClass} text-xs`}>topic: {event.topic}</p>
+                    ) : null}
+                    {summariseEvent(event) ? (
+                      <p className={`${subtleTextClass} text-sm leading-relaxed`}>
+                        {summariseEvent(event)}
+                      </p>
+                    ) : null}
+                    {event.data ? (
+                      <details className="group">
+                        <summary className="cursor-pointer text-xs text-sky-200">payload</summary>
+                        <pre className="mt-2 max-h-60 overflow-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-200">
+                          {typeof event.data === "string"
+                            ? event.data
+                            : JSON.stringify(event.data, null, 2)}
+                        </pre>
+                      </details>
+                    ) : null}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+
+          <aside className={`${panelSurfaceClass} space-y-6 p-6`}>
+            <section className="space-y-3">
+              <h2 className={`${headingClass} text-lg`}>{t("runs.inspector.planHeading")}</h2>
+              <ul className="space-y-2 text-sm text-slate-200">
+                <li className={`${insetSurfaceClass} border-slate-800/60 p-3`}>
+                  <p className="font-semibold">Define goal & constraints</p>
+                  <p className={`${subtleTextClass} text-xs`}>
+                    Validate guardrails before executing tools.
+                  </p>
+                </li>
+                <li className={`${insetSurfaceClass} border-slate-800/60 p-3`}>
+                  <p className="font-semibold">Collect supporting evidence</p>
+                  <p className={`${subtleTextClass} text-xs`}>
+                    Aggregate documents and prior episodes to support the final answer.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className={`${headingClass} text-lg`}>{t("runs.inspector.skillsHeading")}</h2>
+              <ul className="space-y-2 text-sm text-slate-200">
+                <li className={`${insetSurfaceClass} border-slate-800/60 p-3`}>
+                  <div className={`${badgeClass} bg-sky-500/10 text-sky-100`}>web.search</div>
+                  <p className={`${subtleTextClass} mt-2 text-xs`}>
+                    Resolved factual lookup to confirm budget assumptions.
+                  </p>
+                </li>
+                <li className={`${insetSurfaceClass} border-slate-800/60 p-3`}>
+                  <div className={`${badgeClass} bg-sky-500/10 text-sky-100`}>code.diff</div>
+                  <p className={`${subtleTextClass} mt-2 text-xs`}>
+                    Compared recent commit against baseline to surface risky changes.
+                  </p>
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className={`${headingClass} text-lg`}>{t("runs.inspector.logHeading")}</h2>
+              <LogFlowPanel traceId={selectedTraceId ?? undefined} />
+            </section>
+          </aside>
+        </section>
+      </main>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 变更摘要
- 主页导航新增“运行”并移除 Inspector 内的 LogFlow 区块，让首页专注会话创建与复核。
- 重写 `/run` 页面为运行观察三栏布局（运行列表、事件时间轴、Inspector + LogFlow），并复用 Episodes 数据流。
- 新增 `ErrorCard` 组件统一错误呈现，并扩展中英文文案及 I18n 类型校验。

## 影响范围
- Web 前端运行观察体验
- 对话页导航与 Inspector

## 验证步骤
1. pnpm lint
2. pnpm typecheck
3. pnpm test

## 或条件验收
- [x] 错误兜底或重试（统一 ErrorCard 行动按钮）
- [x] 骨架屏或渐进占位（运行列表与时间轴骨架）
- [ ] 搜索入口或命令面板（INP ≤ 200ms）
- [ ] 三步直达关键操作；CLS ≤ 0.1

## PoP 链接
- UX：待补录屏（计划在 `/run` 时间轴虚拟化完成后统一录制）
- REP：`pnpm test`
- API：同上
- OBS：N/A
- ROLL：`artifacts/roll/episodes-rollback.md`

## 回滚方案
- `git checkout -- components/ErrorCard.tsx lib/i18n/I18nProvider.tsx locales/en/common.json locales/zh-CN/common.json pages/index.tsx pages/run.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ce7020a774832bab6b9b9c879d34f2